### PR TITLE
feat(ingestion): paste-text route + Passage persistence (#13)

### DIFF
--- a/alembic/versions/004_add_passage_table.py
+++ b/alembic/versions/004_add_passage_table.py
@@ -1,0 +1,81 @@
+"""add passage table
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-05-08
+
+Stores user-submitted passages. Two ingestion paths per Epic #4:
+paste-text (INGEST-1, this PR) and PDF upload (INGEST-2 #14). Both
+land here with `source_type` distinguishing them. `text_hash` is the
+content-addressable key the comprehension cache (#18) uses to find
+LLM-generated questions for the same text across users.
+
+UUID handling mirrors revision 003: native on Postgres, CHAR(36) on
+SQLite for the in-memory test database. `source_type` carries a CHECK
+constraint that both dialects accept.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "004"
+down_revision: str | None = "003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_pg = bind.dialect.name == "postgresql"
+    uuid_type: sa.types.TypeEngine = sa.Uuid() if is_pg else sa.String(length=36)
+
+    op.create_table(
+        "passage",
+        sa.Column(
+            "id",
+            uuid_type,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()") if is_pg else None,
+        ),
+        sa.Column(
+            "user_id",
+            uuid_type,
+            sa.ForeignKey("user.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column("text_hash", sa.LargeBinary(), nullable=False),
+        sa.Column("source_type", sa.Text(), nullable=False),
+        sa.Column("source_filename", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "source_type IN ('paste', 'pdf')",
+            name="passage_source_type_check",
+        ),
+    )
+
+    # The reading-history view will list passages newest-first per user.
+    # A composite (user_id, created_at DESC) index serves that query
+    # without a separate sort step.
+    op.create_index(
+        "ix_passage_user_id_created_at",
+        "passage",
+        ["user_id", sa.text("created_at DESC")],
+    )
+    # text_hash is the cache lookup key; index it for the cross-user
+    # "have we seen this passage before" path.
+    op.create_index("ix_passage_text_hash", "passage", ["text_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_passage_text_hash", table_name="passage")
+    op.drop_index("ix_passage_user_id_created_at", table_name="passage")
+    op.drop_table("passage")

--- a/app/api/passages.py
+++ b/app/api/passages.py
@@ -1,0 +1,86 @@
+"""Passage ingestion routes.
+
+Two endpoints for the paste-text path:
+  GET  /passages/new — render the paste form (auth-required)
+  POST /passages     — persist the pasted text, redirect to /read/{id}
+
+Both require an authenticated user; unauthenticated requests get the
+standard /login redirect via the `current_user` dependency. Per ADR
+guardrails, this route writes the text byte-for-byte (no normalization)
+so the SHA-256 hash matches what the comprehension cache will look up.
+
+PDF ingestion is a separate route in INGEST-2 (#14); it lives here too
+when shipped.
+"""
+
+import hashlib
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlmodel import Session
+
+from app.db import get_session
+from app.models.passage import Passage
+from app.models.user import User
+from app.services.identity.session import current_user
+from app.templates import templates
+
+router = APIRouter()
+
+SessionDep = Annotated[Session, Depends(get_session)]
+CurrentUser = Annotated[User, Depends(current_user)]
+
+# Hard ceiling on a single passage. ~100k chars is around 4k lines of
+# regular prose — enough for a chapter-length excerpt, far enough below
+# Cloud Run's 32 MB request body limit to stay safe.
+MAX_TEXT_LEN = 100_000
+
+
+@router.get("/passages/new", response_class=HTMLResponse)
+def new_passage_form(request: Request, user: CurrentUser) -> HTMLResponse:
+    """Render the paste-text form."""
+    return templates.TemplateResponse(
+        request=request,
+        name="pages/passages_new.html",
+        context={"user": user},
+    )
+
+
+@router.post("/passages")
+def create_passage(
+    user: CurrentUser,
+    session: SessionDep,
+    text: Annotated[str, Form()],
+) -> RedirectResponse:
+    """Persist the pasted text and redirect to the reading view.
+
+    Validation rules (per ticket guardrails):
+      - 1 <= len(text) <= MAX_TEXT_LEN
+      - text_hash = SHA-256 of the EXACT submitted bytes (no strip,
+        no lowercase) so cross-user cache hits work
+      - source_type='paste', source_filename=None
+    """
+    if len(text) == 0:
+        raise HTTPException(status_code=422, detail="Text is required")
+    if len(text) > MAX_TEXT_LEN:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Passage exceeds {MAX_TEXT_LEN:,}-character limit",
+        )
+
+    text_hash = hashlib.sha256(text.encode("utf-8")).digest()
+    passage = Passage(
+        user_id=user.id,
+        text=text,
+        text_hash=text_hash,
+        source_type="paste",
+        source_filename=None,
+    )
+    session.add(passage)
+    session.commit()
+    session.refresh(passage)
+
+    # /read/{id} ships in READ-1 (#15). Until then this redirect lands
+    # on a 404 — the URL shape is what matters for downstream wiring.
+    return RedirectResponse(url=f"/read/{passage.id}", status_code=303)

--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 
-from app.api import auth, health, todos
+from app.api import auth, health, passages, todos
 from app.services.identity.session import UnauthenticatedError
 
 app = FastAPI(title="Agile Flow GCP")
@@ -42,3 +42,4 @@ app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 app.include_router(health.router)
 app.include_router(todos.router)
 app.include_router(auth.router)
+app.include_router(passages.router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,7 +2,8 @@
 
 from app.models.comprehension_question_cache import ComprehensionQuestionCache
 from app.models.magic_link_token import MagicLinkToken
+from app.models.passage import Passage
 from app.models.todo import Todo
 from app.models.user import User
 
-__all__ = ["ComprehensionQuestionCache", "MagicLinkToken", "Todo", "User"]
+__all__ = ["ComprehensionQuestionCache", "MagicLinkToken", "Passage", "Todo", "User"]

--- a/app/models/passage.py
+++ b/app/models/passage.py
@@ -1,0 +1,29 @@
+"""Passage model.
+
+A piece of text the user is reading. Originates from paste (INGEST-1)
+or PDF upload (INGEST-2 #14). The `text_hash` column is the
+content-addressable key into `comprehension_question_cache` (per
+ADR-001 in docs/TECHNICAL-ARCHITECTURE.md), so the SAME passage pasted
+by two different users hits the same cached questions.
+
+`source_type` is constrained to `'paste' | 'pdf'`. `source_filename` is
+populated only for PDF uploads (kept for display, never re-read from
+disk — the parsed text is the source of truth post-ingestion).
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlmodel import Field, SQLModel
+
+
+class Passage(SQLModel, table=True):
+    __tablename__ = "passage"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    user_id: uuid.UUID = Field(foreign_key="user.id", nullable=False)
+    text: str
+    text_hash: bytes
+    source_type: str
+    source_filename: str | None = Field(default=None)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/templates/pages/passages_new.html
+++ b/templates/pages/passages_new.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block title %}Paste a passage — Cubrox{% endblock %}
+
+{% block content %}
+  <hgroup>
+    <h1>Paste a passage</h1>
+    <p>Paste or type the text you want to read. Your reading preferences will
+       be applied when it renders.</p>
+  </hgroup>
+
+  <form action="/passages" method="post">
+    <label for="text">
+      Text
+      <textarea
+        id="text"
+        name="text"
+        rows="14"
+        required
+        autofocus
+        placeholder="Paste or type your passage here..."
+        aria-describedby="text-help"></textarea>
+      <small id="text-help">Up to 100,000 characters (~4,000 lines).</small>
+    </label>
+
+    <button type="submit">Save and read</button>
+  </form>
+{% endblock %}

--- a/tests/test_passage_migration.py
+++ b/tests/test_passage_migration.py
@@ -1,0 +1,82 @@
+"""Migration cycle test for the passage table (revision 004).
+
+Mirrors test_user_migration.py and test_comprehension_cache_migration.py:
+verifies the migration applies cleanly on a fresh DB, can be downgraded,
+and can be reapplied — catching a broken downgrade() before production.
+"""
+
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+
+from alembic import command
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def alembic_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Config:
+    db_path = tmp_path / "passage_migration_test.db"
+    db_url = f"sqlite:///{db_path}"
+
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+
+    cfg = Config(str(REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(REPO_ROOT / "alembic"))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    return cfg
+
+
+def test_upgrade_creates_passage_table_with_columns_and_fk(alembic_cfg: Config) -> None:
+    command.upgrade(alembic_cfg, "004")
+
+    db_url = alembic_cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+    engine = create_engine(db_url)
+    inspector = inspect(engine)
+
+    assert "passage" in inspector.get_table_names()
+
+    cols = {c["name"] for c in inspector.get_columns("passage")}
+    assert cols == {
+        "id",
+        "user_id",
+        "text",
+        "text_hash",
+        "source_type",
+        "source_filename",
+        "created_at",
+    }
+
+    fks = inspector.get_foreign_keys("passage")
+    assert any(fk["referred_table"] == "user" and fk["referred_columns"] == ["id"] for fk in fks)
+
+    indexes = {ix["name"] for ix in inspector.get_indexes("passage")}
+    assert "ix_passage_text_hash" in indexes
+    assert "ix_passage_user_id_created_at" in indexes
+
+
+def test_upgrade_downgrade_upgrade_cycle(alembic_cfg: Config) -> None:
+    command.upgrade(alembic_cfg, "004")
+    command.downgrade(alembic_cfg, "003")
+
+    db_url = alembic_cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+    engine = create_engine(db_url)
+    inspector = inspect(engine)
+
+    table_names = inspector.get_table_names()
+    assert "passage" not in table_names
+    # Earlier migrations untouched.
+    assert "user" in table_names
+    assert "magic_link_token" in table_names
+    assert "comprehension_question_cache" in table_names
+
+    command.upgrade(alembic_cfg, "004")
+    inspector = inspect(engine)
+    assert "passage" in inspector.get_table_names()

--- a/tests/test_passages_paste.py
+++ b/tests/test_passages_paste.py
@@ -1,0 +1,195 @@
+"""Tests for the paste-text ingestion flow.
+
+Covers the Definition of Done from issue #13 (INGEST-1):
+  - POST /passages with valid text → 303 to /read/<uuid>
+  - Passage row has correct user_id, text, source_type='paste'
+  - source_filename is NULL
+  - text_hash exactly matches sha256(text.encode('utf-8'))
+  - Empty text → 422
+  - Text > 100,000 chars → 422
+  - Unauthenticated POST → 303 to /login
+  - Same text from two different users → two distinct rows
+  - GET /passages/new renders a form posting to /passages
+  - Unauthenticated GET → 303 to /login
+"""
+
+import hashlib
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.models.passage import Passage
+from app.models.user import User
+from app.services.identity.session import SESSION_COOKIE_NAME, sign_session
+
+TEST_SECRET = "dev-only"
+
+
+def _signed_in(client: TestClient, session: Session, email: str = "reader@example.com") -> User:
+    """Seed a User and set a valid session cookie on the client."""
+    user = User(email=email)
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    client.cookies.set(SESSION_COOKIE_NAME, sign_session(user_id=user.id, secret=TEST_SECRET))
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_post_passage_redirects_to_read_route(client: TestClient, session: Session) -> None:
+    _signed_in(client, session)
+    response = client.post("/passages", data={"text": "Hello, world."}, follow_redirects=False)
+    assert response.status_code == 303
+
+    location = response.headers["location"]
+    assert location.startswith("/read/")
+
+    # Tail of the URL must be a parseable UUID.
+    passage_id_str = location.split("/")[-1]
+    uuid.UUID(passage_id_str)  # raises if invalid
+
+
+def test_passage_row_has_correct_fields(client: TestClient, session: Session) -> None:
+    user = _signed_in(client, session)
+    text = "O Son of Spirit! My first counsel is this..."
+
+    client.post("/passages", data={"text": text}, follow_redirects=False)
+
+    passages = session.exec(select(Passage)).all()
+    assert len(passages) == 1
+    p = passages[0]
+    assert p.user_id == user.id
+    assert p.text == text
+    assert p.source_type == "paste"
+    assert p.source_filename is None
+
+
+def test_text_hash_matches_sha256_of_submitted_bytes(client: TestClient, session: Session) -> None:
+    """The hash must be derived from the EXACT submitted bytes — no
+    strip, no lowercase. This is the property that makes cross-user
+    cache hits work."""
+    _signed_in(client, session)
+    text = "  the quick brown fox\nJUMPED over the lazy dog  "
+
+    client.post("/passages", data={"text": text}, follow_redirects=False)
+
+    passages = session.exec(select(Passage)).all()
+    expected = hashlib.sha256(text.encode("utf-8")).digest()
+    assert passages[0].text_hash == expected
+
+
+def test_text_hash_is_thirty_two_bytes(client: TestClient, session: Session) -> None:
+    _signed_in(client, session)
+    client.post("/passages", data={"text": "x"}, follow_redirects=False)
+    passages = session.exec(select(Passage)).all()
+    assert len(passages[0].text_hash) == 32  # SHA-256 is exactly 32 bytes
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_empty_text_returns_422(client: TestClient, session: Session) -> None:
+    _signed_in(client, session)
+    response = client.post("/passages", data={"text": ""}, follow_redirects=False)
+    assert response.status_code == 422
+
+
+def test_text_at_limit_succeeds(client: TestClient, session: Session) -> None:
+    """The boundary case: exactly 100,000 chars must still succeed."""
+    _signed_in(client, session)
+    text = "a" * 100_000
+    response = client.post("/passages", data={"text": text}, follow_redirects=False)
+    assert response.status_code == 303
+
+
+def test_text_over_limit_returns_422(client: TestClient, session: Session) -> None:
+    _signed_in(client, session)
+    text = "a" * 100_001
+    response = client.post("/passages", data={"text": text}, follow_redirects=False)
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def test_unauthenticated_post_redirects_to_login(client: TestClient) -> None:
+    response = client.post("/passages", data={"text": "anything"}, follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login"
+
+
+def test_unauthenticated_get_form_redirects_to_login(client: TestClient) -> None:
+    response = client.get("/passages/new", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login"
+
+
+# ---------------------------------------------------------------------------
+# Cross-user isolation
+# ---------------------------------------------------------------------------
+
+
+def test_same_text_from_two_users_creates_two_distinct_rows(
+    client: TestClient, session: Session
+) -> None:
+    """Different users pasting the same text get separate Passage rows
+    (no cross-user dedup at the row level — only the comprehension cache
+    is shared, via text_hash)."""
+    user_a = User(email="a@example.com")
+    user_b = User(email="b@example.com")
+    session.add(user_a)
+    session.add(user_b)
+    session.commit()
+    session.refresh(user_a)
+    session.refresh(user_b)
+
+    same_text = "The same passage, pasted by two different readers."
+
+    client.cookies.set(SESSION_COOKIE_NAME, sign_session(user_id=user_a.id, secret=TEST_SECRET))
+    client.post("/passages", data={"text": same_text}, follow_redirects=False)
+
+    client.cookies.set(SESSION_COOKIE_NAME, sign_session(user_id=user_b.id, secret=TEST_SECRET))
+    client.post("/passages", data={"text": same_text}, follow_redirects=False)
+
+    passages = session.exec(select(Passage)).all()
+    assert len(passages) == 2
+    assert {p.user_id for p in passages} == {user_a.id, user_b.id}
+    # Both rows share the same text_hash (the cache lookup key).
+    assert passages[0].text_hash == passages[1].text_hash
+
+
+# ---------------------------------------------------------------------------
+# Form rendering
+# ---------------------------------------------------------------------------
+
+
+def test_get_passages_new_renders_form(client: TestClient, session: Session) -> None:
+    _signed_in(client, session)
+    response = client.get("/passages/new")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "<form" in response.text
+    assert "<textarea" in response.text
+    assert 'action="/passages"' in response.text
+    assert 'method="post"' in response.text
+
+
+def test_get_passages_new_form_includes_required_attribute(
+    client: TestClient, session: Session
+) -> None:
+    """Browsers should refuse to submit an empty textarea client-side
+    too — server validation is the gate, but the HTML attribute is the
+    UX courtesy."""
+    _signed_in(client, session)
+    response = client.get("/passages/new")
+    assert "required" in response.text


### PR DESCRIPTION
## Ticket

Closes #13 — INGEST-1: Paste-text route + Passage persistence.

## Summary

The first user-visible feature in Cubrox. With AUTH-1/2/3 merged and an authenticated session in hand, a user can now paste a passage and have it persisted to a new `passage` table. The flow ends with a 303 redirect to `/read/{passage.id}` — that reading-view route ships in READ-1 (#15), so the redirect target 404s in this PR's preview, but the URL shape is right for downstream wiring.

## Changes Made

- **CREATE** [app/models/passage.py](app/models/passage.py) — `Passage` SQLModel: UUID PK, FK CASCADE to user.id, text + sha256 hash, source_type/filename, created_at.
- **CREATE** [alembic/versions/004_add_passage_table.py](alembic/versions/004_add_passage_table.py) — dialect-aware migration with `source_type IN ('paste', 'pdf')` CHECK constraint, composite index on `(user_id, created_at DESC)` for the future history view, and a separate `text_hash` index for cross-user cache lookups.
- **CREATE** [app/api/passages.py](app/api/passages.py) — `GET /passages/new` (paste form) and `POST /passages` (persist + redirect). Both auth-required via `Depends(current_user)`. Length validation: `1 ≤ len(text) ≤ 100,000`.
- **CREATE** [templates/pages/passages_new.html](templates/pages/passages_new.html) — minimal Pico.css form: textarea + submit. `aria-describedby` on the help text.
- **MODIFY** [app/models/\_\_init\_\_.py](app/models/__init__.py) — export `Passage`.
- **MODIFY** [app/main.py](app/main.py) — register the passages router.
- **CREATE** [tests/test_passages_paste.py](tests/test_passages_paste.py) — 12 tests covering each DoD assertion.
- **CREATE** [tests/test_passage_migration.py](tests/test_passage_migration.py) — 2 migration cycle tests (mirroring the COMP-1 and AUTH-1 patterns).

## Design notes

- **Hash on the exact submitted bytes.** No `.strip()`, no `.lower()`, no normalization. This pins the property that makes the comprehension cache hit across users — two readers who paste identical text get the same hash, so the second reader gets the LLM-generated questions for free.
- **`source_type` CHECK constraint at the DB layer.** Both Postgres and SQLite accept inline `CHECK` in `create_table`. Forces every Passage row through the same `{'paste', 'pdf'}` set; INGEST-2 (#14, PDF upload) will use the same table.
- **Composite `(user_id, created_at DESC)` index** — designed for the future "my reading history" view. The DESC ordering is in the index itself, so no separate sort step at query time. Postgres uses it natively; SQLite stores the ordering hint as part of the index too.
- **The redirect target `/read/{id}` doesn't exist yet.** This is intentional per the ticket's happy path. READ-1 (#15) is the next ticket; until then, manual reviewers see a 404 after pasting. Test asserts the redirect URL shape, not the destination's content.
- **No `.strip()` from the front-end side either.** The textarea preserves user-entered whitespace verbatim. If they pasted leading/trailing whitespace, that's the passage they wanted; we don't second-guess them.

## Out of scope (future tickets)

- The `/read/{id}` reading-view route. **READ-1 (#15)**
- PDF upload at `POST /passages/pdf`. **INGEST-2 (#14)** — same table, different ingestion path.
- A "my passages" / history view at `GET /passages`. Future ticket; we have the index ready for it.
- Rate limiting on `/passages` POST. Could come from AUTH-4's pattern; not in DoD here.

## Testing

### Automated tests

- [x] 14 new tests pass locally (12 paste-flow + 2 migration cycle)
- [x] Full suite still green (88 / 88)
- [x] Coverage 98.2% overall; new modules 100%
- [x] `uv run ruff check .` clean
- [x] `uv run mypy app/` clean
- [x] Pre-push hook passed

### Manual verification (per ticket DoD)

```bash
# Reviewer: with SESSION_SECRET, RESEND_API_KEY, DATABASE_URL set
uv run uvicorn app.main:app --reload --port 8080 &
# 1. Sign in (AUTH-1 + AUTH-2 from prior PRs)
# 2. Visit http://localhost:8080/passages/new in a browser
# 3. Paste a Baha'i passage, click "Save and read"
# 4. Observe redirect to /read/<uuid> (404 expected for now until READ-1 ships)
# 5. Confirm a Passage row in psql with the right user_id + source_type='paste'
```

## Checklist

- [x] All tests pass (88/88, 98.2% coverage)
- [x] Code follows project conventions ([CLAUDE.md](CLAUDE.md))
- [x] No lint/type errors
- [x] PR closes the linked issue
- [ ] Reviewer GO/NO-GO recommendation
- [ ] Human merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)