### PR TITLE
feat(a11y): Playwright + axe-core test harness under tests/a11y/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,9 @@ logs/
 # never commit. Use scripts/roster.example.csv as the format reference.
 roster.csv
 roster-output.csv
+
+# Accessibility test harness (A11Y-1). Node lives only under tests/a11y/;
+# node_modules/ is already covered by the framework rule above, but
+# Playwright's per-run artifacts get their own entries.
+tests/a11y/test-results/
+tests/a11y/playwright-report/

--- a/tests/a11y/README.md
+++ b/tests/a11y/README.md
@@ -1,0 +1,43 @@
+# Cubrox accessibility tests
+
+Playwright + axe-core harness for WCAG conformance. Production stays
+Node-free; Node lives only in this directory.
+
+## Run locally
+
+```bash
+cd tests/a11y
+npm ci                              # install Playwright + axe-core
+npx playwright install chromium     # one-time browser download (~100 MB)
+npx playwright test                 # spawns the FastAPI app, runs tests
+```
+
+The config's `webServer` block starts `uv run uvicorn app.main:app --port 8080`
+from the repo root, waits for `/api/health` to return 200, then runs
+the tests against `http://localhost:8080`.
+
+## What's here
+
+| File                       | Purpose                                          |
+| -------------------------- | ------------------------------------------------ |
+| `package.json`             | Pinned Playwright + axe-core versions            |
+| `playwright.config.ts`     | Chromium project, webServer wiring, base URL     |
+| `smoke.spec.ts`            | Single test against `/api/health` proving setup  |
+
+## What's coming
+
+This ticket (#24, A11Y-1) is harness-only. Real accessibility assertions
+land in:
+
+- **A11Y-2 (#25)** — axe-core checks across the reading surface and
+  sidebar for every preference combination (font, size, contrast,
+  spacing, column width).
+- **A11Y-3 (#26)** — CI job in `.github/workflows/` so every PR fails
+  if axe-core finds a new violation.
+
+## Why a separate `package.json`
+
+A `package.json` at the repo root would activate the project's CI
+`node` job (which currently auto-skips for Python-only repos). Keeping
+Node scoped to `tests/a11y/` preserves that auto-skip and signals
+clearly that Node isn't a runtime concern for Cubrox.

--- a/tests/a11y/package-lock.json
+++ b/tests/a11y/package-lock.json
@@ -1,0 +1,100 @@
+{
+  "name": "cubrox-a11y-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cubrox-a11y-tests",
+      "devDependencies": {
+        "@axe-core/playwright": "4.11.3",
+        "@playwright/test": "1.60.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/a11y/package.json
+++ b/tests/a11y/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cubrox-a11y-tests",
+  "private": true,
+  "description": "Playwright + axe-core accessibility harness. Scoped to tests/a11y/ — production stays Node-free. See tests/a11y/README.md.",
+  "scripts": {
+    "test": "playwright test",
+    "install-browser": "playwright install chromium"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "4.11.3",
+    "@playwright/test": "1.60.0"
+  }
+}

--- a/tests/a11y/playwright.config.ts
+++ b/tests/a11y/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config for Cubrox accessibility tests.
+ *
+ * The harness spawns the real FastAPI app via `uv run uvicorn` and
+ * waits for /api/health to return 200 before tests start. Tests run in a
+ * single chromium project — axe-core's rule set is browser-independent,
+ * so multi-browser coverage adds no a11y signal.
+ *
+ * Production stays Node-free. This config lives under tests/a11y/ only;
+ * the repo root has no package.json on purpose.
+ */
+export default defineConfig({
+  testDir: ".",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? "github" : "list",
+
+  use: {
+    baseURL: "http://localhost:8080",
+    trace: "retain-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  webServer: {
+    // Run from repo root so `app.main:app` resolves and uv finds pyproject.toml.
+    command: "uv run uvicorn app.main:app --port 8080",
+    cwd: "../..",
+    url: "http://localhost:8080/api/health",
+    timeout: 60_000,
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/tests/a11y/smoke.spec.ts
+++ b/tests/a11y/smoke.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Smoke test for the a11y harness.
+ *
+ * Hits /api/health to prove the webServer started, browser navigated,
+ * and the test runner reports pass/fail correctly. Real accessibility
+ * assertions land in A11Y-2 (#25), which adds axe-core checks against
+ * the reading surface and sidebar across the preference matrix.
+ *
+ * /api/health is intentionally minimal — no DB, no auth — so this test
+ * doesn't depend on Postgres being up. A11Y-2 will figure out the
+ * per-test DB strategy for the real reading-view assertions.
+ */
+test("smoke: /api/health responds 200 and renders", async ({ page }) => {
+  const response = await page.goto("/api/health");
+  expect(response?.status()).toBe(200);
+
+  // The health-check route returns JSON. Confirm the expected status
+  // field is visible in the rendered body so we know we reached the
+  // FastAPI app and not some intermediary error page.
+  const body = await page.locator("body").textContent();
+  expect(body).toContain("ok");
+});


### PR DESCRIPTION
Closes #24.

## Summary

Scaffolds the accessibility test harness so the rest of the WCAG epic (A11Y-2 / A11Y-3) has a foundation to build on. This PR is harness-only: no real a11y assertions yet — those land in #25.

| File | Purpose |
|------|---------|
| \`tests/a11y/package.json\` | Pinned \`@playwright/test 1.60.0\` + \`@axe-core/playwright 4.11.3\` (exact, no \`^\`) |
| \`tests/a11y/playwright.config.ts\` | Chromium-only project, \`webServer\` spawning \`uv run uvicorn\`, waits for \`/api/health\` |
| \`tests/a11y/smoke.spec.ts\` | Single test against \`/api/health\` proving the harness end-to-end |
| \`tests/a11y/README.md\` | Local run instructions + pointer to A11Y-2/A11Y-3 |
| \`.gitignore\` | New entries for Playwright's per-run artifacts |

## Design choices worth flagging

- **Production stays Node-free.** \`package.json\` lives under \`tests/a11y/\` only. The repo root has no \`package.json\`, which preserves the CI \`node\` job's auto-skip for Python-only repos.
- **\`/api/health\` not \`/healthz\`.** Ticket spec referenced \`/healthz\` but the actual route is \`/api/health\` (see [app/api/health.py](app/api/health.py)). Used the real route.
- **Chromium-only.** Axe-core's rule set is browser-independent; running Firefox + WebKit would add 30-60 seconds of CI time for zero additional a11y signal.
- **Versions pinned exactly.** Visual a11y tests are notoriously sensitive to minor-version bumps. \`@axe-core/playwright 4.11.3\` and \`@playwright/test 1.60.0\` pinned without \`^\` or \`~\`.

## Test plan

- [x] \`cd tests/a11y && npm ci && npx playwright install chromium && npx playwright test\` exits 0 locally (smoke test passes in 314ms)
- [x] Python suite untouched: 196 tests pass, ruff + mypy clean
- [x] Repo root has no \`package.json\` (verified via \`ls\`)
- [ ] CI \`node\` job auto-skips on this PR (verify after CI runs — if a Node job tries to run, the auto-skip is broken)
- [ ] Manual: reviewer can run the smoke test command above and see green

## What's NOT in this PR

- Real a11y assertions (those are A11Y-2 / #25)
- CI job that runs the harness on every PR (that's A11Y-3 / #26)
- OS-level Playwright dependencies in the dev container — currently needs \`sudo npx playwright install-deps chromium\` once; if we want to make this seamless for new contributors, that's a Dockerfile/devcontainer follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)