### PR TITLE
feat(auth): rate-limit /login and /auth/verify with Postgres token buckets

### DIFF
--- a/alembic/versions/006_add_rate_bucket.py
+++ b/alembic/versions/006_add_rate_bucket.py
@@ -1,0 +1,46 @@
+"""add rate_bucket table
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-05-12
+
+Per-key token bucket for AUTH-4 rate limiting on /login and
+/auth/verify. One row per (route, dimension, value) tuple, e.g.:
+
+  - "login:ip:203.0.113.7"
+  - "login:email:reader@example.com"
+  - "verify:ip:203.0.113.7"
+  - "verify:token-prefix:abc12345"
+
+The key is opaque to the schema; the service derives it. Tokens are
+stored as float so the linear refill math works without integer
+truncation. See app/services/rate_limit.py.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "006"
+down_revision: str | None = "005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "rate_bucket",
+        sa.Column("key", sa.String(length=255), primary_key=True),
+        sa.Column("tokens", sa.Float(), nullable=False),
+        sa.Column(
+            "refilled_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("rate_bucket")

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -32,6 +32,10 @@ from app.services.identity.session import (
     current_user,
     sign_session,
 )
+from app.services.rate_limit import (
+    enforce_login_rate_limit,
+    enforce_verify_rate_limit,
+)
 
 router = APIRouter()
 
@@ -47,7 +51,12 @@ GENERIC_FRAGMENT = "<p>Check your inbox for a sign-in link.</p>"
 _TOKEN_TABLE = MagicLinkToken.metadata.tables["magic_link_token"]
 
 
-@router.post("/login", response_class=HTMLResponse, status_code=202)
+@router.post(
+    "/login",
+    response_class=HTMLResponse,
+    status_code=202,
+    dependencies=[Depends(enforce_login_rate_limit)],
+)
 def login(
     background_tasks: BackgroundTasks,
     session: SessionDep,
@@ -77,7 +86,7 @@ def login(
     return GENERIC_FRAGMENT
 
 
-@router.get("/auth/verify")
+@router.get("/auth/verify", dependencies=[Depends(enforce_verify_rate_limit)])
 def verify(
     token: str,
     session: SessionDep,

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.comprehension_question_cache import ComprehensionQuestionCache
 from app.models.magic_link_token import MagicLinkToken
 from app.models.passage import Passage
 from app.models.preference import Preference
+from app.models.rate_bucket import RateBucket
 from app.models.todo import Todo
 from app.models.user import User
 
@@ -12,6 +13,7 @@ __all__ = [
     "MagicLinkToken",
     "Passage",
     "Preference",
+    "RateBucket",
     "Todo",
     "User",
 ]

--- a/app/models/rate_bucket.py
+++ b/app/models/rate_bucket.py
@@ -1,0 +1,27 @@
+"""RateBucket model.
+
+A single row per rate-limit key (e.g. `"login:ip:1.2.3.4"`,
+`"login:email:user@example.com"`). The bucket is a classic
+token-bucket: `tokens` is the current credit balance, `refilled_at`
+is the wall-clock at the last balance update.
+
+Refill is linear: 10 tokens per hour means one token every 360
+seconds. When a request lands, we compute how many tokens have
+accrued since `refilled_at`, cap at the bucket size, decrement one,
+and write back. See `app/services/rate_limit.py` for the math.
+
+Postgres-backed (per ADR — Redis when traffic justifies). No
+foreign keys: keys are opaque strings owned by the service.
+"""
+
+from datetime import datetime
+
+from sqlmodel import Field, SQLModel
+
+
+class RateBucket(SQLModel, table=True):
+    __tablename__ = "rate_bucket"
+
+    key: str = Field(primary_key=True)
+    tokens: float
+    refilled_at: datetime

--- a/app/services/rate_limit.py
+++ b/app/services/rate_limit.py
@@ -15,10 +15,12 @@ Logging discipline: we never log raw emails. Rate-limit hits log
 `route` + 16-hex-char SHA-256 prefix of the email so support can
 correlate without leaking PII into Cloud Logging.
 
-Concurrency: production Postgres uses `SELECT ... FOR UPDATE` so two
-concurrent requests can't both decrement the same bucket below zero.
-SQLite (in tests) treats `FOR UPDATE` as a no-op, which is fine — the
-test session is single-threaded.
+Concurrency: the SELECT uses `with_for_update()` so on Postgres, two
+concurrent workers can't both read the same `tokens` value and clobber
+each other's decrement. SQLite (in tests) silently ignores the lock
+hint, which is fine — the test session is single-threaded. The
+first-touch INSERT is handled separately in `_take_token` (catches
+`IntegrityError`, recurses once into the locked-update path).
 """
 
 import hashlib
@@ -29,7 +31,8 @@ from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, Request
-from sqlmodel import Session
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, select
 
 from app.db import get_session
 from app.models.rate_bucket import RateBucket
@@ -83,15 +86,35 @@ class BucketResult:
 def _take_token(session: Session, key: str, now: datetime) -> BucketResult:
     """Atomically refill + decrement one bucket.
 
+    On Postgres, the SELECT uses `FOR UPDATE` so two concurrent workers
+    can't both read the same `tokens` value, decrement, and clobber each
+    other's write. SQLite (in tests) silently drops the lock hint — the
+    test session is single-threaded so this is fine.
+
+    First-touch INSERT is a separate race: two concurrent first-ever
+    requests for the same key both miss the SELECT, both attempt INSERT,
+    one wins, the other hits `IntegrityError`. We catch and recurse
+    once — by then the row exists and the FOR-UPDATE path is taken.
+
     Returns the outcome. Caller is responsible for committing the
     session if all buckets in the request succeed, or rolling back if
     any fails.
     """
-    bucket = session.get(RateBucket, key)
+    stmt = select(RateBucket).where(RateBucket.key == key).with_for_update()
+    bucket = session.exec(stmt).first()
+
     if bucket is None:
         # First touch: start with a full bucket, immediately decrement one.
+        # If another request races us to INSERT, the unique-PK constraint
+        # fires; we retry once, and the second pass takes the locked-update
+        # path.
         bucket = RateBucket(key=key, tokens=BUCKET_SIZE - 1.0, refilled_at=now)
         session.add(bucket)
+        try:
+            session.flush()
+        except IntegrityError:
+            session.rollback()
+            return _take_token(session, key, now)
         return BucketResult(
             allowed=True,
             tokens_remaining=BUCKET_SIZE - 1.0,

--- a/app/services/rate_limit.py
+++ b/app/services/rate_limit.py
@@ -1,0 +1,226 @@
+"""Token-bucket rate limiting for /login and /auth/verify.
+
+Per ADR — Postgres-backed bucket (Redis when traffic justifies). 10
+tokens per hour, linear refill. Two buckets per request, both must
+have ≥1 token after refill:
+
+  /login:        ("login:ip:<ip>",        "login:email:<email>")
+  /auth/verify:  ("verify:ip:<ip>",       "verify:token-prefix:<8hex>")
+
+The IP key blocks the easy spam-from-one-IP attack. The secondary key
+blocks the distributed-IPs-targeting-one-victim attack (email bomb a
+specific address; brute-force a specific token prefix).
+
+Logging discipline: we never log raw emails. Rate-limit hits log
+`route` + 16-hex-char SHA-256 prefix of the email so support can
+correlate without leaking PII into Cloud Logging.
+
+Concurrency: production Postgres uses `SELECT ... FOR UPDATE` so two
+concurrent requests can't both decrement the same bucket below zero.
+SQLite (in tests) treats `FOR UPDATE` as a no-op, which is fine — the
+test session is single-threaded.
+"""
+
+import hashlib
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request
+from sqlmodel import Session
+
+from app.db import get_session
+from app.models.rate_bucket import RateBucket
+
+logger = logging.getLogger(__name__)
+
+# Bucket physics. 10 tokens max, refilled linearly at 10/hour.
+BUCKET_SIZE = 10.0
+SECONDS_PER_TOKEN = 3600.0 / BUCKET_SIZE  # 360 s/token
+
+
+def _now_utc() -> datetime:
+    """Wall clock. Indirected through a function so tests can override
+    it via `monkeypatch.setattr('app.services.rate_limit._now_utc', ...)`.
+    """
+    return datetime.now(UTC)
+
+
+def _hash_email(email: str) -> str:
+    """First 16 hex chars of SHA-256(email). Enough for correlation in
+    Cloud Logging without storing the raw address."""
+    return hashlib.sha256(email.encode("utf-8")).hexdigest()[:16]
+
+
+def _client_ip(request: Request) -> str:
+    """Real client IP, accounting for Cloud Run's proxy hop.
+
+    Cloud Run strips any upstream `X-Forwarded-For` entries the client
+    set, then appends the true client IP as the LAST entry. So we read
+    the last comma-separated value, not the first. Falls back to
+    `request.client.host` for local-dev / test environments where no
+    proxy header is present.
+    """
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        # Last entry is the one Cloud Run set; entries before it may be
+        # client-supplied lies.
+        return xff.split(",")[-1].strip()
+    return request.client.host if request.client else "unknown"
+
+
+@dataclass(frozen=True)
+class BucketResult:
+    """Outcome of a single bucket check after refill."""
+
+    allowed: bool
+    tokens_remaining: float
+    seconds_until_next_token: float
+
+
+def _take_token(session: Session, key: str, now: datetime) -> BucketResult:
+    """Atomically refill + decrement one bucket.
+
+    Returns the outcome. Caller is responsible for committing the
+    session if all buckets in the request succeed, or rolling back if
+    any fails.
+    """
+    bucket = session.get(RateBucket, key)
+    if bucket is None:
+        # First touch: start with a full bucket, immediately decrement one.
+        bucket = RateBucket(key=key, tokens=BUCKET_SIZE - 1.0, refilled_at=now)
+        session.add(bucket)
+        return BucketResult(
+            allowed=True,
+            tokens_remaining=BUCKET_SIZE - 1.0,
+            seconds_until_next_token=SECONDS_PER_TOKEN,
+        )
+
+    # Refill: tokens accrued since refilled_at, capped at BUCKET_SIZE.
+    last_refill = bucket.refilled_at
+    if last_refill.tzinfo is None:
+        # SQLite drops tzinfo on round-trip; treat naive timestamps as UTC.
+        last_refill = last_refill.replace(tzinfo=UTC)
+    elapsed = max(0.0, (now - last_refill).total_seconds())
+    accrued = elapsed / SECONDS_PER_TOKEN
+    tokens_after_refill = min(BUCKET_SIZE, bucket.tokens + accrued)
+
+    if tokens_after_refill < 1.0:
+        # Not enough; persist the refill but DON'T decrement.
+        bucket.tokens = tokens_after_refill
+        bucket.refilled_at = now
+        seconds_until_one = (1.0 - tokens_after_refill) * SECONDS_PER_TOKEN
+        return BucketResult(
+            allowed=False,
+            tokens_remaining=tokens_after_refill,
+            seconds_until_next_token=seconds_until_one,
+        )
+
+    bucket.tokens = tokens_after_refill - 1.0
+    bucket.refilled_at = now
+    return BucketResult(
+        allowed=True,
+        tokens_remaining=bucket.tokens,
+        seconds_until_next_token=SECONDS_PER_TOKEN,
+    )
+
+
+def _enforce(
+    session: Session,
+    keys: tuple[str, ...],
+    *,
+    route: str,
+    email_hash: str | None,
+) -> None:
+    """Run `_take_token` over every key. If any bucket fails, raise 429
+    with the longest `Retry-After` across the failed buckets.
+
+    On any failure we roll back so the partial decrements don't take
+    effect — otherwise a request that fails the second check would
+    cost a token on the first key.
+    """
+    now = _now_utc()
+    results = [(k, _take_token(session, k, now)) for k in keys]
+
+    if all(r.allowed for _, r in results):
+        session.commit()
+        return
+
+    session.rollback()
+    retry_after = int(max(r.seconds_until_next_token for _, r in results if not r.allowed))
+    # Clamp to at least 1 so clients don't loop instantly.
+    retry_after = max(1, retry_after)
+    logger.warning(
+        "rate_limit.hit route=%s email_hash=%s retry_after_s=%s",
+        route,
+        email_hash or "-",
+        retry_after,
+    )
+    raise HTTPException(
+        status_code=429,
+        detail="Too many requests. Try again later.",
+        headers={"Retry-After": str(retry_after)},
+    )
+
+
+SessionDep = Annotated[Session, Depends(get_session)]
+
+
+async def enforce_login_rate_limit(
+    request: Request,
+    session: SessionDep,
+) -> None:
+    """FastAPI dependency for POST /login.
+
+    Extracts the IP and the form-submitted `email` field. Both buckets
+    must have ≥1 token; otherwise the request is rejected with 429.
+    """
+    ip = _client_ip(request)
+    # Read the email out of the form body. FastAPI's form parsing has
+    # already cached the body by the time this dependency runs, so the
+    # downstream route reading `email: Form()` doesn't re-read.
+    form = await request.form()
+    raw_email = form.get("email")
+    if not isinstance(raw_email, str) or not raw_email:
+        # No email supplied — the route's own Form validation will 422
+        # this. Don't burn a token on malformed input.
+        return
+    email_norm = raw_email.strip().lower()
+
+    _enforce(
+        session,
+        keys=(f"login:ip:{ip}", f"login:email:{email_norm}"),
+        route="login",
+        email_hash=_hash_email(email_norm),
+    )
+
+
+def enforce_verify_rate_limit(
+    request: Request,
+    session: SessionDep,
+    token: str = "",
+) -> None:
+    """FastAPI dependency for GET /auth/verify.
+
+    Secondary key uses the SHA-256 prefix of the token rather than the
+    raw token so the rate_bucket table never stores token material.
+    """
+    ip = _client_ip(request)
+    if not token:
+        # No token in the URL — the verify route will 410. Don't burn
+        # a bucket entry on a malformed request.
+        return
+    token_prefix = hashlib.sha256(token.encode("utf-8")).hexdigest()[:8]
+
+    _enforce(
+        session,
+        keys=(f"verify:ip:{ip}", f"verify:token-prefix:{token_prefix}"),
+        route="verify",
+        email_hash=None,
+    )
+
+
+# Convenience type aliases — useful only for tests / introspection.
+TimeSource = Callable[[], datetime]

--- a/tests/test_rate_bucket_migration.py
+++ b/tests/test_rate_bucket_migration.py
@@ -1,0 +1,67 @@
+"""Migration cycle test for the rate_bucket table (revision 006).
+
+Mirrors the existing migration tests: verifies the migration applies
+cleanly on a fresh DB, can be downgraded, and can be reapplied.
+"""
+
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+
+from alembic import command
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def alembic_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Config:
+    db_path = tmp_path / "rate_bucket_migration_test.db"
+    db_url = f"sqlite:///{db_path}"
+
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+
+    cfg = Config(str(REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(REPO_ROOT / "alembic"))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    return cfg
+
+
+def test_upgrade_creates_rate_bucket_table(alembic_cfg: Config) -> None:
+    command.upgrade(alembic_cfg, "006")
+
+    db_url = alembic_cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+    engine = create_engine(db_url)
+    inspector = inspect(engine)
+
+    assert "rate_bucket" in inspector.get_table_names()
+
+    cols = {c["name"] for c in inspector.get_columns("rate_bucket")}
+    assert cols == {"key", "tokens", "refilled_at"}
+
+    pk = inspector.get_pk_constraint("rate_bucket")
+    assert pk["constrained_columns"] == ["key"]
+
+
+def test_upgrade_downgrade_upgrade_cycle(alembic_cfg: Config) -> None:
+    command.upgrade(alembic_cfg, "006")
+    command.downgrade(alembic_cfg, "005")
+
+    db_url = alembic_cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+    engine = create_engine(db_url)
+    inspector = inspect(engine)
+
+    assert "rate_bucket" not in inspector.get_table_names()
+    # Earlier migrations untouched.
+    assert "preference" in inspector.get_table_names()
+    assert "user" in inspector.get_table_names()
+
+    command.upgrade(alembic_cfg, "006")
+    inspector = inspect(engine)
+    assert "rate_bucket" in inspector.get_table_names()

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -206,10 +206,7 @@ def test_rate_limit_log_hashes_the_email(
     import hashlib
 
     expected_prefix = hashlib.sha256(sensitive.encode("utf-8")).hexdigest()[:16]
-    assert any(
-        expected_prefix in ((msg % args) if args else msg)
-        for msg, args in warn_calls
-    )
+    assert any(expected_prefix in ((msg % args) if args else msg) for msg, args in warn_calls)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,245 @@
+"""Tests for AUTH-4 rate limiting on /login and /auth/verify.
+
+Covers the Definition of Done from issue #12:
+  - 10 requests succeed from the same IP, 11th returns 429
+  - Different IPs are independently bucketed
+  - Same email from different IPs is bucketed by email (10 total)
+  - Retry-After header value is between 1 and 3600
+  - Bucket refills linearly over time
+  - 429 response carries Retry-After and does NOT echo the email
+  - Rate-limit log line hashes the email rather than logging it raw
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.services import rate_limit
+from app.services.identity import magic_link
+
+
+@pytest.fixture(autouse=True)
+def stub_email_sender(monkeypatch: pytest.MonkeyPatch) -> None:
+    """/login dispatches an email on the happy path; mute that side effect."""
+    monkeypatch.setattr(magic_link, "send_magic_link_email", lambda **_: None)
+
+
+@pytest.fixture
+def fake_clock(monkeypatch: pytest.MonkeyPatch) -> dict[str, datetime]:
+    """Replace `rate_limit._now_utc` with a controllable wall clock.
+
+    Tests advance the clock by mutating `fake_clock["now"]`. The
+    rate-limit service reads the latest value on every call.
+    """
+    state = {"now": datetime(2026, 5, 12, 12, 0, 0, tzinfo=UTC)}
+    monkeypatch.setattr(rate_limit, "_now_utc", lambda: state["now"])
+    return state
+
+
+def _post_login(client: TestClient, email: str, ip: str) -> int:
+    """Helper: POST /login with a fake client IP via X-Forwarded-For.
+
+    Returns the HTTP status code so the caller can drive a quick loop.
+    Cloud Run appends the real client IP as the LAST entry; we mimic
+    that here.
+    """
+    response = client.post(
+        "/login",
+        data={"email": email},
+        headers={"X-Forwarded-For": f"10.0.0.1, {ip}"},
+    )
+    return response.status_code
+
+
+# ---------------------------------------------------------------------------
+# IP bucket
+# ---------------------------------------------------------------------------
+
+
+def test_ten_requests_from_same_ip_then_429_on_eleventh(
+    client: TestClient, fake_clock: dict[str, datetime]
+) -> None:
+    """The IP bucket exhausts at 10. The 11th request must 429 even
+    though each request uses a different email (so the email buckets
+    are all untouched)."""
+    for i in range(10):
+        code = _post_login(client, f"user{i}@example.com", "203.0.113.7")
+        assert code == 202, f"request {i + 1} should succeed; got {code}"
+
+    code = _post_login(client, "user99@example.com", "203.0.113.7")
+    assert code == 429
+
+
+def test_different_ips_are_independently_bucketed(
+    client: TestClient, fake_clock: dict[str, datetime]
+) -> None:
+    """An attacker exhausting one IP must not lock out other IPs."""
+    # First IP burns its 10.
+    for i in range(10):
+        assert _post_login(client, f"a{i}@example.com", "203.0.113.7") == 202
+    assert _post_login(client, "a99@example.com", "203.0.113.7") == 429
+
+    # Second IP starts fresh.
+    assert _post_login(client, "b0@example.com", "203.0.113.8") == 202
+
+
+# ---------------------------------------------------------------------------
+# Email bucket (cross-IP defense — the email-bomb scenario)
+# ---------------------------------------------------------------------------
+
+
+def test_same_email_across_different_ips_is_bucketed_by_email(
+    client: TestClient, fake_clock: dict[str, datetime]
+) -> None:
+    """Spammer rotates IPs to target one address. The email bucket
+    catches them at 10 total across all IPs."""
+    victim = "victim@example.com"
+    for i in range(10):
+        # Each request a new IP — IP buckets all stay fresh.
+        ip = f"198.51.100.{i + 1}"
+        assert _post_login(client, victim, ip) == 202, f"request {i + 1} should succeed"
+
+    # 11th from yet another IP should be email-rate-limited.
+    assert _post_login(client, victim, "198.51.100.99") == 429
+
+
+# ---------------------------------------------------------------------------
+# Retry-After + response shape
+# ---------------------------------------------------------------------------
+
+
+def test_429_includes_retry_after_within_plausible_range(
+    client: TestClient, fake_clock: dict[str, datetime]
+) -> None:
+    """`Retry-After` is in seconds and must be between 1 and 3600
+    (one hour is the full-bucket refill window)."""
+    for _ in range(10):
+        _post_login(client, "x@example.com", "203.0.113.7")
+    response = client.post(
+        "/login",
+        data={"email": "x@example.com"},
+        headers={"X-Forwarded-For": "10.0.0.1, 203.0.113.7"},
+    )
+    assert response.status_code == 429
+    retry_after = int(response.headers["retry-after"])
+    assert 1 <= retry_after <= 3600
+
+
+def test_429_body_does_not_leak_the_email(
+    client: TestClient, fake_clock: dict[str, datetime]
+) -> None:
+    """The 429 response body must not echo the rate-limited email — a
+    response that bounces the address back can be used to confirm an
+    address is being hammered."""
+    sensitive = "person.confidential@example.com"
+    for _ in range(10):
+        _post_login(client, sensitive, "203.0.113.7")
+    response = client.post(
+        "/login",
+        data={"email": sensitive},
+        headers={"X-Forwarded-For": "10.0.0.1, 203.0.113.7"},
+    )
+    assert response.status_code == 429
+    assert sensitive not in response.text
+    assert "confidential" not in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Linear refill
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_refills_one_token_after_six_minutes(
+    client: TestClient, fake_clock: dict[str, datetime]
+) -> None:
+    """Linear refill: 10 tokens/hour = 1 token per 360 seconds.
+    Burn the bucket, advance 6 minutes and 1 second, one more request
+    should land."""
+    for _ in range(10):
+        _post_login(client, "z@example.com", "203.0.113.7")
+    assert _post_login(client, "z@example.com", "203.0.113.7") == 429
+
+    # Advance just over 6 minutes — enough for one full token.
+    fake_clock["now"] = fake_clock["now"] + timedelta(seconds=361)
+    assert _post_login(client, "z@example.com", "203.0.113.7") == 202
+
+    # Immediately again: bucket is back to <1, expect 429.
+    assert _post_login(client, "z@example.com", "203.0.113.7") == 429
+
+
+# ---------------------------------------------------------------------------
+# PII discipline
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limit_log_hashes_the_email(
+    client: TestClient,
+    fake_clock: dict[str, datetime],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The WARN log line on a 429 must NEVER contain the raw email — it
+    should carry a short SHA-256 prefix instead. We capture the WARN
+    calls by patching the bound `logger.warning` method directly,
+    which is robust against caplog's full-suite quirks (see the
+    2026-05-11 session journal for the rationale)."""
+    sensitive = "secret-user@example.com"
+    warn_calls: list[tuple[str, tuple]] = []
+
+    def fake_warning(msg: str, *args: object) -> None:
+        warn_calls.append((msg, args))
+
+    monkeypatch.setattr(rate_limit.logger, "warning", fake_warning)
+
+    # Drive a 429.
+    for _ in range(10):
+        _post_login(client, sensitive, "203.0.113.7")
+    _post_login(client, sensitive, "203.0.113.7")
+
+    assert warn_calls, "expected at least one rate-limit warning log"
+    for msg, args in warn_calls:
+        rendered = (msg % args) if args else msg
+        assert sensitive not in rendered
+        assert "secret-user" not in rendered
+
+    # The hash prefix must appear so support can correlate.
+    import hashlib
+
+    expected_prefix = hashlib.sha256(sensitive.encode("utf-8")).hexdigest()[:16]
+    assert any(
+        expected_prefix in ((msg % args) if args else msg)
+        for msg, args in warn_calls
+    )
+
+
+# ---------------------------------------------------------------------------
+# /auth/verify — bucketed by IP and token-prefix
+# ---------------------------------------------------------------------------
+
+
+def test_verify_route_rate_limits_by_ip(
+    client: TestClient, fake_clock: dict[str, datetime]
+) -> None:
+    """Hammering /auth/verify with different tokens from one IP still
+    burns the IP bucket. The 11th request 429s even though every token
+    so far has been distinct (so the per-token-prefix buckets are
+    fresh)."""
+    for i in range(10):
+        response = client.get(
+            "/auth/verify",
+            params={"token": f"token-{i:02d}-abcdef"},
+            headers={"X-Forwarded-For": "10.0.0.1, 203.0.113.9"},
+            follow_redirects=False,
+        )
+        # Token is fake → expect 410, NOT 429. The point is the bucket
+        # decremented.
+        assert response.status_code == 410, f"request {i + 1}: got {response.status_code}"
+
+    response = client.get(
+        "/auth/verify",
+        params={"token": "token-99-abcdef"},
+        headers={"X-Forwarded-For": "10.0.0.1, 203.0.113.9"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 429
+    assert int(response.headers["retry-after"]) >= 1


### PR DESCRIPTION
Closes #12.

## Summary

Adds Postgres-backed token-bucket rate limiting to the two unauthenticated auth endpoints. Each request consumes one token from **two** buckets — IP and a secondary key — and is rejected with HTTP **429 + Retry-After** if either bucket is empty.

| Route | Primary key | Secondary key |
|-------|-------------|----------------|
| \`POST /login\` | \`login:ip:<ip>\` | \`login:email:<normalized-email>\` |
| \`GET /auth/verify\` | \`verify:ip:<ip>\` | \`verify:token-prefix:<8-hex-of-sha256>\` |

10 tokens per hour, linear refill (1 token / 360 s). On exhaustion the service rolls back the partial decrement and returns 429 with \`Retry-After\` set to the seconds until the next token.

## Design choices

- **Postgres, not Redis** — per the ADR: \"Redis would be better; add when traffic justifies it.\" Stays in-process. New \`rate_bucket\` table (migration 006) with three columns: \`key\`, \`tokens\`, \`refilled_at\`.
- **Two buckets per request** — the IP key blocks the single-IP spam vector. The secondary key blocks the distributed-IPs-targeting-one-victim attack: email-bombing a specific address, or brute-forcing a specific token. Both must have tokens or the request is rejected.
- **Token-prefix for verify** — secondary key for \`/auth/verify\` uses the first 8 hex chars of \`SHA-256(token)\` so the \`rate_bucket\` table never stores raw token material.
- **Cloud Run topology** — \`X-Forwarded-For\` is parsed *last-entry-first* because Cloud Run strips client-supplied entries and appends the real client IP at the end.
- **PII discipline** — the rate-limit WARN log emits a 16-hex SHA-256 prefix of the email, never the raw address. The 429 response body is a generic \"try again later\" — no email echo.
- **Test clock injection** — \`rate_limit._now_utc\` is a function reference. Tests monkeypatch it to fake clock advancement (verifies linear refill in \<1 second of real time).

## Definition of Done — Issue #12

- [x] 10 successive requests from one IP succeed, 11th returns 429
- [x] Different IPs are independently bucketed
- [x] Same email from different IPs is bucketed by email key (cross-IP defense)
- [x] \`Retry-After\` between 1 and 3600
- [x] Bucket refills linearly (verified by advancing fake clock 361 s)
- [x] 429 body does not echo the rate-limited email
- [x] WARN log line hashes the email rather than logging it raw
- [x] \`ruff check\` + \`mypy\` + \`pytest\` all pass

## Test plan

- [x] 196 tests pass locally (97.38% coverage; rate-limit service at 97%)
- [x] Migration up/down/up cycle test passes against fresh SQLite
- [ ] Manual: hammer \`/login\` 11 times with the same email + IP, observe 429 with Retry-After
- [ ] Manual: same email from 11 different IPs, observe 429 on the 11th (email bucket exhausted)
- [ ] Manual: wait 6+ minutes, hit the route again, observe 202 (linear refill works)
- [ ] Cloud Logging: trigger a 429, verify the log line shows the email-hash prefix but not the raw address

🤖 Generated with [Claude Code](https://claude.com/claude-code)