### PR TITLE
feat(comprehension): Anthropic SDK wrapper + generator (#19)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -27,6 +27,13 @@ class Settings(BaseSettings):
     magic_link_base_url: str = "http://localhost:8080"
     magic_link_from_email: str = "onboarding@resend.dev"
 
+    # Anthropic LLM (ADR-001). Used by app/services/comprehension/generator.py
+    # to generate reading-comprehension questions. The route layer that
+    # consumes this builds the client lazily so missing config doesn't
+    # fail the app boot — just the /questions feature degrades.
+    anthropic_api_key: str = ""
+    anthropic_model: str = "claude-haiku-4-5"
+
     # Session cookie signing (AUTH-2). 32+ random bytes, set per environment
     # via Secret Manager. The dev default is the literal string "dev-only"
     # so tests can run with no env setup; the validator below refuses this

--- a/app/services/comprehension/generator.py
+++ b/app/services/comprehension/generator.py
@@ -1,0 +1,207 @@
+"""Anthropic-backed comprehension-question generator with caching.
+
+Per ADR-001 in docs/TECHNICAL-ARCHITECTURE.md, this is the ONLY place
+that should call the Anthropic API directly. Every other module goes
+through `generate_questions()`. That gives one place to enforce:
+  - cache-first lookup (so re-reads cost zero LLM calls)
+  - input-token cap (so a huge passage can't accidentally cost much)
+  - prompt caching (so the system prompt is reused across requests)
+  - structured-output validation (so a malformed LLM response can't
+    poison the cache)
+  - no-PII-in-logs (passage text is hashed, never logged verbatim)
+
+The wrapper takes an `anthropic.Anthropic` client as an argument so
+tests can inject a MagicMock. The real client is built by the caller
+(route layer in COMP-3) from `settings.anthropic_api_key`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import TYPE_CHECKING, Annotated, Any, Literal
+
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
+from sqlmodel import Session
+
+from app.services.comprehension import cache
+from app.services.comprehension.prompts import PROMPT_VERSION, SYSTEM_PROMPT
+
+if TYPE_CHECKING:
+    import anthropic
+
+logger = logging.getLogger(__name__)
+
+# Max chars sent to the LLM. ~4 chars per token is a conservative estimate
+# for Claude on English text, so 16_000 chars ≈ 4_000 input tokens. The
+# passage-ingestion route already caps at 100_000 chars per the INGEST-1
+# guardrails, so passages between these two limits are the over-budget
+# ones we reject here.
+MAX_INPUT_CHARS = 16_000
+
+DEFAULT_MAX_TOKENS = 1024
+
+
+class PassageTooLongError(Exception):
+    """The passage exceeds the LLM input-cap. Caller surfaces a UX hint.
+
+    Distinct from GeneratorError because this is a recoverable, user-
+    actionable condition (split the passage), not a system failure.
+    """
+
+    def __init__(self, char_count: int, max_chars: int = MAX_INPUT_CHARS) -> None:
+        super().__init__(
+            f"Passage is {char_count:,} chars; max for comprehension questions "
+            f"is {max_chars:,}. Try splitting it."
+        )
+        self.char_count = char_count
+        self.max_chars = max_chars
+
+
+class GeneratorError(Exception):
+    """The LLM response was malformed (not JSON, wrong schema, etc.).
+
+    Should be rare. The route layer surfaces a generic 'temporarily
+    unavailable' message to the user and logs the raw response.
+    """
+
+
+class _Question(BaseModel):
+    """Pydantic shape for a single LLM-generated question.
+
+    The Literal on `type` is the structural enforcement of the prompt's
+    'recall' or 'summary' allow-list. If the LLM emits any other type,
+    Pydantic raises ValidationError and we surface GeneratorError.
+    """
+
+    type: Annotated[Literal["recall", "summary"], Field()]
+    text: Annotated[str, Field(min_length=1, max_length=500)]
+
+
+_QUESTIONS_ADAPTER: TypeAdapter[list[_Question]] = TypeAdapter(list[_Question])
+
+
+def generate_questions(
+    *,
+    passage_text: str,
+    question_type: str,
+    client: anthropic.Anthropic,
+    model_id: str,
+    session: Session,
+) -> list[dict[str, Any]]:
+    """Return cached or freshly-generated comprehension questions.
+
+    Order of operations (the cost-containment contract):
+      1. SHA-256 the passage text.
+      2. Look up the cache. On hit, return immediately. No LLM call.
+      3. On miss, length-check. Over MAX_INPUT_CHARS → PassageTooLongError.
+      4. Call Anthropic with the system prompt under cache_control
+         ephemeral. Parse + validate the JSON response.
+      5. Persist to cache. Return.
+
+    Tests pass a MagicMock for `client` and a regular Session. Real
+    callers (route in COMP-3) build both from config.
+    """
+    text_hash = hashlib.sha256(passage_text.encode("utf-8")).digest()
+
+    cached = cache.get_cached(
+        passage_hash=text_hash,
+        question_type=question_type,
+        model_id=model_id,
+        prompt_version=PROMPT_VERSION,
+        session=session,
+    )
+    if cached is not None:
+        logger.info(
+            "comprehension cache hit",
+            extra={
+                "text_hash": text_hash.hex(),
+                "question_type": question_type,
+                "model_id": model_id,
+                "prompt_version": PROMPT_VERSION,
+            },
+        )
+        return cached
+
+    if len(passage_text) > MAX_INPUT_CHARS:
+        logger.info(
+            "comprehension passage too long",
+            extra={
+                "text_hash": text_hash.hex(),
+                "char_count": len(passage_text),
+                "max_chars": MAX_INPUT_CHARS,
+            },
+        )
+        raise PassageTooLongError(char_count=len(passage_text))
+
+    logger.info(
+        "comprehension cache miss → calling Anthropic",
+        extra={
+            "text_hash": text_hash.hex(),
+            "question_type": question_type,
+            "model_id": model_id,
+            "prompt_version": PROMPT_VERSION,
+            "char_count": len(passage_text),
+        },
+    )
+
+    response = client.messages.create(
+        model=model_id,
+        max_tokens=DEFAULT_MAX_TOKENS,
+        system=[
+            {
+                "type": "text",
+                "text": SYSTEM_PROMPT,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        messages=[{"role": "user", "content": passage_text}],
+    )
+
+    questions = _parse_response(response, text_hash=text_hash)
+
+    cache.put_cache(
+        passage_hash=text_hash,
+        question_type=question_type,
+        model_id=model_id,
+        prompt_version=PROMPT_VERSION,
+        questions=questions,
+        session=session,
+    )
+    session.commit()
+
+    return questions
+
+
+def _parse_response(response: Any, *, text_hash: bytes) -> list[dict[str, Any]]:
+    """Extract + validate the JSON array from the LLM response.
+
+    Raises GeneratorError with the (hashed-referenced) raw response on
+    any parse / schema failure. Never logs the response body verbatim
+    because the LLM might echo passage content back.
+    """
+    try:
+        raw_text = response.content[0].text
+    except (AttributeError, IndexError) as exc:
+        raise GeneratorError("Anthropic response had no text content block") from exc
+
+    try:
+        parsed = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "comprehension response was not valid JSON",
+            extra={"text_hash": text_hash.hex()},
+        )
+        raise GeneratorError("LLM response was not valid JSON") from exc
+
+    try:
+        validated = _QUESTIONS_ADAPTER.validate_python(parsed)
+    except ValidationError as exc:
+        logger.warning(
+            "comprehension response did not match schema",
+            extra={"text_hash": text_hash.hex()},
+        )
+        raise GeneratorError("LLM response did not match expected schema") from exc
+
+    return [q.model_dump() for q in validated]

--- a/app/services/comprehension/prompts.py
+++ b/app/services/comprehension/prompts.py
@@ -1,0 +1,49 @@
+"""System prompt + version for the comprehension-question generator.
+
+PROMPT_VERSION is part of the cache key in comprehension_question_cache
+(see COMP-1 / #18). Bumping it invalidates every previously-cached
+generation, so prefer minor wording tweaks that don't change the
+output shape over version bumps. Bump when:
+  - the output JSON schema changes
+  - the question-type vocabulary changes
+  - the prompt's instructional content materially changes (e.g.,
+    "ask 3 questions" → "ask 5 questions")
+
+The user message body is just the passage text, sent verbatim. The
+system message carries cache_control={'type': 'ephemeral'} so
+Anthropic's prompt caching kicks in across requests — the system
+prompt is shared, the user message varies per passage.
+"""
+
+from typing import Final
+
+PROMPT_VERSION: Final[int] = 1
+
+SYSTEM_PROMPT: Final[str] = (
+    "You generate reading-comprehension questions for a passage of text."
+    " The reader has chosen this passage and your job is to help them"
+    " confirm they understood it.\n"
+    "\n"
+    "Output requirements (strict):\n"
+    "  - Exactly 3 questions\n"
+    "  - Each question is under 25 words\n"
+    "  - Each question is specific to the passage (no generic 'what is the"
+    " main idea' questions)\n"
+    "  - Each question has a 'type' of either 'recall' or 'summary'\n"
+    "    - 'recall' tests memory of a specific detail or fact in the passage\n"
+    "    - 'summary' tests understanding of an overall theme or argument\n"
+    "  - Output ONLY a JSON array of objects with keys 'type' and 'text'\n"
+    "  - NO preamble, NO markdown, NO commentary — only the JSON array\n"
+    "\n"
+    "The reader may be neurodivergent or otherwise prefer plain, direct"
+    " language. Avoid abstract framings, double negatives, and questions"
+    " that require interpretation of literary devices unless the passage"
+    " itself uses them.\n"
+    "\n"
+    "Example output for a hypothetical passage:\n"
+    "[\n"
+    '  {"type": "recall", "text": "Who did the speaker address in the opening line?"},\n'
+    '  {"type": "recall", "text": "What did the protagonist do when they saw the storm?"},\n'
+    '  {"type": "summary", "text": "In one sentence, what is the speaker urging?"}\n'
+    "]\n"
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "resend>=2.29.0",
     "email-validator>=2.3.0",
     "itsdangerous>=2.2.0",
+    "anthropic>=0.101.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_comprehension_generator.py
+++ b/tests/test_comprehension_generator.py
@@ -1,0 +1,449 @@
+"""Tests for the Anthropic-backed comprehension-question generator.
+
+Covers the Definition of Done from issue #19 (COMP-2):
+  - Cache hit returns immediately without invoking the Anthropic client
+  - Cache miss calls Anthropic exactly once, persists to cache, returns parsed list
+  - Second call with the same text after a miss is a cache hit
+  - Passage exceeding 16,000 chars raises PassageTooLongError BEFORE the LLM call
+  - The call to messages.create uses cache_control={'type': 'ephemeral'} on the system message
+  - The call uses model=settings.anthropic_model
+  - Malformed JSON response raises GeneratorError
+  - Schema-mismatched response (e.g., wrong "type" value) raises GeneratorError
+  - The passage text never appears in log output
+  - Bumping PROMPT_VERSION produces a cache miss for previously-cached entries
+
+The Anthropic client is ALWAYS a MagicMock. The real API is never hit
+from this file. CI never makes outbound requests to Anthropic.
+"""
+
+import hashlib
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from sqlmodel import Session
+
+from app.services.comprehension import cache, generator
+from app.services.comprehension.generator import (
+    MAX_INPUT_CHARS,
+    GeneratorError,
+    PassageTooLongError,
+    generate_questions,
+)
+from app.services.comprehension.prompts import PROMPT_VERSION
+
+TEST_MODEL_ID = "claude-haiku-4-5"
+TEST_PASSAGE = "O Son of Spirit! My first counsel is this: possess a pure, kindly heart."
+
+VALID_LLM_OUTPUT = (
+    '[{"type":"recall","text":"What is the first counsel?"},'
+    '{"type":"recall","text":"What attribute should the heart have?"},'
+    '{"type":"summary","text":"What virtue is the passage urging?"}]'
+)
+
+
+def _make_mock_client(*, response_text: str = VALID_LLM_OUTPUT) -> MagicMock:
+    """Build a MagicMock client whose messages.create() returns one
+    text content block carrying `response_text`."""
+    response = MagicMock()
+    text_block = MagicMock()
+    text_block.text = response_text
+    response.content = [text_block]
+
+    client = MagicMock()
+    client.messages.create.return_value = response
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Cache-first contract — the cost-containment promise
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_returns_immediately_without_calling_anthropic(session: Session) -> None:
+    """The ADR-001 cost story rests on this: any cache hit short-circuits
+    before the Anthropic SDK is touched. Verify by pre-populating the
+    cache and asserting the mock client's create() is never called."""
+    text_hash = hashlib.sha256(TEST_PASSAGE.encode("utf-8")).digest()
+    cached_questions = [{"type": "recall", "text": "cached question?"}]
+
+    cache.put_cache(
+        passage_hash=text_hash,
+        question_type="recall",
+        model_id=TEST_MODEL_ID,
+        prompt_version=PROMPT_VERSION,
+        questions=cached_questions,
+        session=session,
+    )
+    session.commit()
+
+    client = _make_mock_client()
+
+    result = generate_questions(
+        passage_text=TEST_PASSAGE,
+        question_type="recall",
+        client=client,
+        model_id=TEST_MODEL_ID,
+        session=session,
+    )
+
+    assert result == cached_questions
+    assert client.messages.create.call_count == 0
+
+
+def test_cache_miss_calls_anthropic_once_and_persists(session: Session) -> None:
+    client = _make_mock_client()
+
+    result = generate_questions(
+        passage_text=TEST_PASSAGE,
+        question_type="recall",
+        client=client,
+        model_id=TEST_MODEL_ID,
+        session=session,
+    )
+
+    assert client.messages.create.call_count == 1
+    assert len(result) == 3
+    assert result[0] == {"type": "recall", "text": "What is the first counsel?"}
+
+    # And the cache now has it.
+    text_hash = hashlib.sha256(TEST_PASSAGE.encode("utf-8")).digest()
+    cached = cache.get_cached(
+        passage_hash=text_hash,
+        question_type="recall",
+        model_id=TEST_MODEL_ID,
+        prompt_version=PROMPT_VERSION,
+        session=session,
+    )
+    assert cached == result
+
+
+def test_second_call_after_miss_is_a_cache_hit(session: Session) -> None:
+    """Pins the round-trip: first call is a miss (LLM invoked once),
+    second call with the same input is a hit (no further LLM calls)."""
+    client = _make_mock_client()
+
+    generate_questions(
+        passage_text=TEST_PASSAGE,
+        question_type="recall",
+        client=client,
+        model_id=TEST_MODEL_ID,
+        session=session,
+    )
+    generate_questions(
+        passage_text=TEST_PASSAGE,
+        question_type="recall",
+        client=client,
+        model_id=TEST_MODEL_ID,
+        session=session,
+    )
+
+    assert client.messages.create.call_count == 1  # only the first call
+
+
+# ---------------------------------------------------------------------------
+# Input-cap contract — the runaway-cost prevention
+# ---------------------------------------------------------------------------
+
+
+def test_passage_at_input_cap_succeeds(session: Session) -> None:
+    """Exactly MAX_INPUT_CHARS passes — boundary case."""
+    client = _make_mock_client()
+    passage = "a" * MAX_INPUT_CHARS
+
+    result = generate_questions(
+        passage_text=passage,
+        question_type="recall",
+        client=client,
+        model_id=TEST_MODEL_ID,
+        session=session,
+    )
+    assert client.messages.create.call_count == 1
+    assert len(result) == 3
+
+
+def test_passage_over_input_cap_raises_and_does_not_call_anthropic(
+    session: Session,
+) -> None:
+    """The cost-prevention property: a too-long passage raises BEFORE the
+    LLM is invoked, AND BEFORE writing anything to the cache. Pinned by
+    asserting both side effects didn't happen."""
+    client = _make_mock_client()
+    passage = "a" * (MAX_INPUT_CHARS + 1)
+
+    with pytest.raises(PassageTooLongError) as exc_info:
+        generate_questions(
+            passage_text=passage,
+            question_type="recall",
+            client=client,
+            model_id=TEST_MODEL_ID,
+            session=session,
+        )
+
+    assert client.messages.create.call_count == 0
+    assert exc_info.value.char_count == MAX_INPUT_CHARS + 1
+
+    # No cache row was written.
+    text_hash = hashlib.sha256(passage.encode("utf-8")).digest()
+    assert (
+        cache.get_cached(
+            passage_hash=text_hash,
+            question_type="recall",
+            model_id=TEST_MODEL_ID,
+            prompt_version=PROMPT_VERSION,
+            session=session,
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anthropic call shape — pinning the prompt-caching invariant
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_call_uses_ephemeral_cache_control_on_system(session: Session) -> None:
+    """The system message must carry cache_control={'type': 'ephemeral'}.
+    Without this, Anthropic's prompt cache never warms up and we re-pay
+    the system-prompt tokens on every call."""
+    client = _make_mock_client()
+
+    generate_questions(
+        passage_text=TEST_PASSAGE,
+        question_type="recall",
+        client=client,
+        model_id=TEST_MODEL_ID,
+        session=session,
+    )
+
+    _, kwargs = client.messages.create.call_args
+    system = kwargs["system"]
+    assert isinstance(system, list)
+    assert system[0]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_anthropic_call_uses_supplied_model_id(session: Session) -> None:
+    client = _make_mock_client()
+
+    generate_questions(
+        passage_text=TEST_PASSAGE,
+        question_type="recall",
+        client=client,
+        model_id="claude-haiku-4-5",
+        session=session,
+    )
+
+    _, kwargs = client.messages.create.call_args
+    assert kwargs["model"] == "claude-haiku-4-5"
+
+
+def test_anthropic_call_carries_passage_as_user_message(session: Session) -> None:
+    client = _make_mock_client()
+
+    generate_questions(
+        passage_text=TEST_PASSAGE,
+        question_type="recall",
+        client=client,
+        model_id=TEST_MODEL_ID,
+        session=session,
+    )
+
+    _, kwargs = client.messages.create.call_args
+    messages = kwargs["messages"]
+    assert messages == [{"role": "user", "content": TEST_PASSAGE}]
+
+
+# ---------------------------------------------------------------------------
+# Malformed responses — the bad-LLM-day case
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_json_response_raises_generator_error(session: Session) -> None:
+    """The LLM occasionally emits prose preamble even when told not to.
+    Catch it, raise GeneratorError, surface a friendly UX message at
+    the route layer."""
+    client = _make_mock_client(response_text="Here are your questions: ...")
+
+    with pytest.raises(GeneratorError):
+        generate_questions(
+            passage_text=TEST_PASSAGE,
+            question_type="recall",
+            client=client,
+            model_id=TEST_MODEL_ID,
+            session=session,
+        )
+
+
+def test_schema_mismatched_response_raises_generator_error(session: Session) -> None:
+    """The LLM emits valid JSON but with the wrong 'type' enum or missing
+    'text' field. Pydantic catches it; we re-raise as GeneratorError."""
+    bad_payload = '[{"type":"opinion","text":"What did you think?"}]'
+    client = _make_mock_client(response_text=bad_payload)
+
+    with pytest.raises(GeneratorError):
+        generate_questions(
+            passage_text=TEST_PASSAGE,
+            question_type="recall",
+            client=client,
+            model_id=TEST_MODEL_ID,
+            session=session,
+        )
+
+
+def test_malformed_response_does_not_poison_cache(session: Session) -> None:
+    """A failed call must NOT write the bad output to the cache. Otherwise
+    every retry would serve the broken result without re-calling the LLM."""
+    client = _make_mock_client(response_text="not json")
+
+    with pytest.raises(GeneratorError):
+        generate_questions(
+            passage_text=TEST_PASSAGE,
+            question_type="recall",
+            client=client,
+            model_id=TEST_MODEL_ID,
+            session=session,
+        )
+
+    text_hash = hashlib.sha256(TEST_PASSAGE.encode("utf-8")).digest()
+    assert (
+        cache.get_cached(
+            passage_hash=text_hash,
+            question_type="recall",
+            model_id=TEST_MODEL_ID,
+            prompt_version=PROMPT_VERSION,
+            session=session,
+        )
+        is None
+    )
+
+
+def test_empty_content_blocks_raises_generator_error(session: Session) -> None:
+    """Defensive: if the SDK returns a response with no content blocks
+    (rare but possible on some error paths), surface GeneratorError
+    rather than 500ing."""
+    client = MagicMock()
+    response = MagicMock()
+    response.content = []  # no blocks at all
+    client.messages.create.return_value = response
+
+    with pytest.raises(GeneratorError):
+        generate_questions(
+            passage_text=TEST_PASSAGE,
+            question_type="recall",
+            client=client,
+            model_id=TEST_MODEL_ID,
+            session=session,
+        )
+
+
+# ---------------------------------------------------------------------------
+# PII-in-logs — never leak passage text
+# ---------------------------------------------------------------------------
+
+
+def test_passage_text_never_appears_in_logs(
+    session: Session, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Passages may contain personal or sacred text. Never log them
+    verbatim. The text_hash hex is the loggable identifier; passage
+    contents are not."""
+    client = _make_mock_client()
+    sensitive_phrase = "O Son of Spirit"
+    passage_with_sensitive_phrase = f"{sensitive_phrase}! My first counsel..."
+
+    with caplog.at_level(logging.DEBUG):
+        generate_questions(
+            passage_text=passage_with_sensitive_phrase,
+            question_type="recall",
+            client=client,
+            model_id=TEST_MODEL_ID,
+            session=session,
+        )
+
+    assert sensitive_phrase not in caplog.text
+
+
+def test_passage_too_long_log_does_not_include_passage(
+    session: Session, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The 'too long' log line records char count but never the text."""
+    client = _make_mock_client()
+    sensitive_marker = "THIS_IS_THE_SECRET_MARKER"
+    passage = sensitive_marker + ("a" * (MAX_INPUT_CHARS + 1))
+
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(PassageTooLongError):
+            generate_questions(
+                passage_text=passage,
+                question_type="recall",
+                client=client,
+                model_id=TEST_MODEL_ID,
+                session=session,
+            )
+
+    assert sensitive_marker not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation via PROMPT_VERSION
+# ---------------------------------------------------------------------------
+
+
+def test_bumping_prompt_version_produces_cache_miss(
+    session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A prompt-text change is communicated via PROMPT_VERSION bump.
+    Cached questions tagged with the OLD version are no longer found
+    on lookup — the next call refetches from the LLM."""
+    client = _make_mock_client()
+
+    # Prime the cache at the current PROMPT_VERSION.
+    generate_questions(
+        passage_text=TEST_PASSAGE,
+        question_type="recall",
+        client=client,
+        model_id=TEST_MODEL_ID,
+        session=session,
+    )
+    assert client.messages.create.call_count == 1
+
+    # Bump the version that generator.py references.
+    monkeypatch.setattr(generator, "PROMPT_VERSION", PROMPT_VERSION + 1)
+
+    # The next call should be a miss (different cache key now).
+    generate_questions(
+        passage_text=TEST_PASSAGE,
+        question_type="recall",
+        client=client,
+        model_id=TEST_MODEL_ID,
+        session=session,
+    )
+    assert client.messages.create.call_count == 2  # second LLM call
+
+
+# ---------------------------------------------------------------------------
+# Return shape
+# ---------------------------------------------------------------------------
+
+
+def test_return_shape_is_list_of_plain_dicts(session: Session) -> None:
+    """Caller (COMP-3 route) and cache storage both expect plain dicts.
+    Pydantic models go through .model_dump() before they leave this
+    module so callers never see Pydantic types."""
+    client = _make_mock_client()
+
+    result: list[dict[str, Any]] = generate_questions(
+        passage_text=TEST_PASSAGE,
+        question_type="recall",
+        client=client,
+        model_id=TEST_MODEL_ID,
+        session=session,
+    )
+
+    assert isinstance(result, list)
+    for q in result:
+        assert isinstance(q, dict)
+        assert set(q.keys()) == {"type", "text"}
+        assert isinstance(q["text"], str)
+        assert q["type"] in ("recall", "summary")

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "anthropic" },
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "itsdangerous" },
@@ -33,6 +34,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
+    { name = "anthropic", specifier = ">=0.101.0" },
     { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
@@ -82,6 +84,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.101.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/cb/9d0123243e749ac3a579972b2c398971bce1dc57bcc4efb08066df610360/anthropic-0.101.0.tar.gz", hash = "sha256:1116a6a87c55757e0fbe3e1ba40804fbd04de7963601a6dd6b539a889f18de3e", size = 758603, upload-time = "2026-05-11T15:46:33.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/b2/74ff06762d005ecf1658929a292df0acb786d025f6a6c54fcb30e2dc7761/anthropic-0.101.0-py3-none-any.whl", hash = "sha256:cc3cc6576989471e2aa9132258034ad0ff0d8fe500b04ac499e4e46ed68c5ed0", size = 753594, upload-time = "2026-05-11T15:46:32.216Z" },
 ]
 
 [[package]]
@@ -285,12 +306,30 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -464,6 +503,78 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/a329e9d469f86307203594b1707e11ae51c3348d03bfd514a5f997870012/jiter-0.14.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ede4331a1899d604463369c730dbb961ffdc5312bc7f16c41c2896415b1304a", size = 370102, upload-time = "2026-04-10T14:26:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c1/5e3dfc59635aa4d4c7bd20a820ac1d09b8ed851568356802cf1c08edb3cf/jiter-0.14.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92cd8b6025981a041f5310430310b55b25ca593972c16407af8837d3d7d2ca01", size = 461335, upload-time = "2026-04-10T14:26:31.911Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/dd157009dbc058f7b00108f545ccb72a2d56461395c4fc7b9cfdccb00af4/jiter-0.14.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:351bf6eda4e3a7ceb876377840c702e9a3e4ecc4624dbfb2d6463c67ae52637d", size = 378536, upload-time = "2026-04-10T14:26:33.595Z" },
+    { url = "https://files.pythonhosted.org/packages/91/78/256013667b7c10b8834f8e6e54cd3e562d4c6e34227a1596addccc05e38c/jiter-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dcfbeb93d9ecd9ca128bbf8910120367777973fa193fb9a39c31237d8df165", size = 353859, upload-time = "2026-04-10T14:26:35.098Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d9/137d65ade9093a409fe80955ce60b12bb753722c986467aeda47faf450ad/jiter-0.14.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ae039aaef8de3f8157ecc1fdd4d85043ac4f57538c245a0afaecb8321ec951c3", size = 357626, upload-time = "2026-04-10T14:26:36.685Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/48/76750835b87029342727c1a268bea8878ab988caf81ee4e7b880900eeb5a/jiter-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d9d51eb96c82a9652933bd769fe6de66877d6eb2b2440e281f2938c51b5643e", size = 393172, upload-time = "2026-04-10T14:26:38.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/60/456c4e81d5c8045279aefe60e9e483be08793828800a4e64add8fdde7f2a/jiter-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d824ca4148b705970bf4e120924a212fdfca9859a73e42bd7889a63a4ea6bb98", size = 520300, upload-time = "2026-04-10T14:26:39.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/2020e0984c235f678dced38fe4eec3058cf528e6af36ebf969b410305941/jiter-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3", size = 553059, upload-time = "2026-04-10T14:26:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030, upload-time = "2026-04-10T14:26:42.517Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603, upload-time = "2026-04-10T14:26:44.328Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525, upload-time = "2026-04-10T14:26:46Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
 ]
 
 [[package]]
@@ -1020,6 +1131,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
     { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
     { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Ticket

Closes #19 — COMP-2: Anthropic SDK wrapper (input cap, prompt caching, mock-friendly).

## Summary

The single place in the codebase that calls the Anthropic API, per [ADR-001](docs/TECHNICAL-ARCHITECTURE.md#adr-001-anthropic-claude-for-comprehension-question-generation). Wraps `client.messages.create` with the four cost-containment + quality invariants in one place: cache-first lookup, input-char cap, prompt caching on the system message, structured-output validation. After this lands, COMP-3 (#20) wires the wrapper into an HTMX-lazy-loaded fragment on the reading view.

## Changes Made

- **CREATE** [app/services/comprehension/prompts.py](app/services/comprehension/prompts.py) — `SYSTEM_PROMPT` constant + `PROMPT_VERSION` integer. Cache-key contribution: bumping PROMPT_VERSION invalidates all previously-cached entries.
- **CREATE** [app/services/comprehension/generator.py](app/services/comprehension/generator.py) — `generate_questions()`, `PassageTooLongError`, `GeneratorError`, the Pydantic `_Question` schema, the `_parse_response` helper.
- **MODIFY** [app/config.py](app/config.py) — `ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL` (default `claude-haiku-4-5`).
- **MODIFY** [pyproject.toml](pyproject.toml) — adds `anthropic` runtime dep.
- **CREATE** [tests/test_comprehension_generator.py](tests/test_comprehension_generator.py) — 16 tests covering every DoD assertion.

## The four invariants the wrapper enforces

1. **Cache-first lookup.** SHA-256(passage_text) + question_type + model_id + PROMPT_VERSION is the cache key. A hit returns immediately with NO LLM call. Pinned by `test_cache_hit_returns_immediately_without_calling_anthropic`.

2. **Input cap at 16,000 chars (~4,000 Claude tokens).** Raised BEFORE any LLM call and BEFORE any cache write. Pinned by `test_passage_over_input_cap_raises_and_does_not_call_anthropic` (asserts both side effects didn't happen).

3. **Prompt caching on the system message.** Passes `cache_control={"type": "ephemeral"}` on the system block so Anthropic's server-side prompt cache kicks in across requests. Pinned by `test_anthropic_call_uses_ephemeral_cache_control_on_system`.

4. **Structured-output validation.** The LLM response goes through `Pydantic`'s `TypeAdapter[list[_Question]]` before being returned or cached. Malformed JSON, wrong schema, missing fields → `GeneratorError`. Pinned by `test_malformed_json_response_raises_generator_error`, `test_schema_mismatched_response_raises_generator_error`, and `test_malformed_response_does_not_poison_cache`.

## Design notes

- **Anthropic client is an explicit parameter, not built inside the function.** Tests pass `MagicMock`; routes (in COMP-3 / #20) will build the real client from `settings.anthropic_api_key`. **The real API is never hit in CI.**
- **Char-count as the input gate, not the SDK's `count_tokens` API.** Conservative chars/4 estimate keeps the pre-flight check fully local (no extra network round-trip per cache miss). For typical English passages, 16,000 chars maps to ~4,000 tokens. If real usage shows tighter coverage is needed, swap in `client.messages.count_tokens` later.
- **Logging never includes the passage text.** Two log-PII tests pin this: one for the happy path (`test_passage_text_never_appears_in_logs`) and one for the too-long path (`test_passage_too_long_log_does_not_include_passage`). The text_hash hex is the loggable identifier.
- **`PROMPT_VERSION` as cache-key participant.** Bumping the version invalidates all previously-cached entries. The intended semantic when the prompt text materially changes. Pinned by `test_bumping_prompt_version_produces_cache_miss`.
- **No new validator in `app/config.py` for empty `ANTHROPIC_API_KEY`.** Deliberate: missing API key shouldn't fail the app boot — it just means the /questions feature (COMP-3) degrades gracefully. Route-layer will detect and surface a friendly message.

## Out of scope (future tickets)

- The HTMX-lazy-loaded question-fragment route. **COMP-3 (#20)** — this wrapper's downstream consumer.
- Real-API integration tests under `tests/integration/`. Env-var-gated, never CI. Out of scope here; reviewer can run a one-line script manually to dogfood with a real key.
- Token-counting via the SDK's `count_tokens` API. If passage length proves a tight gate, this is the upgrade path.
- Caching-by-prompt-prefix for the user message too. Anthropic's prompt cache supports it; could optimise repeat-visit costs further. Polish.

## Manual verification

```bash
# Reviewer: with ANTHROPIC_API_KEY set
python -c "
import anthropic, hashlib
from sqlmodel import Session, create_engine, SQLModel
from app.services.comprehension.generator import generate_questions
import app.models  # registers tables

engine = create_engine('sqlite:///:memory:')
SQLModel.metadata.create_all(engine)
client = anthropic.Anthropic()

with Session(engine) as session:
    result = generate_questions(
        passage_text='O Son of Spirit! My first counsel is this: possess a pure, kindly heart.',
        question_type='recall',
        client=client,
        model_id='claude-haiku-4-5',
        session=session,
    )
    print(result)
"
# → expect a list of 3 dicts each with type ∈ {'recall', 'summary'} and a text field
```

## Testing

### Automated tests

- [x] 16 new tests pass locally
- [x] Full suite still green (157 / 157)
- [x] Coverage 98.91% overall; new modules at 100%
- [x] `uv run ruff check .` clean
- [x] `uv run mypy app/` clean
- [x] Pre-push hook passed

## Checklist

- [x] All tests pass (157/157, 98.91% coverage)
- [x] Code follows project conventions
- [x] No lint/type errors
- [x] PR closes the linked issue
- [x] Real Anthropic API never invoked from CI
- [ ] Reviewer GO/NO-GO recommendation
- [ ] Human merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)