### PR TITLE
docs(architecture): bootstrap technical architecture

### DIFF
--- a/.claude/PROJECT.md
+++ b/.claude/PROJECT.md
@@ -1,0 +1,38 @@
+# Project Configuration
+
+## Platform
+
+- **Hosting**: gcp
+- **Compute**: Cloud Run
+- **Database**: Neon
+- **Selected**: 2026-05-02
+
+## Stack
+
+- **Backend**: FastAPI + Uvicorn (Python 3.12)
+- **Templates**: Jinja2
+- **Interactivity**: HTMX 2.x (CDN, no build step)
+- **Styling**: Pico.css 2.x + project CSS variables
+- **ORM**: SQLModel + Alembic
+- **DB driver**: psycopg 3 (binary + pool)
+- **Package manager**: uv
+
+## External services
+
+- **LLM**: Anthropic Claude API (model: `claude-haiku-4-5`)
+- **Email**: Resend
+- **PDF parsing**: pdfplumber (in-process)
+- **Observability**: Google Cloud Logging + Error Reporting
+
+## Required secrets (Google Secret Manager → Cloud Run env)
+
+- `database-url` — Neon pooled connection string
+- `anthropic-api-key` — Claude API key
+- `resend-api-key` — transactional email
+- `session-secret` — `itsdangerous` signing key (32 random bytes)
+
+## Required GitHub Actions secrets
+
+- `GCP_PROJECT_ID`, `GCP_SERVICE_ACCOUNT`, `GCP_WORKLOAD_IDENTITY_PROVIDER`
+- `NEON_PROJECT_ID`, `NEON_API_KEY`, `PRODUCTION_DATABASE_URL`
+- `NEON_PARENT_BRANCH` (optional, defaults to `main`)

--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -30,15 +30,15 @@ You are a Senior Full-Stack Engineer. Your primary responsibility is to autonomo
 
 ## Project Context
 
-<!--
-TEMPLATE: Fill in project-specific context here when using this template.
-
-Example fields to populate:
-- **Platform(s)**: [Web, Mobile, Desktop, etc.]
-- **Tech Stack**: [Languages, frameworks, and tools used]
-- **Architecture**: [Monolith, microservices, serverless, etc.]
-- **Key Quality Standards**: [Performance, accessibility, security requirements]
--->
+- **Product**: Cubrox — a WCAG-conformant reading surface for neurodivergent readers of Baha'i writings. See [docs/PRODUCT-REQUIREMENTS.md](../../docs/PRODUCT-REQUIREMENTS.md).
+- **Platform**: Single web app on GCP Cloud Run (us-east1, scale-to-zero). Per-PR ephemeral environments with isolated Neon Postgres branches.
+- **Tech stack**: Python 3.12 / FastAPI + Uvicorn / Jinja2 / HTMX 2.x (CDN, no build step) / SQLModel + Alembic / psycopg 3 / pdfplumber / Anthropic Python SDK / Resend / `itsdangerous`. Package manager: **uv** (never `pip`).
+- **Architecture**: Modular monolith — single FastAPI process. No microservices, no SPA, no JavaScript build. Full architecture: [docs/TECHNICAL-ARCHITECTURE.md](../../docs/TECHNICAL-ARCHITECTURE.md).
+- **Key non-functional requirements**:
+  - **WCAG conformance is a defining product requirement** (PRD), not a checkbox. Accessibility regressions on the reading surface are blocking.
+  - **<100 ms perceived latency** for in-page view changes (preference toggles, fragment swaps).
+  - **Per-user configurability** — every reading transformation is a per-user preference; never ship a "one-size accessible default."
+- **Domain context**: All user data (passages, preferences, reading events) is private to the owning user. Authorization is enforced in route handlers via `WHERE user_id = current_user.id` — there is no admin role and no cross-user reads.
 
 ## Tools and Capabilities
 
@@ -135,26 +135,44 @@ ask the user to run `gh auth login` (solo) or
 
 You must strictly adhere to the project's architecture and coding standards defined in `CLAUDE.md`.
 
-<!--
-TEMPLATE: Fill in project-specific implementation standards here.
+**Technology stack:**
+- Python 3.12 (pinned in `.python-version` and `pyproject.toml`)
+- FastAPI + Uvicorn, async by default
+- SQLModel for ORM; Alembic for migrations (every schema change ships with one migration in the same PR)
+- Jinja2 templates; HTMX 2.x for interactivity; Pico.css 2.x for baseline styling
+- psycopg 3 with binary + pool extras
+- `anthropic` SDK (LLM), `resend` SDK (email), `pdfplumber` (PDF), `itsdangerous` (sessions)
+- Package management: **uv only**. `uv add <pkg>` to add a runtime dep, `uv add --dev <pkg>` for dev.
 
-Example sections:
-**Technology Stack:**
-- [Language and version]
-- [Framework]
-- [Build tooling]
-- [Testing framework]
+**Code quality:**
+- **Lint + format**: `uv run ruff check .` and `uv run ruff format .`. Ruff config in `pyproject.toml` (line-length 100; rules `E F I W B UP`).
+- **Type check**: `uv run mypy app/`. `check_untyped_defs = true`. New code should be fully typed.
+- **Naming**: `snake_case` modules and functions, `PascalCase` for SQLModel classes, `UPPER_SNAKE` for constants. Module names singular (`app/models/passage.py`, not `passages.py`).
+- **Comments**: only when the *why* is non-obvious. No what-comments. No "added for ticket #N" — that belongs in the PR description.
+- **Imports**: stdlib → third-party → local; ruff isort handles the ordering.
 
-**Code Quality:**
-- [Type safety requirements]
-- [Code style guidelines]
-- [Documentation standards]
+**Testing requirements:**
+- `uv run pytest` (must pass before every push)
+- `uv run pytest --cov=app --cov-report=term-missing` — **coverage threshold: 80%** on `app/`
+- HTTP tests use `fastapi.testclient.TestClient` with the `get_session` dependency overridden to yield a fresh in-memory SQLite session per test. Pattern documented in [docs/TECHNICAL-ARCHITECTURE.md](../../docs/TECHNICAL-ARCHITECTURE.md#fastapi-testing).
+- HTMX endpoints: assert on HTML substrings. **Fragment responses must NOT include `<html`** — assert this explicitly to catch accidental full-page returns.
+- LLM call sites: **mock the `anthropic.Anthropic` client**. Never hit the real API in CI. Real-API tests, if any, live under `tests/integration/` and are env-var-gated.
+- Accessibility tests for the reading surface use Playwright + `@axe-core/playwright` under `tests/a11y/`.
 
-**Testing Requirements:**
-- [Test types required]
-- [Coverage thresholds]
-- [Pre-commit checks]
--->
+**Pre-push checks (REQUIRED — see CLAUDE.md):**
+- `uv run ruff check .`
+- `uv run ruff format --check .`
+- `uv run mypy app/`
+- `uv run pytest`
+The pre-push hook at `scripts/hooks` runs these automatically when `git config core.hooksPath scripts/hooks` is set. **Never use `git push --no-verify`** — fix the failing check.
+
+**Stack-specific pitfalls to avoid:**
+- Do not import `pymupdf` / `fitz`. PyMuPDF is AGPL and incompatible with the project's BSL 1.1 → Apache 2.0 release path. Use `pdfplumber`. (ADR-003.)
+- Do not call the Anthropic API without (a) checking the `comprehension_question_cache` table first, (b) capping input at 4,000 tokens, and (c) using prompt caching on the system message. Unbounded LLM cost is a blocking review finding.
+- Do not return a full Jinja page from a route that's serving an HTMX request. Switch templates on `HX-Request: true`.
+- Do not hardcode application URLs (CLAUDE.md rule #8). Use `request.headers["x-forwarded-host"]` server-side or `window.location.origin` client-side so PR previews work.
+- Do not put secrets in source. Add to Secret Manager and inject as Cloud Run env vars; reference via `pydantic-settings`.
+- Do not skip writing an Alembic migration for schema changes; the deploy workflow runs `alembic upgrade head` against production.
 
 ### 4. Pull Request Creation
 

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -49,14 +49,15 @@ You are a Staff Engineer and Tech Lead responsible for maintaining the highest q
 
 ## Project Context
 
-<!--
-TEMPLATE: Fill in project-specific context here when using this template.
-
-Example fields to populate:
-- **Platform(s)**: [Web, Mobile, Desktop, etc.]
-- **Tech Stack**: [Languages, frameworks, and tools used]
-- **Quality Standards**: [Performance, accessibility, security requirements]
--->
+- **Product**: Cubrox — a WCAG-conformant reading surface for neurodivergent readers. See [docs/PRODUCT-REQUIREMENTS.md](../../docs/PRODUCT-REQUIREMENTS.md).
+- **Platform**: Single FastAPI app on GCP Cloud Run; Neon Postgres with per-PR branches.
+- **Tech stack**: Python 3.12 / FastAPI / Jinja2 / HTMX 2.x / SQLModel + Alembic / psycopg 3 / pdfplumber / Anthropic SDK / Resend / `itsdangerous`. Package manager: **uv**.
+- **Architecture reference**: [docs/TECHNICAL-ARCHITECTURE.md](../../docs/TECHNICAL-ARCHITECTURE.md) — five ADRs you should know cold (Anthropic Haiku for comprehension Qs, magic-link auth, pdfplumber over PyMuPDF, Cloud Logging, HTMX-no-SPA).
+- **Quality standards**:
+  - **WCAG conformance is a defining product requirement.** An accessibility regression on the reading surface is a **blocking** finding, not a suggestion.
+  - **Test coverage ≥80%** on `app/`. Untested new code is a blocking finding.
+  - **<100 ms perceived latency** for in-page view changes (preference toggles, fragment swaps). Flag any change that adds a synchronous network call to that path.
+  - **Privacy**: passages may be sensitive (sacred text, personal uploads). Cross-user reads = blocking. New surfaces that send passage text to third parties (other than Anthropic for question generation) require explicit ADR.
 
 Your reviews must ensure that code is:
 - Technically correct and follows best practices
@@ -146,20 +147,39 @@ Conduct thorough technical reviews of PRs linked to issues in the 'In Review' co
 
 Ensure changes align with standards in `CLAUDE.md`.
 
-<!--
-TEMPLATE: Fill in project-specific architecture compliance checks here.
+**Stack compliance (blocking if violated):**
+- New runtime dependencies added via `uv add` (not edited into `pyproject.toml` by hand). `uv.lock` must be committed alongside any dep change.
+- No new Node/JS build step. HTMX stays CDN-loaded. Pico.css stays CDN-loaded. The CI `node` job must remain auto-skipped.
+- No `pymupdf` / `fitz` imports — use `pdfplumber`. (ADR-003: PyMuPDF is AGPL, conflicts with BSL release path.)
+- No SPA framework imports (`react`, `vue`, `svelte`, `htmx-component-libraries`). HTMX-only client per ADR-005.
+- No password fields, password hashes, or `passlib` imports. Auth is passwordless magic link (ADR-002). A change introducing passwords requires a superseding ADR.
+- LLM calls go through the wrapper service, not directly to `anthropic.Anthropic`. The wrapper enforces the cache lookup, the input-token cap, and prompt caching.
 
-Example sections:
-**Technology Stack Compliance:**
-- [Language/framework version requirements]
-- [Build configuration]
-- [Testing patterns]
+**Code organization:**
+- App code in `app/` only. Tests in `tests/` only. Migrations in `alembic/versions/`.
+- One module per SQLModel entity: `app/models/<entity>.py` (singular). No god-modules.
+- Routes grouped by resource: `app/api/<resource>.py`. HTMX fragment templates under `templates/fragments/`; full pages under `templates/pages/`.
+- Shared services (LLM wrapper, email sender, PDF parser) live under `app/services/`.
 
-**Code Organization:**
-- [Directory structure]
-- [Module organization]
-- [Test file location]
--->
+**Migration discipline:**
+- Every schema change ships with an Alembic migration in the same PR.
+- Migration message describes the *why*, not the *what*. The SQL is in the file.
+- Migrations must be reversible (`downgrade()` defined and tested) unless the change is genuinely irreversible (data loss). Justify in the PR description if so.
+- A migration that touches existing rows must be safe under concurrent writes (no long table locks during business hours). Flag any `ALTER TABLE ... NOT NULL` without a backfill strategy.
+
+**Reading-surface specific checks:**
+- Preferences are applied via CSS variables in a server-rendered `<style id="reading-surface-style">` block. New transformations should follow the same pattern unless they fundamentally require DOM rewrites (e.g., bionic emphasis).
+- Server-side text transformations (e.g., bionic emphasis) must be opt-in per user and gated on a preference flag.
+- HTMX endpoints must return fragments, not full pages, when `HX-Request: true`. Assert `<html` is absent from the test response body.
+
+**Security checks:**
+- Secrets via `pydantic-settings` from env, never literals in code. New secret = new entry in `.claude/PROJECT.md` + Secret Manager.
+- `/login` and `/auth/verify` rate-limited per IP and per email. Any new unauthenticated POST endpoint needs the same.
+- New routes that read DB rows must filter by `current_user.id` unless explicitly public.
+
+**Performance checks:**
+- Any new synchronous external HTTP call on a render path is a flag — would it push the route over 100 ms?
+- N+1 queries on the reading surface are blocking (the surface is the perceived-latency hot spot).
 
 ### 3. Approval Decision Criteria
 

--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -151,15 +151,33 @@ You are a master of:
 
 ## Project-Specific Context
 
-<!--
-TEMPLATE: Fill in project-specific testing context here when using this template.
+- **Product**: Cubrox — configurable reading surface for neurodivergent readers of Baha'i writings. PRD: [docs/PRODUCT-REQUIREMENTS.md](../../docs/PRODUCT-REQUIREMENTS.md). Architecture: [docs/TECHNICAL-ARCHITECTURE.md](../../docs/TECHNICAL-ARCHITECTURE.md).
+- **Architecture**: Server-rendered FastAPI monolith on Cloud Run; HTMX for in-page interactivity; Neon Postgres via SQLModel + Alembic. No SPA, no JavaScript build.
 
-Example fields to populate:
-- **Architecture**: [Description of the application architecture]
-- **Testing Stack**: [Testing frameworks and tools used]
-- **Key Test Areas**: [Core areas requiring testing]
-- **Critical Quality Concerns**: [Project-specific quality priorities]
--->
+- **Testing stack**:
+  - **`pytest` + `pytest-asyncio` + `pytest-cov`** — primary test runner. Config in `pyproject.toml`; `testpaths = ["tests"]`, `asyncio_mode = "auto"`.
+  - **`fastapi.testclient.TestClient` + `httpx`** — HTTP-level tests. The `get_session` dependency is overridden to yield sessions bound to an in-memory SQLite database (StaticPool). Each test gets a fresh database. Pattern: see `## FastAPI Testing Guidance` in `.claude/commands/bootstrap-architecture.md` and the consolidated form in [docs/TECHNICAL-ARCHITECTURE.md](../../docs/TECHNICAL-ARCHITECTURE.md).
+  - **Playwright + `@axe-core/playwright`** — accessibility smoke tests for the reading surface. Lives under `tests/a11y/`; runs in CI on every PR. The Node toolchain is **only** for these tests; production stays Node-free.
+  - **`pytest-mock` (or `unittest.mock`)** — mock the `anthropic.Anthropic` client at every test site. The real Anthropic API is **never** called in CI. Optional `tests/integration/` directory hits the real API behind an env-var gate, run only manually.
+
+- **Key test areas (MVP P0)**:
+  1. **Reading surface** — preference application (CSS variable swap renders correctly), font/size/contrast/spacing/line-height combinations, bionic-emphasis rendering when enabled.
+  2. **Auth** — magic-link issuance (token hashed at rest, single-use, 15-min TTL, rate-limited), session cookie attributes (`HttpOnly`, `Secure`, `SameSite=Lax`), cross-user data isolation.
+  3. **Passage ingestion** — paste path, PDF upload (size cap at 25 MB, malformed PDF surfaces clear error per Risk #3), text-hash idempotency.
+  4. **Comprehension questions** — cache hit returns without hitting LLM, cache miss invokes wrapper service (mocked), input >4,000 tokens is rejected before SDK call, prompt caching headers set.
+  5. **Reading-event metric** — events recorded on session close, `lines_processed` counted from rendered output, dashboard query returns aggregate against the 100k target.
+  6. **Accessibility (axe-core)** — reading surface passes with zero serious/critical violations. Run on every preference combination class (default, high-contrast, large-text, bionic).
+  7. **HTMX contract** — fragment routes return fragments (no `<html`), full-page routes return chrome, `HX-Request` header switches templates correctly.
+
+- **Coverage threshold**: **80%** on `app/` (enforced via `pytest-cov`). New code added without tests is a quality blocker.
+
+- **Critical quality concerns**:
+  - **WCAG conformance** is a defining product requirement, not a checkbox. An axe-core failure on the reading surface is a **blocking** finding.
+  - **Per-user privacy**: passages may include sacred text and personal uploads. Any test that touches cross-user reads or writes is verifying a security boundary, not just behavior.
+  - **LLM cost containment**: tests for the question generator must verify the cache-first path. A regression that bypasses the cache could silently 10x monthly Anthropic spend.
+  - **Performance NFR**: <100 ms perceived latency for view changes. Flag any test that is slow to set up — the production hot path likely is too.
+  - **PDF ingestion fragility** (Risk #3 in PRD): test against representative documents, not just synthetic fixtures. A PDF that produces empty text must surface a clear, accessible error to the user.
+  - **Comprehension-question quality on poetic text** (Risk #2): integration tests against a small curated set of Baha'i passages, run manually before each release. LLM-as-judge is not sufficient for sacred text — human review is required for the question-quality gate.
 
 ## Quality Standards
 

--- a/.claude/agents/system-architect.md
+++ b/.claude/agents/system-architect.md
@@ -433,28 +433,105 @@ Use the **ATAM (Architecture Tradeoff Analysis Method)**:
 
 ## Project-Specific Domain Analysis
 
-<!--
-TEMPLATE: Fill in project-specific domain analysis here when using this template.
+**Source documents:** [docs/PRODUCT-REQUIREMENTS.md](../../docs/PRODUCT-REQUIREMENTS.md), [docs/PRODUCT-ROADMAP.md](../../docs/PRODUCT-ROADMAP.md), [docs/TECHNICAL-ARCHITECTURE.md](../../docs/TECHNICAL-ARCHITECTURE.md), [.claude/PROJECT.md](../PROJECT.md).
 
-Example structure:
+The project is a **modular monolith**, not a microservices system. Bounded contexts below are conceptual seams within one FastAPI process — they shape module boundaries (`app/services/<context>/`) and review heuristics, not deployment units.
+
 ### Bounded Contexts
 
-#### 1. [Context Name]
+#### 1. Identity
 **Aggregates:**
-- `Entity` (root) → `ChildEntity1`, `ChildEntity2`
+- `User` (root) → `MagicLinkToken`, `Session`
 
 **Value Objects:**
-- `ValueObject1`, `ValueObject2`
+- `Email` (citext-stored, normalized lowercase), `MagicToken` (32-byte URL-safe; stored as SHA-256 hash; 15-min TTL; single-use), `SessionCookie` (signed via `itsdangerous`; `HttpOnly`, `Secure`, `SameSite=Lax`; 30-day rolling)
 
 **Domain Events:**
-- `Event1`, `Event2`
+- `MagicLinkRequested` (triggers Resend send), `MagicLinkConsumed` (invalidates outstanding tokens; mints session), `SessionEstablished`
 
 **Ubiquitous Language:**
-- Term1, Term2, Term3
+- *Account*, *Magic link*, *Session*. Never *password*, *signup* (we say *first sign-in*), or *bot user*.
+
+#### 2. Reading Surface
+**Aggregates:**
+- `Preference` (root, one per user) — keyed JSONB store of reading-support choices
+- `Passage` (root) → text content, source metadata, text hash
+
+**Value Objects:**
+- `ReadingMode` (font, size, line-height, contrast, max-width, bionic-on/off), `PassageHash` (SHA-256 of text content; cache key)
+
+**Domain Events:**
+- `PreferenceUpdated` (single-key swap; triggers `<style>` fragment swap), `PassageOpened`, `PassageClosed` (emits `ReadingEvent` for the metric)
+
+**Ubiquitous Language:**
+- *Reading surface* (the rendered page), *Reading-support mode* (a configurable transformation), *Bionic emphasis* (server-side first-N-chars-bold transform). Never *theme* (too generic), *style preset* (we don't ship presets — every choice is per-user).
+
+#### 3. Comprehension
+**Aggregates:**
+- `ComprehensionQuestionCache` (root, keyed by passage hash + question_type + model_id + prompt_version)
+
+**Value Objects:**
+- `QuestionType` (e.g. `recall`, `summary`, `inference`), `PromptVersion` (integer; bump invalidates cache)
+
+**Domain Events:**
+- `QuestionsRequested` (cache lookup), `QuestionsGenerated` (LLM call completed; cache populated)
+
+**Ubiquitous Language:**
+- *Comprehension check*, *Question type*. Never *quiz* (implies grading) or *test* (clinical connotation).
+
+**External dependency:** Anthropic Claude API (model `claude-haiku-4-5`). All access goes through `app/services/comprehension/generator.py`, which enforces (a) cache-first lookup, (b) input cap of 4,000 tokens, (c) prompt caching on the system message. Direct `anthropic.Anthropic()` calls outside this module are an architecture violation.
+
+#### 4. Ingestion
+**Aggregates:**
+- (Stateless) — accepts raw input, produces a `Passage` in the Reading Surface context
+
+**Value Objects:**
+- `RawPaste` (text), `UploadedPdf` (≤25 MB, `application/pdf`)
+
+**Domain Events:**
+- `PassageIngested` (success), `IngestionFailed` (surfaces error to user per Risk #3)
+
+**Ubiquitous Language:**
+- *Ingest*, *Parse* (PDF → text). Never *import* (implies bulk) or *upload* alone (ambiguous: is the file the goal or the text?).
+
+**Implementation constraint:** PDF parsing uses `pdfplumber` only. PyMuPDF is forbidden by ADR-003 (AGPL conflict with BSL release path).
 
 ### Context Mapping
-[Diagram showing how contexts relate to each other]
--->
+
+```
+   Identity ──── (provides current_user) ────┐
+                                              │
+                                              ▼
+   Ingestion ────(produces Passage)────► Reading Surface ◄────(consumes Passage)──── Comprehension
+                                              │                          │
+                                              │ emits ReadingEvent       │ calls Anthropic API
+                                              ▼                          ▼
+                                      [reading_event tbl]         [Anthropic Claude Haiku 4.5]
+                                              │                          │
+                                              ▼                          │
+                                       100k-line metric                  │
+                                                                         ▼
+                                                         [comprehension_question_cache tbl]
+```
+
+All four contexts share one Postgres database (Neon) and one Cloud Run process. The seams are enforced at the module level (`app/services/identity/`, `app/services/reading/`, `app/services/comprehension/`, `app/services/ingestion/`) and at the route level (one router per context under `app/api/`). Cross-context calls are direct function calls, not HTTP — but they should pass identifiers, not entities, so a future split would only require swapping the import for an HTTP client.
+
+### Architecture patterns in use
+
+- **Server-rendered HTML + HTMX fragment swaps** (ADR-005). No SPA. Same handler returns a full Jinja page or a fragment based on `HX-Request: true`.
+- **Cache-aside with content-addressable keys** for LLM responses. Postgres-backed; no Redis in MVP.
+- **Passwordless auth via signed, single-use tokens** (ADR-002). Hand-rolled (~50 LOC) rather than dragging in a heavy auth framework.
+- **Per-PR ephemeral environments** with Neon branching. The `preview-deploy.yml` workflow creates a Neon branch per PR; `preview-cleanup.yml` deletes it on close.
+
+### Key technical decisions
+
+See ADRs in [docs/TECHNICAL-ARCHITECTURE.md §Architecture Decision Records](../../docs/TECHNICAL-ARCHITECTURE.md):
+
+- ADR-001: Anthropic Claude Haiku for comprehension questions (with prompt + Postgres caching)
+- ADR-002: Passwordless magic-link authentication
+- ADR-003: pdfplumber over PyMuPDF (license cleanliness)
+- ADR-004: Cloud Logging + Error Reporting (defer Sentry to Phase 2)
+- ADR-005: HTMX + server rendering, no SPA
 
 ## Communication Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,9 +165,9 @@ TEMPLATE: Fill in project-specific details below when using this template.
 ### Project Information
 
 - **License**: BSL 1.1 (converts to Apache 2.0 after 3 years per release)
-- **Project Name**: [Your project name]
-- **Repository**: [GitHub repo URL]
-- **Project Board**: [GitHub project board URL]
+- **Project Name**: Cubrox
+- **Repository**: https://github.com/vibeacademy/cubrox
+- **Project Board**: TBD (created in Phase 4 — `/bootstrap-workflow`)
 - **Tech Stack**: FastAPI + Jinja2 + HTMX on Python 3.12
 - **Database layer**: SQLModel + Alembic
 - **Platform**: Google Cloud Platform (Cloud Run)
@@ -175,7 +175,12 @@ TEMPLATE: Fill in project-specific details below when using this template.
 - **Container Registry**: Artifact Registry
 - **Secrets**: Google Secret Manager
 - **Package manager**: uv
-- **Organization**: [GitHub org name]
+- **Organization**: vibeacademy
+- **LLM**: Anthropic Claude API (`claude-haiku-4-5` for comprehension questions, with prompt caching + Postgres result cache)
+- **Email**: Resend (passwordless magic-link auth)
+- **PDF**: pdfplumber, in-process, ≤25 MB
+- **Observability**: Google Cloud Logging + Error Reporting
+- **Architecture doc**: `docs/TECHNICAL-ARCHITECTURE.md`
 
 ### Build & Test Commands
 

--- a/docs/TECHNICAL-ARCHITECTURE.md
+++ b/docs/TECHNICAL-ARCHITECTURE.md
@@ -1,0 +1,469 @@
+# Technical Architecture
+
+## Overview
+
+Cubrox is a server-rendered web application that delivers a configurable
+reading surface for neurodivergent readers, with Baha'i writings as its
+primary corpus. A single FastAPI process on Cloud Run serves Jinja2-rendered
+HTML; HTMX drives in-page interactivity (preference toggles, fragment swaps,
+deferred comprehension-question loading) without a JavaScript build step.
+State persists to Neon Postgres via SQLModel; per-PR Neon branches give
+every preview deploy an isolated database. Comprehension questions are
+generated on demand by Anthropic's Claude API and cached by passage hash.
+Authentication is passwordless via signed magic links delivered through
+Resend.
+
+The design optimises for two product invariants: **WCAG conformance is a
+defining requirement, not a checkbox**, and **readability needs vary
+significantly between individuals** (PRD §Constraints). Every reading
+transformation is therefore a per-user preference, every UI surface ships
+with semantic markup and keyboard support, and the rendering pipeline
+applies user CSS variables server-side so the first paint already reflects
+the reader's profile.
+
+## Technology Stack
+
+### Frontend
+
+- Templates: **Jinja2** (server-rendered, no build step)
+- Interactivity: **HTMX 2.x** loaded from CDN (`unpkg.com/htmx.org@2`)
+- Styling: **Pico.css 2.x** (class-less baseline) layered with project CSS
+  variables for the per-user reading surface
+- Reading-support transforms: server-side text rewriters (e.g., bionic
+  emphasis = wrap first N chars of each token in `<b>`); no client-side
+  transformation libraries
+- Accessibility tooling: **axe-core via Playwright** (test only); manual
+  audit gates the WCAG success criterion (Roadmap §Phase 1)
+- No bundler, no Node runtime — the CI `node` job is intentionally absent
+
+### Backend
+
+- Runtime: **Python 3.12**
+- Framework: **FastAPI** + **Uvicorn** (single-process, async)
+- ORM: **SQLModel** (Pydantic + SQLAlchemy)
+- Migrations: **Alembic**
+- Driver: **psycopg 3** with binary + connection pool
+- Settings: **pydantic-settings** (env-driven; values surfaced from Secret
+  Manager via Cloud Run env vars)
+- HTTP client (LLM, email): **httpx** (already a dev dep; promote to runtime)
+- Background work: **`fastapi.BackgroundTasks`** for fire-and-forget email
+  sends and comprehension-question warmups. No queue infrastructure in MVP.
+
+### LLM (comprehension questions)
+
+- Provider: **Anthropic Claude API**, model **`claude-haiku-4-5`** (fast,
+  cheap, strong on nuanced/sacred text)
+- SDK: **`anthropic` Python SDK** with **prompt caching** on the system
+  prompt (the per-passage user message is the only thing that changes)
+- Secret: `ANTHROPIC_API_KEY` in Secret Manager → injected as Cloud Run env
+- Budgeting: cap input passage at 4,000 tokens; refuse longer with a UX
+  hint to split. Generated questions cached in Postgres by SHA-256 of
+  `(passage_text, question_type, model_id, prompt_version)` so re-reads
+  cost zero LLM calls.
+
+### Authentication
+
+- **Passwordless magic link**, hand-rolled (~50 LOC)
+- Token: 32 bytes from `secrets.token_urlsafe`, stored as SHA-256 hash with
+  15-minute expiry. Single-use; one active token per email at a time.
+- Email transport: **Resend** (`resend` Python SDK)
+- Session: signed cookie via **`itsdangerous`** (`HttpOnly`, `Secure`,
+  `SameSite=Lax`, 30-day rolling)
+- Secrets: `RESEND_API_KEY`, `SESSION_SECRET` in Secret Manager
+
+### PDF ingestion
+
+- Parser: **`pdfplumber`** (MIT-licensed; license-clean for BSL 1.1 release)
+- Path: multipart upload → FastAPI route → in-process parse → render in
+  reading view. Cap at 25 MB to stay under Cloud Run's 32 MB request limit.
+- Errors surfaced inline ("This PDF couldn't be parsed — try copy-pasting
+  the text") per Risk #3 in the PRD.
+
+### Database
+
+- Primary: **Neon Postgres** (serverless, per-PR branching wired via
+  `preview-deploy.yml`)
+- No cache layer in MVP; Postgres handles preference + passage reads.
+  Reading-event writes are cheap (single INSERT). Reconsider Redis in
+  Phase 2 only if latency target (<100 ms) is missed.
+- No search engine in MVP. Add when curated-library work in Phase 3 lands.
+
+### Infrastructure
+
+- Hosting: **GCP Cloud Run** (scale-to-zero, single region us-east1)
+- Container registry: **Artifact Registry**
+- Secrets: **Google Secret Manager** → mounted as Cloud Run env vars
+- Auth to GCP: **Workload Identity Federation** from GitHub Actions (SA key
+  fallback for workshops only)
+- CI/CD: **GitHub Actions** — `ci.yml` (lint+test), `preview-deploy.yml`
+  (per-PR ephemeral env + Neon branch), `deploy.yml` (main → production)
+- Observability: **Google Cloud Logging + Error Reporting** (zero-setup,
+  auto-grouping of FastAPI tracebacks). Sentry deferred to Phase 2 if
+  Cloud Logging proves insufficient.
+
+## System Design
+
+### Component Diagram
+
+```
+                ┌──────────────────────────────────────────────┐
+                │              Browser (HTMX 2.x)              │
+                │  Renders server HTML; swaps fragments on     │
+                │  preference toggle / question request.       │
+                └──────────────────┬───────────────────────────┘
+                                   │ HTTPS
+                                   ▼
+              ┌────────────────────────────────────────────────┐
+              │              Cloud Run service                 │
+              │   FastAPI + Uvicorn (single async process)     │
+              │                                                │
+              │  ┌────────┐  ┌──────────┐  ┌────────────────┐  │
+              │  │ Auth   │  │ Reading  │  │ Comprehension  │  │
+              │  │ routes │  │ surface  │  │ question route │  │
+              │  │ /login │  │ /read    │  │ (HTMX lazy)    │  │
+              │  │ /verify│  │ /upload  │  │                │  │
+              │  └────────┘  └──────────┘  └────────────────┘  │
+              │       │           │                │           │
+              │       ▼           ▼                ▼           │
+              │  ┌───────────────────────┐  ┌────────────────┐ │
+              │  │  SQLModel session     │  │ Anthropic SDK  │ │
+              │  │  (psycopg pool)       │  │ (httpx-backed) │ │
+              │  └───────────┬───────────┘  └────────┬───────┘ │
+              └──────────────┼───────────────────────┼─────────┘
+                             ▼                       ▼
+                  ┌──────────────────┐   ┌────────────────────┐
+                  │  Neon Postgres   │   │  Anthropic API     │
+                  │  user / pref /   │   │  Claude Haiku 4.5  │
+                  │  passage / event │   │  (prompt caching)  │
+                  └──────────────────┘   └────────────────────┘
+
+                             ┌──────────────────┐
+                             │  Resend (email)  │ ← magic-link delivery
+                             └──────────────────┘
+```
+
+### Data Flow — typical reading session
+
+1. User pastes text or uploads PDF → `POST /passages` → server parses
+   (pdfplumber) → row in `passage` → redirect to `/read/{id}`.
+2. `GET /read/{id}` renders the reading surface with the user's preferences
+   inlined as CSS variables in the template head. First paint is already
+   correctly styled — no reflow.
+3. Comprehension panel is loaded via `hx-get="/passages/{id}/questions"
+   hx-trigger="load delay:200ms"` so the page appears instantly.
+4. The question route checks the cache (`comprehension_question_cache` keyed
+   by passage hash). On miss, it calls Claude Haiku via the Anthropic SDK
+   with prompt caching on the system prompt, persists the result, returns
+   the HTML fragment.
+5. Preference toggles `hx-post` to `/preferences/{key}`, swap the `<style>`
+   variable block via `hx-target="#reading-surface-style"
+   hx-swap="outerHTML"`. No full-page reload.
+6. Reading-event writes (`reading_event` table) happen on passage close
+   (`hx-trigger="unload"` beacon) and feed the 100k-line metric.
+
+### API Design
+
+REST + HTML fragments. Routes return either a full Jinja page (browser
+navigation) or an HTMX fragment (when `HX-Request: true`). Same handler,
+template selection driven by request header.
+
+| Route                              | Method | Returns          | Notes                                  |
+|------------------------------------|--------|------------------|----------------------------------------|
+| `/`                                | GET    | Page             | Marketing / login CTA                  |
+| `/login`                           | POST   | Fragment         | Email submitted → magic link sent      |
+| `/auth/verify`                     | GET    | Redirect         | Token consumed → session cookie set    |
+| `/passages`                        | POST   | Redirect         | Paste or PDF upload                    |
+| `/read/{passage_id}`               | GET    | Page             | Reading surface (full chrome)          |
+| `/passages/{id}/questions`        | GET    | Fragment         | Lazy-loaded comprehension panel        |
+| `/preferences/{key}`               | POST   | Fragment         | Updates one preference, swaps `<style>` |
+| `/healthz`                         | GET    | JSON             | Cloud Run liveness/readiness           |
+
+JSON APIs are intentionally absent in MVP — there is no mobile client or
+third-party integration. Adding JSON later is straightforward (FastAPI's
+`response_class` already supports both).
+
+### Reading-Surface Mechanics
+
+The reading surface is a single Jinja template that injects per-user CSS
+variables in a `<style id="reading-surface-style">` block:
+
+```html
+<style id="reading-surface-style">
+  :root {
+    --reader-font: {{ prefs.font }};
+    --reader-size: {{ prefs.size }};
+    --reader-line-height: {{ prefs.line_height }};
+    --reader-bg: {{ prefs.bg }};
+    --reader-fg: {{ prefs.fg }};
+    --reader-max-width: {{ prefs.max_width }};
+  }
+</style>
+```
+
+Visual reformatting modes (font, size, contrast, spacing, max width) are
+all CSS-variable swaps — no DOM rewrites. Bionic-style emphasis is the
+exception: it requires server-side text transformation (wrap first N chars
+of each token in `<b>`), produced when the passage is rendered, gated on
+`prefs.bionic_enabled`.
+
+This keeps the reading surface accessible by default: screen readers see
+plain semantic HTML; visual transformations are CSS-only or
+opt-in-and-explicit.
+
+## Data Models
+
+### Core Entities
+
+- **User**: account holder. Identified by email. No password hash
+  (passwordless).
+- **MagicLinkToken**: short-lived, hashed; one active per user.
+- **Preference**: per-user reading-support settings. JSONB-typed for
+  schema flexibility as the support toolkit evolves.
+- **Passage**: a piece of text the user is reading. Originates from paste
+  or PDF upload.
+- **ComprehensionQuestionCache**: keyed by passage hash; stores generated
+  questions to avoid re-paying the LLM cost on re-reads.
+- **ReadingEvent**: append-only log of read sessions, used for the 100k
+  metric. Stores `lines_processed` as the rendered-line count at session
+  close.
+
+### Database Schema (sketch)
+
+```sql
+CREATE TABLE "user" (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email       CITEXT UNIQUE NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_login  TIMESTAMPTZ
+);
+
+CREATE TABLE magic_link_token (
+  user_id     UUID NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  token_hash  BYTEA PRIMARY KEY,
+  expires_at  TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ
+);
+CREATE INDEX ON magic_link_token (user_id);
+
+CREATE TABLE preference (
+  user_id    UUID PRIMARY KEY REFERENCES "user"(id) ON DELETE CASCADE,
+  values     JSONB NOT NULL DEFAULT '{}'::jsonb,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE passage (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  text            TEXT NOT NULL,
+  text_hash       BYTEA NOT NULL,           -- SHA-256, used as cache key
+  source_type     TEXT NOT NULL CHECK (source_type IN ('paste','pdf')),
+  source_filename TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON passage (user_id, created_at DESC);
+CREATE INDEX ON passage (text_hash);
+
+CREATE TABLE comprehension_question_cache (
+  passage_hash    BYTEA NOT NULL,
+  question_type   TEXT NOT NULL,
+  model_id        TEXT NOT NULL,
+  prompt_version  INT  NOT NULL,
+  questions       JSONB NOT NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (passage_hash, question_type, model_id, prompt_version)
+);
+
+CREATE TABLE reading_event (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          UUID NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  passage_id       UUID NOT NULL REFERENCES passage(id) ON DELETE CASCADE,
+  lines_processed  INT  NOT NULL,
+  occurred_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON reading_event (occurred_at);
+```
+
+`citext` and `gen_random_uuid()` ship with Neon; enable via Alembic
+migration that runs `CREATE EXTENSION IF NOT EXISTS citext;` and
+`CREATE EXTENSION IF NOT EXISTS pgcrypto;`.
+
+## Development Standards
+
+### Code Style
+
+- Lint + format: **ruff** (`ruff check .` / `ruff format .`), line-length 100
+- Selected rules: `E`, `F`, `I`, `W`, `B`, `UP` (already configured)
+- Type-checking: **mypy** in strict-ish mode (`check_untyped_defs = true`)
+- Naming: `snake_case` modules and functions, `PascalCase` for SQLModel
+  classes, `UPPER_SNAKE` for constants. Module names singular
+  (`app/models/passage.py`), not plural.
+- Imports: stdlib → third-party → local, separated by blank lines (ruff
+  isort handles automatically)
+- Comments: only when *why* is non-obvious. No what-comments. No "added
+  for ticket #123" — that belongs in the PR.
+
+### Testing Requirements
+
+- Unit + HTTP tests: **pytest** + **httpx.AsyncClient** with the in-memory
+  SQLite session fixture documented in this file.
+- HTMX endpoints: assert on HTML substrings; assert fragment responses do
+  NOT include `<html` (catches accidental full-page returns).
+- LLM call sites: mock the `anthropic.Anthropic` client; never hit the
+  real API in CI. A separate `tests/integration/` directory may hit the
+  real API behind an env-var gate, run only manually.
+- Coverage target: **>80%** on `app/`. Enforced via `pytest-cov`.
+- Accessibility: Playwright + `@axe-core/playwright` smoke test on the
+  reading surface; runs on every PR via `ci.yml`. (Adds Node only for the
+  test run, kept in `tests/a11y/`; production stays Node-free.)
+
+### Documentation
+
+- Public functions: one-line docstring when the name doesn't tell the
+  whole story; otherwise none.
+- Migrations: Alembic message must describe *why*, not *what* the SQL
+  does. The SQL itself is in the file.
+- Architecture decisions: ADRs appended to this document under
+  "Architecture Decision Records" — short, dated, never edited after
+  acceptance (supersede with a new ADR instead).
+
+### Code Review
+
+- All PRs reviewed by `pr-reviewer` agent before human merge.
+- Required-change blockers: failing tests, missing migration for schema
+  change, secret leak, accessibility regression on the reading surface,
+  unbounded LLM cost (no cache lookup, no input cap).
+- Suggestions are non-blocking — merge can proceed if author disagrees
+  with rationale.
+
+## Security
+
+### Authentication
+
+- Passwordless magic link (15-minute TTL, single-use, hashed at rest).
+- Sessions: signed cookie via `itsdangerous`, `HttpOnly`, `Secure`,
+  `SameSite=Lax`. 30-day rolling re-issue.
+- Rate-limit `/login` and `/auth/verify` per IP and per email
+  (10/hour each) using a Postgres-backed token bucket. (Redis would be
+  better; add when traffic justifies it.)
+
+### Authorization
+
+- Single role: authenticated user. A user can only read/write their own
+  rows (enforced in route handlers via `WHERE user_id = current_user.id`).
+- No admin UI in MVP. Admin tasks happen via psql against the Neon branch.
+
+### Data Protection
+
+- TLS via Cloud Run's managed cert.
+- Secrets in **Google Secret Manager**, never in source. The `database-url`,
+  `ANTHROPIC_API_KEY`, `RESEND_API_KEY`, and `SESSION_SECRET` secrets are
+  injected as Cloud Run env vars at deploy time.
+- PII collected: email only. Passages may contain user-uploaded content;
+  treat as private to the user (no cross-user reads, no LLM training opt-in).
+- Anthropic data handling: passages are sent to the Claude API for
+  question generation. Anthropic's default policy does not train on API
+  inputs — verify in the privacy policy linked from the marketing page.
+- No third-party analytics in MVP. (Cloud Logging is first-party.)
+
+## Scalability
+
+### Current Targets (Roadmap §M2)
+
+- **100,000 lines processed within 3 months of launch.** Assuming a
+  working session is ~200 lines, that's ~500 sessions, easily handled by
+  a single Cloud Run instance.
+- **Perceived latency < 100 ms for view changes** (PRD §NFR). This is the
+  binding constraint, not throughput.
+
+### Scaling Strategy
+
+- Cloud Run scales horizontally on request concurrency (default 80
+  concurrent requests per instance). Scale-to-zero when idle.
+- Neon's connection-pooled URL handles fan-out without exhausting the
+  database.
+- Comprehension-question cache keeps LLM calls bounded by *distinct
+  passages* read, not *re-reads*. Even at 10x the metric target, expected
+  monthly LLM spend is under $20.
+- Reading-event writes are append-only and cheap; no concern through M3.
+
+### When to revisit
+
+- Add Redis if `reading_event` aggregation queries (the metric dashboard)
+  become slow, or if rate-limit lookups exceed 10 ms p99.
+- Move PDF parsing to a Cloud Tasks worker if files >25 MB become common
+  (workshop-style large documents). Until then, in-process is simpler.
+
+## Architecture Decision Records
+
+### ADR-001: Anthropic Claude for comprehension question generation
+
+- Status: Accepted (2026-05-02)
+- Context: PRD lists the comprehension-question generator as TBD between
+  LLM and rules-based. Sacred/poetic text quality is a Risk #2 explicitly
+  called out. Neurodivergent reading benefits from questions that engage
+  with *meaning*, not just recall.
+- Decision: Use **Anthropic Claude Haiku 4.5** via the official Python
+  SDK, with prompt caching on the system prompt and Postgres-backed
+  result caching by passage hash.
+- Consequences: Adds Anthropic as a third-party vendor and `ANTHROPIC_API_KEY`
+  as a managed secret. Avoids vendor lock-in by isolating the call site
+  behind an `app/services/questions.py` interface — swap to Vertex/Gemini
+  is a one-file change. Cost remains negligible at MVP scale due to
+  result caching.
+
+### ADR-002: Passwordless magic-link authentication
+
+- Status: Accepted (2026-05-02)
+- Context: Primary users are neurodivergent readers; password friction
+  (remembering, typing, resetting) is exactly the kind of cognitive load
+  the product is built to remove.
+- Decision: Hand-rolled magic-link flow (~50 LOC), token hashed at rest,
+  15-minute TTL, single-use. Email delivery via **Resend**. Sessions via
+  signed cookie (`itsdangerous`).
+- Consequences: Adds Resend as a vendor and `RESEND_API_KEY` as a managed
+  secret. Removes the entire password-reset surface (no UI, no rate-limit
+  story, no breach exposure for stored hashes). Magic links can be
+  hijacked if the user's email is compromised — same exposure as
+  password reset, so net-equivalent risk.
+
+### ADR-003: pdfplumber over PyMuPDF for PDF parsing
+
+- Status: Accepted (2026-05-02)
+- Context: PRD lists PDF upload as P0. PyMuPDF has better text-extraction
+  fidelity but is **AGPL-licensed**, which conflicts with this project's
+  BSL 1.1 → Apache 2.0 release path.
+- Decision: Use **pdfplumber** (MIT-licensed). If extraction quality is
+  inadequate during Phase 1 testing on representative documents, revisit
+  with options: (a) license PyMuPDF commercially, (b) move to a separate
+  AGPL-clean parser like `pypdf` + Tesseract for OCR, (c) sandbox PyMuPDF
+  in an isolated worker that the BSL conversion can exclude.
+- Consequences: Some loss of fidelity on heavily-formatted PDFs.
+  Mitigated by clear error UX (Risk #3 in PRD) — user can fall back to
+  paste.
+
+### ADR-004: Cloud Logging + Error Reporting over Sentry for MVP
+
+- Status: Accepted (2026-05-02)
+- Context: Three observability options exist (Cloud Logging, Sentry,
+  both). MVP scope favours zero-setup over best-in-class.
+- Decision: **Cloud Logging + Error Reporting**, both auto-wired by Cloud
+  Run. Add Sentry in Phase 2 if grouping/triage proves insufficient.
+- Consequences: Slightly worse stack-trace ergonomics than Sentry, no
+  release tracking, no issue assignment. Acceptable for an MVP whose
+  user base is a small first cohort. The instrumentation cost to add
+  Sentry later is one `app/main.py` import + one secret.
+
+### ADR-005: HTMX + server-side rendering, no SPA
+
+- Status: Accepted (2026-05-02)
+- Context: Reading surface needs to feel instant (<100 ms perceived
+  latency) and be WCAG-conformant by default. SPA frameworks add a
+  rendering layer between source HTML and what assistive tech sees, and
+  shift accessibility burden onto the framework.
+- Decision: Server-rendered Jinja templates + HTMX for in-page swaps. No
+  React/Vue/Svelte. No bundler. Pico.css for baseline styling.
+- Consequences: Smaller bundle, faster first paint, easier accessibility
+  audit, no Node toolchain in production. The cost is that complex
+  client-side interactions (e.g., drag-to-reorder) require either light
+  custom JS or graceful server round-trips. Acceptable for the MVP
+  surface, which is fundamentally a read-and-toggle experience.


### PR DESCRIPTION
## Summary

- Phase 2 of bootstrap — captures architecture decisions made during `/bootstrap-architecture`.
- Adds [docs/TECHNICAL-ARCHITECTURE.md](docs/TECHNICAL-ARCHITECTURE.md) with five ADRs (Anthropic Claude Haiku for comprehension Qs, magic-link auth via Resend, pdfplumber over PyMuPDF for BSL license cleanliness, Cloud Logging for MVP observability, HTMX-only client).
- Adds [.claude/PROJECT.md](.claude/PROJECT.md) — platform/stack pin consumed by `devops-engineer` and `system-architect` agents.
- Updates [CLAUDE.md](CLAUDE.md) Project Information section (name, repo, org, external services, link to architecture doc).

## What this unblocks

- `/bootstrap-agents` (Phase 3) — agent files can now read project-specific context from these documents.
- `/bootstrap-workflow` (Phase 4) — backlog seeding from PRD + roadmap.

## Out of scope

- Dependency additions (`anthropic`, `resend`, `pdfplumber`, `itsdangerous`) will land with the first ticket that uses each one.
- New Secret Manager secrets (`anthropic-api-key`, `resend-api-key`, `session-secret`) — provisioning happens before the relevant feature ticket runs end-to-end.

## Test plan

- [ ] CI lint + format pass (doc-only change; `ruff` should not flag anything)
- [ ] CI test suite green (no code touched)
- [ ] Markdown renders cleanly on the PR diff view
- [ ] ADR numbering and dates consistent (ADR-001 through ADR-005, all dated 2026-05-02)

🤖 Generated with [Claude Code](https://claude.com/claude-code)