### PR TITLE
docs(agents): specialize agents with project-specific context

### DIFF
--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -30,15 +30,15 @@ You are a Senior Full-Stack Engineer. Your primary responsibility is to autonomo
 
 ## Project Context
 
-<!--
-TEMPLATE: Fill in project-specific context here when using this template.
-
-Example fields to populate:
-- **Platform(s)**: [Web, Mobile, Desktop, etc.]
-- **Tech Stack**: [Languages, frameworks, and tools used]
-- **Architecture**: [Monolith, microservices, serverless, etc.]
-- **Key Quality Standards**: [Performance, accessibility, security requirements]
--->
+- **Product**: Cubrox — a WCAG-conformant reading surface for neurodivergent readers of Baha'i writings. See [docs/PRODUCT-REQUIREMENTS.md](../../docs/PRODUCT-REQUIREMENTS.md).
+- **Platform**: Single web app on GCP Cloud Run (us-east1, scale-to-zero). Per-PR ephemeral environments with isolated Neon Postgres branches.
+- **Tech stack**: Python 3.12 / FastAPI + Uvicorn / Jinja2 / HTMX 2.x (CDN, no build step) / SQLModel + Alembic / psycopg 3 / pdfplumber / Anthropic Python SDK / Resend / `itsdangerous`. Package manager: **uv** (never `pip`).
+- **Architecture**: Modular monolith — single FastAPI process. No microservices, no SPA, no JavaScript build. Full architecture: [docs/TECHNICAL-ARCHITECTURE.md](../../docs/TECHNICAL-ARCHITECTURE.md).
+- **Key non-functional requirements**:
+  - **WCAG conformance is a defining product requirement** (PRD), not a checkbox. Accessibility regressions on the reading surface are blocking.
+  - **<100 ms perceived latency** for in-page view changes (preference toggles, fragment swaps).
+  - **Per-user configurability** — every reading transformation is a per-user preference; never ship a "one-size accessible default."
+- **Domain context**: All user data (passages, preferences, reading events) is private to the owning user. Authorization is enforced in route handlers via `WHERE user_id = current_user.id` — there is no admin role and no cross-user reads.
 
 ## Tools and Capabilities
 
@@ -135,26 +135,44 @@ ask the user to run `gh auth login` (solo) or
 
 You must strictly adhere to the project's architecture and coding standards defined in `CLAUDE.md`.
 
-<!--
-TEMPLATE: Fill in project-specific implementation standards here.
+**Technology stack:**
+- Python 3.12 (pinned in `.python-version` and `pyproject.toml`)
+- FastAPI + Uvicorn, async by default
+- SQLModel for ORM; Alembic for migrations (every schema change ships with one migration in the same PR)
+- Jinja2 templates; HTMX 2.x for interactivity; Pico.css 2.x for baseline styling
+- psycopg 3 with binary + pool extras
+- `anthropic` SDK (LLM), `resend` SDK (email), `pdfplumber` (PDF), `itsdangerous` (sessions)
+- Package management: **uv only**. `uv add <pkg>` to add a runtime dep, `uv add --dev <pkg>` for dev.
 
-Example sections:
-**Technology Stack:**
-- [Language and version]
-- [Framework]
-- [Build tooling]
-- [Testing framework]
+**Code quality:**
+- **Lint + format**: `uv run ruff check .` and `uv run ruff format .`. Ruff config in `pyproject.toml` (line-length 100; rules `E F I W B UP`).
+- **Type check**: `uv run mypy app/`. `check_untyped_defs = true`. New code should be fully typed.
+- **Naming**: `snake_case` modules and functions, `PascalCase` for SQLModel classes, `UPPER_SNAKE` for constants. Module names singular (`app/models/passage.py`, not `passages.py`).
+- **Comments**: only when the *why* is non-obvious. No what-comments. No "added for ticket #N" — that belongs in the PR description.
+- **Imports**: stdlib → third-party → local; ruff isort handles the ordering.
 
-**Code Quality:**
-- [Type safety requirements]
-- [Code style guidelines]
-- [Documentation standards]
+**Testing requirements:**
+- `uv run pytest` (must pass before every push)
+- `uv run pytest --cov=app --cov-report=term-missing` — **coverage threshold: 80%** on `app/`
+- HTTP tests use `fastapi.testclient.TestClient` with the `get_session` dependency overridden to yield a fresh in-memory SQLite session per test. Pattern documented in [docs/TECHNICAL-ARCHITECTURE.md](../../docs/TECHNICAL-ARCHITECTURE.md#fastapi-testing).
+- HTMX endpoints: assert on HTML substrings. **Fragment responses must NOT include `<html`** — assert this explicitly to catch accidental full-page returns.
+- LLM call sites: **mock the `anthropic.Anthropic` client**. Never hit the real API in CI. Real-API tests, if any, live under `tests/integration/` and are env-var-gated.
+- Accessibility tests for the reading surface use Playwright + `@axe-core/playwright` under `tests/a11y/`.
 
-**Testing Requirements:**
-- [Test types required]
-- [Coverage thresholds]
-- [Pre-commit checks]
--->
+**Pre-push checks (REQUIRED — see CLAUDE.md):**
+- `uv run ruff check .`
+- `uv run ruff format --check .`
+- `uv run mypy app/`
+- `uv run pytest`
+The pre-push hook at `scripts/hooks` runs these automatically when `git config core.hooksPath scripts/hooks` is set. **Never use `git push --no-verify`** — fix the failing check.
+
+**Stack-specific pitfalls to avoid:**
+- Do not import `pymupdf` / `fitz`. PyMuPDF is AGPL and incompatible with the project's BSL 1.1 → Apache 2.0 release path. Use `pdfplumber`. (ADR-003.)
+- Do not call the Anthropic API without (a) checking the `comprehension_question_cache` table first, (b) capping input at 4,000 tokens, and (c) using prompt caching on the system message. Unbounded LLM cost is a blocking review finding.
+- Do not return a full Jinja page from a route that's serving an HTMX request. Switch templates on `HX-Request: true`.
+- Do not hardcode application URLs (CLAUDE.md rule #8). Use `request.headers["x-forwarded-host"]` server-side or `window.location.origin` client-side so PR previews work.
+- Do not put secrets in source. Add to Secret Manager and inject as Cloud Run env vars; reference via `pydantic-settings`.
+- Do not skip writing an Alembic migration for schema changes; the deploy workflow runs `alembic upgrade head` against production.
 
 ### 4. Pull Request Creation
 

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -49,14 +49,15 @@ You are a Staff Engineer and Tech Lead responsible for maintaining the highest q
 
 ## Project Context
 
-<!--
-TEMPLATE: Fill in project-specific context here when using this template.
-
-Example fields to populate:
-- **Platform(s)**: [Web, Mobile, Desktop, etc.]
-- **Tech Stack**: [Languages, frameworks, and tools used]
-- **Quality Standards**: [Performance, accessibility, security requirements]
--->
+- **Product**: Cubrox — a WCAG-conformant reading surface for neurodivergent readers. See [docs/PRODUCT-REQUIREMENTS.md](../../docs/PRODUCT-REQUIREMENTS.md).
+- **Platform**: Single FastAPI app on GCP Cloud Run; Neon Postgres with per-PR branches.
+- **Tech stack**: Python 3.12 / FastAPI / Jinja2 / HTMX 2.x / SQLModel + Alembic / psycopg 3 / pdfplumber / Anthropic SDK / Resend / `itsdangerous`. Package manager: **uv**.
+- **Architecture reference**: [docs/TECHNICAL-ARCHITECTURE.md](../../docs/TECHNICAL-ARCHITECTURE.md) — five ADRs you should know cold (Anthropic Haiku for comprehension Qs, magic-link auth, pdfplumber over PyMuPDF, Cloud Logging, HTMX-no-SPA).
+- **Quality standards**:
+  - **WCAG conformance is a defining product requirement.** An accessibility regression on the reading surface is a **blocking** finding, not a suggestion.
+  - **Test coverage ≥80%** on `app/`. Untested new code is a blocking finding.
+  - **<100 ms perceived latency** for in-page view changes (preference toggles, fragment swaps). Flag any change that adds a synchronous network call to that path.
+  - **Privacy**: passages may be sensitive (sacred text, personal uploads). Cross-user reads = blocking. New surfaces that send passage text to third parties (other than Anthropic for question generation) require explicit ADR.
 
 Your reviews must ensure that code is:
 - Technically correct and follows best practices
@@ -146,20 +147,39 @@ Conduct thorough technical reviews of PRs linked to issues in the 'In Review' co
 
 Ensure changes align with standards in `CLAUDE.md`.
 
-<!--
-TEMPLATE: Fill in project-specific architecture compliance checks here.
+**Stack compliance (blocking if violated):**
+- New runtime dependencies added via `uv add` (not edited into `pyproject.toml` by hand). `uv.lock` must be committed alongside any dep change.
+- No new Node/JS build step. HTMX stays CDN-loaded. Pico.css stays CDN-loaded. The CI `node` job must remain auto-skipped.
+- No `pymupdf` / `fitz` imports — use `pdfplumber`. (ADR-003: PyMuPDF is AGPL, conflicts with BSL release path.)
+- No SPA framework imports (`react`, `vue`, `svelte`, `htmx-component-libraries`). HTMX-only client per ADR-005.
+- No password fields, password hashes, or `passlib` imports. Auth is passwordless magic link (ADR-002). A change introducing passwords requires a superseding ADR.
+- LLM calls go through the wrapper service, not directly to `anthropic.Anthropic`. The wrapper enforces the cache lookup, the input-token cap, and prompt caching.
 
-Example sections:
-**Technology Stack Compliance:**
-- [Language/framework version requirements]
-- [Build configuration]
-- [Testing patterns]
+**Code organization:**
+- App code in `app/` only. Tests in `tests/` only. Migrations in `alembic/versions/`.
+- One module per SQLModel entity: `app/models/<entity>.py` (singular). No god-modules.
+- Routes grouped by resource: `app/api/<resource>.py`. HTMX fragment templates under `templates/fragments/`; full pages under `templates/pages/`.
+- Shared services (LLM wrapper, email sender, PDF parser) live under `app/services/`.
 
-**Code Organization:**
-- [Directory structure]
-- [Module organization]
-- [Test file location]
--->
+**Migration discipline:**
+- Every schema change ships with an Alembic migration in the same PR.
+- Migration message describes the *why*, not the *what*. The SQL is in the file.
+- Migrations must be reversible (`downgrade()` defined and tested) unless the change is genuinely irreversible (data loss). Justify in the PR description if so.
+- A migration that touches existing rows must be safe under concurrent writes (no long table locks during business hours). Flag any `ALTER TABLE ... NOT NULL` without a backfill strategy.
+
+**Reading-surface specific checks:**
+- Preferences are applied via CSS variables in a server-rendered `<style id="reading-surface-style">` block. New transformations should follow the same pattern unless they fundamentally require DOM rewrites (e.g., bionic emphasis).
+- Server-side text transformations (e.g., bionic emphasis) must be opt-in per user and gated on a preference flag.
+- HTMX endpoints must return fragments, not full pages, when `HX-Request: true`. Assert `<html` is absent from the test response body.
+
+**Security checks:**
+- Secrets via `pydantic-settings` from env, never literals in code. New secret = new entry in `.claude/PROJECT.md` + Secret Manager.
+- `/login` and `/auth/verify` rate-limited per IP and per email. Any new unauthenticated POST endpoint needs the same.
+- New routes that read DB rows must filter by `current_user.id` unless explicitly public.
+
+**Performance checks:**
+- Any new synchronous external HTTP call on a render path is a flag — would it push the route over 100 ms?
+- N+1 queries on the reading surface are blocking (the surface is the perceived-latency hot spot).
 
 ### 3. Approval Decision Criteria
 

--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -151,15 +151,33 @@ You are a master of:
 
 ## Project-Specific Context
 
-<!--
-TEMPLATE: Fill in project-specific testing context here when using this template.
+- **Product**: Cubrox — configurable reading surface for neurodivergent readers of Baha'i writings. PRD: [docs/PRODUCT-REQUIREMENTS.md](../../docs/PRODUCT-REQUIREMENTS.md). Architecture: [docs/TECHNICAL-ARCHITECTURE.md](../../docs/TECHNICAL-ARCHITECTURE.md).
+- **Architecture**: Server-rendered FastAPI monolith on Cloud Run; HTMX for in-page interactivity; Neon Postgres via SQLModel + Alembic. No SPA, no JavaScript build.
 
-Example fields to populate:
-- **Architecture**: [Description of the application architecture]
-- **Testing Stack**: [Testing frameworks and tools used]
-- **Key Test Areas**: [Core areas requiring testing]
-- **Critical Quality Concerns**: [Project-specific quality priorities]
--->
+- **Testing stack**:
+  - **`pytest` + `pytest-asyncio` + `pytest-cov`** — primary test runner. Config in `pyproject.toml`; `testpaths = ["tests"]`, `asyncio_mode = "auto"`.
+  - **`fastapi.testclient.TestClient` + `httpx`** — HTTP-level tests. The `get_session` dependency is overridden to yield sessions bound to an in-memory SQLite database (StaticPool). Each test gets a fresh database. Pattern: see `## FastAPI Testing Guidance` in `.claude/commands/bootstrap-architecture.md` and the consolidated form in [docs/TECHNICAL-ARCHITECTURE.md](../../docs/TECHNICAL-ARCHITECTURE.md).
+  - **Playwright + `@axe-core/playwright`** — accessibility smoke tests for the reading surface. Lives under `tests/a11y/`; runs in CI on every PR. The Node toolchain is **only** for these tests; production stays Node-free.
+  - **`pytest-mock` (or `unittest.mock`)** — mock the `anthropic.Anthropic` client at every test site. The real Anthropic API is **never** called in CI. Optional `tests/integration/` directory hits the real API behind an env-var gate, run only manually.
+
+- **Key test areas (MVP P0)**:
+  1. **Reading surface** — preference application (CSS variable swap renders correctly), font/size/contrast/spacing/line-height combinations, bionic-emphasis rendering when enabled.
+  2. **Auth** — magic-link issuance (token hashed at rest, single-use, 15-min TTL, rate-limited), session cookie attributes (`HttpOnly`, `Secure`, `SameSite=Lax`), cross-user data isolation.
+  3. **Passage ingestion** — paste path, PDF upload (size cap at 25 MB, malformed PDF surfaces clear error per Risk #3), text-hash idempotency.
+  4. **Comprehension questions** — cache hit returns without hitting LLM, cache miss invokes wrapper service (mocked), input >4,000 tokens is rejected before SDK call, prompt caching headers set.
+  5. **Reading-event metric** — events recorded on session close, `lines_processed` counted from rendered output, dashboard query returns aggregate against the 100k target.
+  6. **Accessibility (axe-core)** — reading surface passes with zero serious/critical violations. Run on every preference combination class (default, high-contrast, large-text, bionic).
+  7. **HTMX contract** — fragment routes return fragments (no `<html`), full-page routes return chrome, `HX-Request` header switches templates correctly.
+
+- **Coverage threshold**: **80%** on `app/` (enforced via `pytest-cov`). New code added without tests is a quality blocker.
+
+- **Critical quality concerns**:
+  - **WCAG conformance** is a defining product requirement, not a checkbox. An axe-core failure on the reading surface is a **blocking** finding.
+  - **Per-user privacy**: passages may include sacred text and personal uploads. Any test that touches cross-user reads or writes is verifying a security boundary, not just behavior.
+  - **LLM cost containment**: tests for the question generator must verify the cache-first path. A regression that bypasses the cache could silently 10x monthly Anthropic spend.
+  - **Performance NFR**: <100 ms perceived latency for view changes. Flag any test that is slow to set up — the production hot path likely is too.
+  - **PDF ingestion fragility** (Risk #3 in PRD): test against representative documents, not just synthetic fixtures. A PDF that produces empty text must surface a clear, accessible error to the user.
+  - **Comprehension-question quality on poetic text** (Risk #2): integration tests against a small curated set of Baha'i passages, run manually before each release. LLM-as-judge is not sufficient for sacred text — human review is required for the question-quality gate.
 
 ## Quality Standards
 

--- a/.claude/agents/system-architect.md
+++ b/.claude/agents/system-architect.md
@@ -433,28 +433,105 @@ Use the **ATAM (Architecture Tradeoff Analysis Method)**:
 
 ## Project-Specific Domain Analysis
 
-<!--
-TEMPLATE: Fill in project-specific domain analysis here when using this template.
+**Source documents:** [docs/PRODUCT-REQUIREMENTS.md](../../docs/PRODUCT-REQUIREMENTS.md), [docs/PRODUCT-ROADMAP.md](../../docs/PRODUCT-ROADMAP.md), [docs/TECHNICAL-ARCHITECTURE.md](../../docs/TECHNICAL-ARCHITECTURE.md), [.claude/PROJECT.md](../PROJECT.md).
 
-Example structure:
+The project is a **modular monolith**, not a microservices system. Bounded contexts below are conceptual seams within one FastAPI process — they shape module boundaries (`app/services/<context>/`) and review heuristics, not deployment units.
+
 ### Bounded Contexts
 
-#### 1. [Context Name]
+#### 1. Identity
 **Aggregates:**
-- `Entity` (root) → `ChildEntity1`, `ChildEntity2`
+- `User` (root) → `MagicLinkToken`, `Session`
 
 **Value Objects:**
-- `ValueObject1`, `ValueObject2`
+- `Email` (citext-stored, normalized lowercase), `MagicToken` (32-byte URL-safe; stored as SHA-256 hash; 15-min TTL; single-use), `SessionCookie` (signed via `itsdangerous`; `HttpOnly`, `Secure`, `SameSite=Lax`; 30-day rolling)
 
 **Domain Events:**
-- `Event1`, `Event2`
+- `MagicLinkRequested` (triggers Resend send), `MagicLinkConsumed` (invalidates outstanding tokens; mints session), `SessionEstablished`
 
 **Ubiquitous Language:**
-- Term1, Term2, Term3
+- *Account*, *Magic link*, *Session*. Never *password*, *signup* (we say *first sign-in*), or *bot user*.
+
+#### 2. Reading Surface
+**Aggregates:**
+- `Preference` (root, one per user) — keyed JSONB store of reading-support choices
+- `Passage` (root) → text content, source metadata, text hash
+
+**Value Objects:**
+- `ReadingMode` (font, size, line-height, contrast, max-width, bionic-on/off), `PassageHash` (SHA-256 of text content; cache key)
+
+**Domain Events:**
+- `PreferenceUpdated` (single-key swap; triggers `<style>` fragment swap), `PassageOpened`, `PassageClosed` (emits `ReadingEvent` for the metric)
+
+**Ubiquitous Language:**
+- *Reading surface* (the rendered page), *Reading-support mode* (a configurable transformation), *Bionic emphasis* (server-side first-N-chars-bold transform). Never *theme* (too generic), *style preset* (we don't ship presets — every choice is per-user).
+
+#### 3. Comprehension
+**Aggregates:**
+- `ComprehensionQuestionCache` (root, keyed by passage hash + question_type + model_id + prompt_version)
+
+**Value Objects:**
+- `QuestionType` (e.g. `recall`, `summary`, `inference`), `PromptVersion` (integer; bump invalidates cache)
+
+**Domain Events:**
+- `QuestionsRequested` (cache lookup), `QuestionsGenerated` (LLM call completed; cache populated)
+
+**Ubiquitous Language:**
+- *Comprehension check*, *Question type*. Never *quiz* (implies grading) or *test* (clinical connotation).
+
+**External dependency:** Anthropic Claude API (model `claude-haiku-4-5`). All access goes through `app/services/comprehension/generator.py`, which enforces (a) cache-first lookup, (b) input cap of 4,000 tokens, (c) prompt caching on the system message. Direct `anthropic.Anthropic()` calls outside this module are an architecture violation.
+
+#### 4. Ingestion
+**Aggregates:**
+- (Stateless) — accepts raw input, produces a `Passage` in the Reading Surface context
+
+**Value Objects:**
+- `RawPaste` (text), `UploadedPdf` (≤25 MB, `application/pdf`)
+
+**Domain Events:**
+- `PassageIngested` (success), `IngestionFailed` (surfaces error to user per Risk #3)
+
+**Ubiquitous Language:**
+- *Ingest*, *Parse* (PDF → text). Never *import* (implies bulk) or *upload* alone (ambiguous: is the file the goal or the text?).
+
+**Implementation constraint:** PDF parsing uses `pdfplumber` only. PyMuPDF is forbidden by ADR-003 (AGPL conflict with BSL release path).
 
 ### Context Mapping
-[Diagram showing how contexts relate to each other]
--->
+
+```
+   Identity ──── (provides current_user) ────┐
+                                              │
+                                              ▼
+   Ingestion ────(produces Passage)────► Reading Surface ◄────(consumes Passage)──── Comprehension
+                                              │                          │
+                                              │ emits ReadingEvent       │ calls Anthropic API
+                                              ▼                          ▼
+                                      [reading_event tbl]         [Anthropic Claude Haiku 4.5]
+                                              │                          │
+                                              ▼                          │
+                                       100k-line metric                  │
+                                                                         ▼
+                                                         [comprehension_question_cache tbl]
+```
+
+All four contexts share one Postgres database (Neon) and one Cloud Run process. The seams are enforced at the module level (`app/services/identity/`, `app/services/reading/`, `app/services/comprehension/`, `app/services/ingestion/`) and at the route level (one router per context under `app/api/`). Cross-context calls are direct function calls, not HTTP — but they should pass identifiers, not entities, so a future split would only require swapping the import for an HTTP client.
+
+### Architecture patterns in use
+
+- **Server-rendered HTML + HTMX fragment swaps** (ADR-005). No SPA. Same handler returns a full Jinja page or a fragment based on `HX-Request: true`.
+- **Cache-aside with content-addressable keys** for LLM responses. Postgres-backed; no Redis in MVP.
+- **Passwordless auth via signed, single-use tokens** (ADR-002). Hand-rolled (~50 LOC) rather than dragging in a heavy auth framework.
+- **Per-PR ephemeral environments** with Neon branching. The `preview-deploy.yml` workflow creates a Neon branch per PR; `preview-cleanup.yml` deletes it on close.
+
+### Key technical decisions
+
+See ADRs in [docs/TECHNICAL-ARCHITECTURE.md §Architecture Decision Records](../../docs/TECHNICAL-ARCHITECTURE.md):
+
+- ADR-001: Anthropic Claude Haiku for comprehension questions (with prompt + Postgres caching)
+- ADR-002: Passwordless magic-link authentication
+- ADR-003: pdfplumber over PyMuPDF (license cleanliness)
+- ADR-004: Cloud Logging + Error Reporting (defer Sentry to Phase 2)
+- ADR-005: HTMX + server rendering, no SPA
 
 ## Communication Style
 


### PR DESCRIPTION
## Summary

- Phase 3 of bootstrap. Replaces six `TEMPLATE` blocks across four agent files with concrete Cubrox context drawn from the PRD and the [TECHNICAL-ARCHITECTURE](docs/TECHNICAL-ARCHITECTURE.md) doc.
- After merge, `grep -r "TEMPLATE:" .claude/agents/` returns nothing.

### Per-agent changes

- **[github-ticket-worker](.claude/agents/github-ticket-worker.md)** — stack, lint/format/type/test commands, coverage threshold, pre-push contract, and stack-specific pitfalls (PyMuPDF ban per ADR-003, LLM cost containment, HTMX fragment contract, no hardcoded URLs).
- **[pr-reviewer](.claude/agents/pr-reviewer.md)** — stack-compliance blocking criteria, code organization, migration discipline, reading-surface accessibility checks, security and performance review heuristics.
- **[quality-engineer](.claude/agents/quality-engineer.md)** — testing stack (pytest / TestClient + in-memory SQLite / Playwright + axe), seven key MVP test areas, 80% coverage threshold, project-specific quality concerns (WCAG, privacy, LLM cost, perf, PDF fragility, question quality on poetic text).
- **[system-architect](.claude/agents/system-architect.md)** — four bounded contexts (Identity, Reading Surface, Comprehension, Ingestion) with aggregates / value objects / events / ubiquitous language, a context-mapping diagram, the pattern catalogue, and ADR cross-references.

The other three agents (`agile-product-manager`, `agile-backlog-prioritizer`, `devops-engineer`) read PRD / roadmap / `.claude/PROJECT.md` directly and need no template filling.

## Stacking note

This PR is **based on `feature/bootstrap-architecture`** (PR #1), not `main`. PR #1 must merge first. Once it does, GitHub will rebase this PR's base to `main` automatically.

## Out of scope

- Agent runtime behavior is unchanged — these are purely documentation edits to the agent context blocks.
- No code, no dependencies, no CI changes.

## Test plan

- [ ] CI lint + format pass (markdown only)
- [ ] CI test suite green (no code touched)
- [ ] `grep -r "TEMPLATE:" .claude/agents/` returns no results
- [ ] Each updated agent's project-specific block references the architecture doc and the PRD
- [ ] No `TEMPLATE:` placeholders remain anywhere in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)