### PR TITLE
fix(auth): redirect unauthenticated visitors to landing page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -22,15 +22,23 @@ app = FastAPI(title="Agile Flow GCP")
 async def _handle_unauthenticated(request: Request, exc: UnauthenticatedError) -> Response:
     """Convert UnauthenticatedError into the right response shape.
 
-    Top-level browser navigation gets a 303 to /login. HTMX requests
-    (intercepted by HTMX before the browser sees them) get a 200 with
-    an `HX-Redirect: /login` header — HTMX reads that header and
-    performs a client-side redirect. Without this branch, HTMX would
-    swallow the 303 and the user's URL bar wouldn't change.
+    Top-level browser navigation gets a 303 to / (the landing page,
+    which serves the sign-in form). HTMX requests (intercepted by
+    HTMX before the browser sees them) get a 200 with an
+    `HX-Redirect: /` header — HTMX reads that header and performs a
+    client-side redirect. Without this branch, HTMX would swallow
+    the 303 and the user's URL bar wouldn't change.
+
+    Note: the redirect target is `/`, not `/login`. `/login` is a
+    POST-only API endpoint that handles form submission, not a page.
+    Sending unauthenticated visitors to a POST-only endpoint via GET
+    would land them on a 405 Method Not Allowed. The landing page at
+    `/` is the actual sign-in entry point — visiting it shows the
+    form whose submit handler hits `/login`.
     """
     if request.headers.get("HX-Request") == "true":
-        return Response(status_code=200, headers={"HX-Redirect": "/login"})
-    return RedirectResponse(url="/login", status_code=303)
+        return Response(status_code=200, headers={"HX-Redirect": "/"})
+    return RedirectResponse(url="/", status_code=303)
 
 
 # Mount static files (CSS, images, favicon).

--- a/tests/test_current_user.py
+++ b/tests/test_current_user.py
@@ -75,16 +75,16 @@ def test_valid_cookie_returns_user_info(client: TestClient, session: Session) ->
 # ---------------------------------------------------------------------------
 
 
-def test_missing_cookie_browser_request_redirects_to_login(client: TestClient) -> None:
+def test_missing_cookie_browser_request_redirects_to_landing(client: TestClient) -> None:
     response = client.get("/api/me", follow_redirects=False)
     assert response.status_code == 303
-    assert response.headers["location"] == "/login"
+    assert response.headers["location"] == "/"
 
 
 def test_missing_cookie_htmx_request_returns_hx_redirect(client: TestClient) -> None:
     response = client.get("/api/me", headers={"HX-Request": "true"}, follow_redirects=False)
     assert response.status_code == 200
-    assert response.headers.get("hx-redirect") == "/login"
+    assert response.headers.get("hx-redirect") == "/"
 
 
 def test_tampered_cookie_browser_request_redirects(client: TestClient, session: Session) -> None:
@@ -95,7 +95,7 @@ def test_tampered_cookie_browser_request_redirects(client: TestClient, session: 
     response = client.get("/api/me", follow_redirects=False)
 
     assert response.status_code == 303
-    assert response.headers["location"] == "/login"
+    assert response.headers["location"] == "/"
 
 
 def test_tampered_cookie_htmx_returns_hx_redirect(client: TestClient, session: Session) -> None:
@@ -106,7 +106,7 @@ def test_tampered_cookie_htmx_returns_hx_redirect(client: TestClient, session: S
     response = client.get("/api/me", headers={"HX-Request": "true"}, follow_redirects=False)
 
     assert response.status_code == 200
-    assert response.headers.get("hx-redirect") == "/login"
+    assert response.headers.get("hx-redirect") == "/"
 
 
 def test_cookie_for_deleted_user_redirects(client: TestClient, session: Session) -> None:
@@ -121,7 +121,7 @@ def test_cookie_for_deleted_user_redirects(client: TestClient, session: Session)
     response = client.get("/api/me", follow_redirects=False)
 
     assert response.status_code == 303
-    assert response.headers["location"] == "/login"
+    assert response.headers["location"] == "/"
 
 
 def test_cookie_with_signed_secret_mismatch_redirects(client: TestClient) -> None:

--- a/tests/test_passages_paste.py
+++ b/tests/test_passages_paste.py
@@ -121,16 +121,16 @@ def test_text_over_limit_returns_422(client: TestClient, session: Session) -> No
 # ---------------------------------------------------------------------------
 
 
-def test_unauthenticated_post_redirects_to_login(client: TestClient) -> None:
+def test_unauthenticated_post_redirects_to_landing(client: TestClient) -> None:
     response = client.post("/passages", data={"text": "anything"}, follow_redirects=False)
     assert response.status_code == 303
-    assert response.headers["location"] == "/login"
+    assert response.headers["location"] == "/"
 
 
-def test_unauthenticated_get_form_redirects_to_login(client: TestClient) -> None:
+def test_unauthenticated_get_form_redirects_to_landing(client: TestClient) -> None:
     response = client.get("/passages/new", follow_redirects=False)
     assert response.status_code == 303
-    assert response.headers["location"] == "/login"
+    assert response.headers["location"] == "/"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -191,10 +191,10 @@ def test_bionic_enabled_rejects_non_boolean_strings(client: TestClient, session:
 # ---------------------------------------------------------------------------
 
 
-def test_unauthenticated_post_redirects_to_login(client: TestClient) -> None:
+def test_unauthenticated_post_redirects_to_landing(client: TestClient) -> None:
     response = client.post("/preferences/size", data={"value": "20px"}, follow_redirects=False)
     assert response.status_code == 303
-    assert response.headers["location"] == "/login"
+    assert response.headers["location"] == "/"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_questions_route.py
+++ b/tests/test_questions_route.py
@@ -305,24 +305,24 @@ def test_generator_error_log_does_not_include_passage_text(
 # ---------------------------------------------------------------------------
 
 
-def test_unauthenticated_returns_303_to_login(client: TestClient) -> None:
+def test_unauthenticated_returns_303_to_landing(client: TestClient) -> None:
     response = client.get(f"/passages/{uuid.uuid4()}/questions", follow_redirects=False)
     # Without HX-Request header: browser navigation → 303 redirect.
     assert response.status_code == 303
-    assert response.headers["location"] == "/login"
+    assert response.headers["location"] == "/"
 
 
 def test_unauthenticated_htmx_request_gets_hx_redirect(client: TestClient) -> None:
     """An HTMX request without a session cookie gets the HX-Redirect
     treatment from AUTH-3's exception handler. Without this, HTMX
-    would silently fail to navigate the user to /login."""
+    would silently fail to navigate the user to the landing page."""
     response = client.get(
         f"/passages/{uuid.uuid4()}/questions",
         headers={"HX-Request": "true"},
         follow_redirects=False,
     )
     assert response.status_code == 200
-    assert response.headers.get("HX-Redirect") == "/login"
+    assert response.headers.get("HX-Redirect") == "/"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reading_view.py
+++ b/tests/test_reading_view.py
@@ -235,10 +235,10 @@ def test_other_user_and_nonexistent_have_identical_response_shape(
 # ---------------------------------------------------------------------------
 
 
-def test_unauthenticated_returns_303_to_login(client: TestClient) -> None:
+def test_unauthenticated_returns_303_to_landing(client: TestClient) -> None:
     response = client.get(f"/read/{uuid.uuid4()}", follow_redirects=False)
     assert response.status_code == 303
-    assert response.headers["location"] == "/login"
+    assert response.headers["location"] == "/"
 
 
 def test_invalid_uuid_returns_422(client: TestClient, session: Session) -> None:


### PR DESCRIPTION
## Summary

The AUTH-3 exception handler was redirecting unauthenticated visitors to `/login`, but `/login` is a POST-only API endpoint that handles magic-link form submission — not a page. So an unauth GET to a protected route landed on a 405 Method Not Allowed instead of a sign-in form.

With the landing page at `/` (PR #39, just merged), we have a real page that serves the sign-in form. This PR points the redirect there instead. Caught by the PR #39 reviewer subagent.

## What changed

- `app/main.py`: `_handle_unauthenticated` now redirects to `/` for both browser navigation (303) and HTMX requests (HX-Redirect). Docstring updated with the why.
- 11 test assertions across 5 test files flipped from `/login` to `/`. Test names like `redirects_to_login` renamed to `redirects_to_landing` where the old name became misleading.

## Test plan

- [x] All 178 tests pass locally (97.52% coverage)
- [x] ruff check + format clean
- [x] mypy clean
- [ ] Manual: unauth GET to `/passages/new` lands on the landing page with sign-in form (not 405)
- [ ] Manual: HTMX request without session triggers HX-Redirect to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)