### PR TITLE
feat(home): Cubrox landing page with sign-in form

### DIFF
--- a/app/api/home.py
+++ b/app/api/home.py
@@ -1,0 +1,22 @@
+"""Landing-page route.
+
+GET / renders the Cubrox landing page with a sign-in form. The form
+posts to /login (AUTH-1) via HTMX, so a successful submit swaps the
+form for the "check your inbox" fragment without a page reload.
+
+Public route — no authentication required. This is the only URL on
+the site a person can find without already being signed in.
+"""
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from app.templates import templates
+
+router = APIRouter()
+
+
+@router.get("/", response_class=HTMLResponse)
+def landing(request: Request) -> HTMLResponse:
+    """Render the landing page with the sign-in form."""
+    return templates.TemplateResponse(request=request, name="home.html")

--- a/app/api/todos.py
+++ b/app/api/todos.py
@@ -25,17 +25,6 @@ router = APIRouter()
 SessionDep = Annotated[Session, Depends(get_session)]
 
 
-@router.get("/", response_class=HTMLResponse)
-async def home(request: Request, session: SessionDep) -> HTMLResponse:
-    """Render the home page with the full todo list."""
-    todos = session.exec(select(Todo).order_by(desc("created_at"))).all()
-    return templates.TemplateResponse(
-        request,
-        "home.html",
-        {"todos": todos},
-    )
-
-
 @router.post("/todos", response_class=HTMLResponse)
 async def create_todo(
     request: Request,

--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 
-from app.api import auth, health, passages, reading, todos
+from app.api import auth, health, home, passages, reading, todos
 from app.services.identity.session import UnauthenticatedError
 
 app = FastAPI(title="Agile Flow GCP")
@@ -39,6 +39,7 @@ STATIC_DIR = Path(__file__).parent.parent / "static"
 app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 
 # Routes
+app.include_router(home.router)
 app.include_router(health.router)
 app.include_router(todos.router)
 app.include_router(auth.router)

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,40 +1,38 @@
 {% extends "base.html" %}
 
-{% block title %}Todo — Agile Flow GCP{% endblock %}
+{% block title %}Cubrox — A calmer way to read{% endblock %}
 
 {% block content %}
   <hgroup>
-    <h1>Todo</h1>
-    <p>
-      Reference app for the Agile Flow GCP workshop. Delete this and build
-      your own product. The HTMX patterns below show how to swap server-
-      rendered fragments into the DOM without writing any JavaScript.
-    </p>
+    <h1>Cubrox</h1>
+    <p>A reading experience tuned for neurodivergent readers — and anyone
+       else who finds long-form text hard to stay with.</p>
   </hgroup>
 
   <section>
-    <form hx-post="/todos"
-          hx-target="#todo-list"
-          hx-swap="outerHTML"
-          hx-on::after-request="this.reset()">
-      <fieldset role="group">
-        <input type="text"
-               name="title"
-               placeholder="What needs doing?"
-               required
-               autofocus>
-        <button type="submit">Add</button>
-      </fieldset>
-    </form>
-
-    {% include "_fragments/todo_list.html" %}
+    <p>Paste any passage. Cubrox renders it in a calm, configurable
+       reading surface with your choice of font, size, contrast, line
+       spacing, and column width — and offers a quick comprehension
+       check at the end so you know what you absorbed.</p>
   </section>
 
-  <footer>
-    <small>
-      Built with FastAPI + Jinja2 + HTMX on GCP Cloud Run + Neon.
-      See <code>docs/PATTERN-LIBRARY.md</code> for the patterns powering
-      this stack.
-    </small>
-  </footer>
+  <form id="signin-form"
+        hx-post="/login"
+        hx-target="#signin-form"
+        hx-swap="outerHTML">
+    <label for="email">
+      Email
+      <input
+        type="email"
+        id="email"
+        name="email"
+        required
+        autofocus
+        placeholder="you@example.com"
+        autocomplete="email">
+      <small>We'll email you a one-time sign-in link. No password to remember.</small>
+    </label>
+
+    <button type="submit">Send me a sign-in link</button>
+  </form>
 {% endblock %}

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1,0 +1,108 @@
+"""Tests for the public landing page at GET /.
+
+This is the ONLY public page on Cubrox — it must work without
+authentication and serve as the on-ramp to the magic-link sign-in
+flow (AUTH-1/2/3).
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.services.identity import magic_link
+
+
+@pytest.fixture(autouse=True)
+def stub_email_sender(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the real Resend dispatch with a no-op.
+
+    The signin-form-submits-to-/login test exercises the real /login
+    route, which would otherwise call Resend with the (unset) test
+    API key. Stub it out the same way test_auth_login.py does.
+    """
+    monkeypatch.setattr(
+        magic_link,
+        "send_magic_link_email",
+        lambda **_: None,
+    )
+
+
+def test_landing_page_returns_200_and_html(client: TestClient) -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+
+
+def test_landing_page_does_not_require_auth(client: TestClient) -> None:
+    """The landing page is the only public URL. Unauthenticated requests
+    must NOT redirect to /login (that would be a redirect loop, since
+    /login is where someone gets the form to sign in from)."""
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 200
+    assert response.headers.get("location") is None
+
+
+def test_landing_page_renders_signin_form(client: TestClient) -> None:
+    """The form is the whole point of this page — without it, a user has
+    no way to get into the product."""
+    response = client.get("/")
+    body = response.text
+
+    assert "<form" in body
+    # Form has an email input.
+    assert "<input" in body
+    assert 'type="email"' in body
+    assert 'name="email"' in body
+    # Form submits to /login.
+    assert 'hx-post="/login"' in body
+
+
+def test_landing_page_signin_form_swaps_inline(client: TestClient) -> None:
+    """The form uses HTMX outerHTML swap so the success message replaces
+    the form in place — no full-page reload. Pin this so a future
+    refactor can't accidentally drop the swap config."""
+    body = client.get("/").text
+
+    assert 'hx-target="#signin-form"' in body
+    assert 'hx-swap="outerHTML"' in body
+    # The form's id is the swap target.
+    assert 'id="signin-form"' in body
+
+
+def test_landing_page_mentions_cubrox(client: TestClient) -> None:
+    """Basic branding sanity check — visiting the URL should make it
+    obvious you're looking at Cubrox, not the starter template's todo
+    demo."""
+    body = client.get("/").text
+    assert "Cubrox" in body
+
+
+def test_landing_page_does_not_mention_todos(client: TestClient) -> None:
+    """The todo demo was the starter scaffolding. Make sure no leftover
+    text bleeds through into the landing page."""
+    body = client.get("/").text.lower()
+    assert "todo" not in body
+
+
+def test_landing_page_email_input_has_html5_validation(client: TestClient) -> None:
+    """`required` and `type='email'` give the browser a free first pass
+    at input validation before the form even submits. Pin both."""
+    body = client.get("/").text
+    assert "required" in body
+    assert 'autocomplete="email"' in body
+
+
+def test_signin_form_submission_returns_check_inbox_fragment(
+    client: TestClient,
+) -> None:
+    """End-to-end smoke: posting the form's value to /login returns the
+    success fragment from AUTH-1. This pins the template-route contract
+    (the form's action target must match the route's expected method
+    and field name)."""
+    response = client.post(
+        "/login",
+        data={"email": "reader@example.com"},
+        headers={"HX-Request": "true"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 202
+    assert "Check your inbox" in response.text

--- a/tests/test_todos.py
+++ b/tests/test_todos.py
@@ -10,13 +10,6 @@ from sqlmodel import Session, select
 from app.models.todo import Todo
 
 
-def test_home_renders_empty_state(client: TestClient) -> None:
-    response = client.get("/")
-    assert response.status_code == 200
-    assert "text/html" in response.headers["content-type"]
-    assert "No todos yet" in response.text
-
-
 def test_create_todo_returns_updated_list_fragment(
     client: TestClient,
     session: Session,


### PR DESCRIPTION
## Summary

Closes the **biggest UX gap** in the live product. Until now, visiting the production URL `https://agile-flow-app-heo5ry7rua-uc.a.run.app/` showed the starter scaffolding's todo demo, and the ONLY way to sign in was running `curl -X POST /login` from a terminal. After this merges, a person can:

1. Visit the URL in any browser
2. See a Cubrox-branded landing page with a one-paragraph product description
3. Type their email into a form
4. Click "Send me a sign-in link"
5. Get the same magic-link flow AUTH-1/2/3 already built

The form HTMX-swaps in the "check your inbox" fragment in place — no page reload.

## Changes Made

- **CREATE** [app/api/home.py](app/api/home.py) — public `GET /` route. No auth gate.
- **REPLACE** [templates/home.html](templates/home.html) — was the todo-demo page, now Cubrox-branded with the sign-in form.
- **MODIFY** [app/api/todos.py](app/api/todos.py) — removes the `GET /` handler. The todo demo's `/todos` POST/DELETE endpoints are untouched.
- **MODIFY** [app/main.py](app/main.py) — registers the home router first so it claims `/`.
- **CREATE** [tests/test_home.py](tests/test_home.py) — 8 tests covering rendering, no-auth, form structure, HTMX swap config, branding, no-leftover-todo-text, HTML5 validation, and an end-to-end smoke that posts the form's exact field name to `/login` and verifies the AUTH-1 success fragment comes back.
- **MODIFY** [tests/test_todos.py](tests/test_todos.py) — removes `test_home_renders_empty_state` (the old todo-at-/ test).

## Design notes

- **The form's POST target is `/login`** (the AUTH-1 endpoint that already exists). No new route was needed for the form action — just wire the template to the existing endpoint. Pinned by `test_signin_form_submission_returns_check_inbox_fragment`, which submits the form's actual field name (`email`) to the actual endpoint and asserts the 202 + "Check your inbox" fragment comes back.
- **`hx-target="#signin-form" hx-swap="outerHTML"`** so the success fragment replaces the form in place. No page reload, no flash of empty page.
- **`<input type="email" required autocomplete="email">`** for free browser-side validation + browser autofill UX. Server-side validation in `/login` is still the gate.
- **The home router is registered FIRST** in `app/main.py` so it claims `/` before any other router could (defensive — there's no conflict today, but if a future router added a `/` handler unintentionally, the home router wins).

## What's still left for "demo-ready"

This PR closes the biggest gap. Still outstanding before broader sharing:

- **AUTH-4** — rate limiting on `/login`, so an attacker can't email-bomb people via the form.
- **A11Y-1/2/3** — accessibility test harness covering the landing page + sidebar + reading view.
- **Verified Resend sending domain** — emails currently come from the `onboarding@resend.dev` sandbox and only deliver to the address that signed up at resend.com. For real users, a verified domain is needed.

## Testing

- [x] 8 new tests pass locally
- [x] Full suite still green (178 / 178)
- [x] Coverage 98.94% overall; new module + template at 100%
- [x] `uv run ruff check .` clean
- [x] `uv run mypy app/` clean
- [x] Pre-push hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)