### PR TITLE
docs(workflow): finalize CLAUDE.md with project board URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,16 +158,12 @@ Every agent output MUST follow these patterns. Full spec: `docs/AGENT-OUTPUT-STA
 
 ## Project-Specific Configuration
 
-<!--
-TEMPLATE: Fill in project-specific details below when using this template.
--->
-
 ### Project Information
 
 - **License**: BSL 1.1 (converts to Apache 2.0 after 3 years per release)
 - **Project Name**: Cubrox
 - **Repository**: https://github.com/vibeacademy/cubrox
-- **Project Board**: TBD (created in Phase 4 — `/bootstrap-workflow`)
+- **Project Board**: https://github.com/users/cubrox/projects/1
 - **Tech Stack**: FastAPI + Jinja2 + HTMX on Python 3.12
 - **Database layer**: SQLModel + Alembic
 - **Platform**: Google Cloud Platform (Cloud Run)


### PR DESCRIPTION
## Summary

Phase 4 cleanup. Replaces the TBD project-board placeholder with the live URL ([github.com/users/cubrox/projects/1](https://github.com/users/cubrox/projects/1)) and removes the stale TEMPLATE comment above the Project Information block.

## Context — what /bootstrap-workflow did beyond this commit

- Branch protection enabled on `main` (1-review requirement, conversation resolution, no force-push, no deletions)
- 10 labels created (P0/P1/P2 + epic + 6 area/* labels)
- 6 epics + 18 child tickets (#3-#26) created with full Power Sections per [docs/TICKET-FORMAT.md](docs/TICKET-FORMAT.md)
- All 24 items added to the project board with Priority + Size populated
- 4 dependency-free starters in Ready: #9 AUTH-1, #18 COMP-1, #21 METRIC-1, #24 A11Y-1

## Manual follow-ups (UI-only, not in this PR)

- [ ] Project ⋯ → Workflows → "Item closed → Status: Done" → Enable
- [ ] After A11Y-3 (#26) ships: require the new `a11y` check in branch protection

## Test plan

- [ ] CI lint passes (markdown only)
- [ ] CI test suite passes (no code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)