### PR TITLE
feat(a11y): reading-surface axe assertions across preference variants

### DIFF
--- a/app/api/test_seed.py
+++ b/app/api/test_seed.py
@@ -1,0 +1,142 @@
+"""Test-only seed router for the WCAG harness (A11Y-2 #25).
+
+Provides POST /test/seed-passage-and-login, which provisions a fresh
+User + Passage (+ optional Preference row) and returns a signed
+session cookie + the new passage id. Playwright specs hit this once
+per test to set up an authenticated, parameterized reading surface
+without needing email + magic-link plumbing.
+
+## Two-layer guard
+
+This router must never load in production:
+
+1. **Module-level guard** (this file): the import itself raises
+   `RuntimeError` unless `CUBROX_TEST_SEED_ENABLED=true` OR
+   `ENVIRONMENT=test`. Belt-and-braces — even a stray `import` from
+   anywhere in the codebase fails loudly.
+
+2. **Registration-level guard** (app/main.py): the import + router
+   registration is wrapped in `if os.environ.get(...) == "true": ...`.
+   So unless the env var is explicitly set, the module is never
+   imported in the first place.
+
+The CI a11y job sets `CUBROX_TEST_SEED_ENABLED=true` on the FastAPI
+process via `playwright.config.ts > webServer.env`. Production Cloud
+Run revisions do not set this var; the seed router cannot be reached.
+"""
+
+import os
+import uuid
+from datetime import UTC, datetime
+from typing import Annotated, Any, Literal
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from sqlmodel import Session
+
+from app.config import Settings, get_settings
+from app.db import get_session
+from app.models.passage import Passage
+from app.models.preference import Preference
+from app.models.user import User
+from app.services.identity.session import SESSION_COOKIE_NAME, sign_session
+
+_SEED_ENABLED = os.environ.get("CUBROX_TEST_SEED_ENABLED") == "true"
+_TEST_ENV = os.environ.get("ENVIRONMENT") == "test"
+if not (_SEED_ENABLED or _TEST_ENV):
+    raise RuntimeError(
+        "app.api.test_seed loaded in non-test environment. "
+        "Set CUBROX_TEST_SEED_ENABLED=true (test envs only) or "
+        "ENVIRONMENT=test to enable."
+    )
+
+
+router = APIRouter()
+
+SessionDep = Annotated[Session, Depends(get_session)]
+SettingsDep = Annotated[Settings, Depends(get_settings)]
+
+Variant = Literal["default", "high-contrast", "large-text", "bionic"]
+
+# A representative passage with multiple paragraphs so axe-core has a
+# real surface to analyze — headings, paragraph spacing, line wrap, and
+# color contrast over substantive content.
+SEED_PASSAGE_TEXT = (
+    "O Son of Spirit!\n\n"
+    "My first counsel is this: Possess a pure, kindly and radiant heart, "
+    "that thine may be a sovereignty ancient, imperishable and everlasting.\n\n"
+    "O Son of Spirit!\n\n"
+    "The best beloved of all things in My sight is Justice. Turn not away "
+    "therefrom if thou desirest Me, and neglect it not that I may confide in thee."
+)
+
+
+# Per-variant overrides to the stored Preference values. `default` is
+# empty (no row created — the reading view falls back to
+# DEFAULT_PREFERENCES). The other three exercise one axis each so any
+# a11y regression points clearly at which preference broke.
+_PREFS_FOR_VARIANT: dict[str, dict[str, Any]] = {
+    "default": {},
+    "high-contrast": {"bg": "#1a1a1a", "fg": "#e8e8e8"},
+    "large-text": {"size": "28px"},
+    "bionic": {"bionic_enabled": True},
+}
+
+
+@router.post("/test/seed-passage-and-login")
+def seed_passage_and_login(
+    variant: Variant,
+    session: SessionDep,
+    settings: SettingsDep,
+) -> JSONResponse:
+    """Seed a fresh user + passage + (optional) preference; return the
+    session cookie + passage id.
+
+    Each invocation creates an independent user (UUID-suffixed email),
+    so concurrent tests don't collide on the email unique constraint.
+    The cookie is set with `secure=False` because the harness runs over
+    http://localhost — production Cloud Run cookies remain secure-only.
+    """
+    user = User(email=f"a11y-{uuid.uuid4()}@example.test")
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    passage = Passage(
+        user_id=user.id,
+        # Placeholder hash — the read path doesn't validate it; only
+        # the comprehension-cache uses text_hash, which the a11y tests
+        # don't exercise (the questions panel makes a network call we
+        # don't care about for visual a11y).
+        text_hash=b"\x00" * 32,
+        text=SEED_PASSAGE_TEXT,
+        source_type="paste",
+        source_filename=None,
+    )
+    session.add(passage)
+
+    prefs_overrides = _PREFS_FOR_VARIANT[variant]
+    if prefs_overrides:
+        session.add(
+            Preference(
+                user_id=user.id,
+                values=prefs_overrides,
+                updated_at=datetime.now(UTC),
+            )
+        )
+
+    session.commit()
+    session.refresh(passage)
+
+    response = JSONResponse({"passage_id": str(passage.id), "variant": variant})
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=sign_session(user_id=user.id, secret=settings.session_secret),
+        max_age=settings.session_ttl_days * 86400,
+        httponly=True,
+        # Test harness runs over plain HTTP on localhost. Production
+        # cookies stay `secure=True` via the normal /auth/verify path.
+        secure=False,
+        samesite="lax",
+    )
+    return response

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ Run locally:
 Production (Cloud Run) runs the same command — see Dockerfile.
 """
 
+import os
 from pathlib import Path
 
 from fastapi import FastAPI, Request
@@ -53,3 +54,17 @@ app.include_router(todos.router)
 app.include_router(auth.router)
 app.include_router(passages.router)
 app.include_router(reading.router)
+
+# Test-only seed router (A11Y-2 #25). Loaded ONLY when explicitly
+# enabled via env var — production Cloud Run revisions never set this.
+# See app/api/test_seed.py for the module-level guardrail.
+if os.environ.get("CUBROX_TEST_SEED_ENABLED") == "true":
+    from app.api import test_seed  # noqa: PLC0415  intentional conditional import
+    from app.db import create_db_and_tables  # noqa: PLC0415  test-only path
+
+    # Ensure tables exist before the seed router writes to them. The
+    # a11y harness points at a throwaway SQLite file with no migrations
+    # applied; in production, this branch is never reached.
+    create_db_and_tables()
+
+    app.include_router(test_seed.router)

--- a/tests/a11y/README.md
+++ b/tests/a11y/README.md
@@ -13,27 +13,58 @@ npx playwright test                 # spawns the FastAPI app, runs tests
 ```
 
 The config's `webServer` block starts `uv run uvicorn app.main:app --port 8080`
-from the repo root, waits for `/api/health` to return 200, then runs
-the tests against `http://localhost:8080`.
+from the repo root with `CUBROX_TEST_SEED_ENABLED=true` and a few other
+test-only env vars, waits for `/api/health` to return 200, then runs the
+specs against `http://localhost:8080`.
 
 ## What's here
 
-| File                       | Purpose                                          |
-| -------------------------- | ------------------------------------------------ |
-| `package.json`             | Pinned Playwright + axe-core versions            |
-| `playwright.config.ts`     | Chromium project, webServer wiring, base URL     |
-| `smoke.spec.ts`            | Single test against `/api/health` proving setup  |
+| File                              | Purpose                                            |
+| --------------------------------- | -------------------------------------------------- |
+| `package.json`                    | Pinned Playwright + axe-core versions              |
+| `playwright.config.ts`            | Chromium project, webServer wiring, env vars       |
+| `smoke.spec.ts`                   | Single test against `/api/health` proving setup    |
+| `reading_surface.spec.ts`         | Four axe-core tests across preference variants     |
+| `fixtures/seed.ts`                | Helper that calls the seed route + sets the cookie |
 
-## What's coming
+## Test-only seed router
 
-This ticket (#24, A11Y-1) is harness-only. Real accessibility assertions
-land in:
+`reading_surface.spec.ts` provisions an authenticated session + a real
+passage on a fresh user via `POST /test/seed-passage-and-login`. This
+route is implemented in [app/api/test_seed.py](../../app/api/test_seed.py)
+and gated by **two layers**:
 
-- **A11Y-2 (#25)** — axe-core checks across the reading surface and
-  sidebar for every preference combination (font, size, contrast,
-  spacing, column width).
-- **A11Y-3 (#26)** — CI job in `.github/workflows/` so every PR fails
-  if axe-core finds a new violation.
+1. **Module guard** — `app/api/test_seed.py` raises `RuntimeError` on
+   import unless `CUBROX_TEST_SEED_ENABLED=true` OR `ENVIRONMENT=test`.
+2. **Registration guard** — `app/main.py` only imports + mounts the
+   router when `CUBROX_TEST_SEED_ENABLED=true`. Production Cloud Run
+   revisions do not set this var, so the seed router is never loaded.
+
+The Python test suite covers the import guard
+(`tests/test_test_seed_guard.py`) and the route's variant matrix
+(`tests/test_seed_route.py`), so regressions are caught in pytest
+before they ever reach Playwright.
+
+## Preference variants
+
+Each variant in `reading_surface.spec.ts` exercises ONE axis at a time
+so an a11y regression points clearly at which preference broke:
+
+| Variant         | Preference row                                | What it tests             |
+| --------------- | --------------------------------------------- | ------------------------- |
+| `default`       | (no row — falls back to DEFAULT_PREFERENCES)  | The default reading view  |
+| `high-contrast` | `{bg: "#1a1a1a", fg: "#e8e8e8"}`              | Dark-mode contrast        |
+| `large-text`    | `{size: "28px"}`                              | Low-vision text size      |
+| `bionic`        | `{bionic_enabled: true}`                      | The bionicize transform   |
+
+Gate: **zero `serious` or `critical` axe violations** under WCAG 2.0
+A+AA rules. `moderate` and `minor` findings are logged to stdout for
+future tickets to address but do not fail the build.
+
+## CI integration
+
+A11Y-3 (#26) adds a GitHub Actions job that runs this suite on every PR.
+Until that lands, the harness is local-only.
 
 ## Why a separate `package.json`
 
@@ -41,3 +72,15 @@ A `package.json` at the repo root would activate the project's CI
 `node` job (which currently auto-skips for Python-only repos). Keeping
 Node scoped to `tests/a11y/` preserves that auto-skip and signals
 clearly that Node isn't a runtime concern for Cubrox.
+
+## One-time devcontainer setup
+
+Playwright's Chromium needs OS-level libraries (glib, gtk, x11, etc.)
+that aren't in the default devcontainer. If `npx playwright test` errors
+with `libglib-2.0.so.0: cannot open shared object file`:
+
+```bash
+sudo env "PATH=$PATH" npx playwright install-deps chromium
+```
+
+Installs ~30 apt packages and only needs to run once per container.

--- a/tests/a11y/fixtures/seed.ts
+++ b/tests/a11y/fixtures/seed.ts
@@ -1,0 +1,50 @@
+import type { APIRequestContext, BrowserContext } from "@playwright/test";
+
+export type Variant = "default" | "high-contrast" | "large-text" | "bionic";
+
+export interface SeedResult {
+  passageId: string;
+  variant: Variant;
+}
+
+/**
+ * Provision a fresh user + passage (+ optional Preference) via the
+ * test-only seed route, then propagate the session cookie onto the
+ * BrowserContext so navigations are authenticated.
+ *
+ * The /test/seed-passage-and-login route is gated behind
+ * CUBROX_TEST_SEED_ENABLED=true at app boot — see
+ * `app/api/test_seed.py`. Production Cloud Run revisions don't set
+ * the var; the seed route returns 404 there because the router is
+ * never registered.
+ *
+ * Implementation note: Playwright's `request` fixture maintains a
+ * separate cookie jar from the browser context. The seed response's
+ * `Set-Cookie` lands in `request.storageState().cookies`; we copy
+ * those into `context.addCookies(...)` so `page.goto()` carries the
+ * authenticated session.
+ */
+export async function seedAndLogin(
+  request: APIRequestContext,
+  context: BrowserContext,
+  variant: Variant,
+): Promise<SeedResult> {
+  const response = await request.post(
+    `/test/seed-passage-and-login?variant=${variant}`,
+  );
+  if (!response.ok()) {
+    throw new Error(
+      `seed failed: ${response.status()} ${await response.text()}`,
+    );
+  }
+
+  const body = (await response.json()) as {
+    passage_id: string;
+    variant: Variant;
+  };
+
+  const state = await request.storageState();
+  await context.addCookies(state.cookies);
+
+  return { passageId: body.passage_id, variant: body.variant };
+}

--- a/tests/a11y/playwright.config.ts
+++ b/tests/a11y/playwright.config.ts
@@ -40,5 +40,18 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     stdout: "pipe",
     stderr: "pipe",
+    env: {
+      // Enable the test-only seed router (POST /test/seed-passage-and-login)
+      // used by reading_surface.spec.ts. See app/api/test_seed.py for the
+      // module-level guardrail; production Cloud Run never sets this.
+      CUBROX_TEST_SEED_ENABLED: "true",
+      // Harness runs over http://localhost; secure-only cookies would
+      // never be sent back to the seed-issued session.
+      SESSION_COOKIE_SECURE: "false",
+      // Allow the dev-default session secret so seedAndLogin's signed
+      // cookies are verifiable. Config's _refuse_sqlite_outside_dev
+      // gate trips on "dev-only" outside development/test envs.
+      ENVIRONMENT: "test",
+    },
   },
 });

--- a/tests/a11y/reading_surface.spec.ts
+++ b/tests/a11y/reading_surface.spec.ts
@@ -1,0 +1,68 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import { seedAndLogin, type Variant } from "./fixtures/seed";
+
+/**
+ * Reading-surface accessibility assertions (A11Y-2 #25).
+ *
+ * Each test exercises one representative preference combination by
+ * provisioning an isolated user + passage + Preference row via the
+ * test-only seed route, navigating the authenticated browser to
+ * /read/<passage_id>, and running axe-core against the rendered page.
+ *
+ * Gate: ZERO `serious` or `critical` violations under WCAG 2.0 A+AA
+ * rules. `moderate` and `minor` findings are surfaced in the test
+ * output for future follow-up but don't fail the build — those tend
+ * to be opinionated rule judgments rather than user-blocking issues.
+ *
+ * Each variant tests one axis at a time so a regression points
+ * clearly at which preference broke a11y:
+ *   - default      → no Preference row; full DEFAULT_PREFERENCES path
+ *   - high-contrast → dark bg + light fg (dark-mode users)
+ *   - large-text   → 28px font (low-vision users)
+ *   - bionic       → bionic_enabled=true (the bionicize transform)
+ */
+
+const VARIANTS: Variant[] = ["default", "high-contrast", "large-text", "bionic"];
+
+for (const variant of VARIANTS) {
+  test(`reading surface a11y: ${variant}`, async ({ page, context, request }) => {
+    const { passageId } = await seedAndLogin(request, context, variant);
+
+    await page.goto(`/read/${passageId}`);
+    // Wait for the reading-surface element to render — the seed
+    // passage has known content, so we anchor on that.
+    await expect(page.locator("#reading-surface")).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa"])
+      .analyze();
+
+    const blockers = results.violations.filter(
+      (v) => v.impact === "critical" || v.impact === "serious",
+    );
+
+    if (blockers.length > 0) {
+      // Print the violations so failure output is actionable. Each
+      // violation includes the rule id, impact, and the HTML of the
+      // offending node — enough to reproduce locally.
+      console.log(
+        `[a11y blockers — ${variant}]`,
+        JSON.stringify(blockers, null, 2),
+      );
+    }
+
+    // Surface non-blocking findings for future tickets to address.
+    const nonBlocking = results.violations.filter(
+      (v) => v.impact !== "critical" && v.impact !== "serious",
+    );
+    if (nonBlocking.length > 0) {
+      console.log(
+        `[a11y non-blocking — ${variant}]`,
+        nonBlocking.map((v) => `${v.id} (${v.impact})`).join(", "),
+      );
+    }
+
+    expect(blockers, "axe found serious/critical violations").toHaveLength(0);
+  });
+}

--- a/tests/test_seed_route.py
+++ b/tests/test_seed_route.py
@@ -1,0 +1,146 @@
+"""Route-level tests for the test-only seed endpoint (A11Y-2 #25).
+
+These tests exercise the actual POST /test/seed-passage-and-login
+route. The conftest doesn't normally register this router (the
+conditional in `app/main.py` only fires when `CUBROX_TEST_SEED_ENABLED=true`
+at app boot), so we mount the router onto the existing test app via
+FastAPI's `include_router` for the duration of each test.
+
+This is functional coverage of the seed handler — the variant
+matrix, the cookie shape, the row counts that the Playwright suite
+implicitly relies on. Pytest catches regressions before Playwright
+has to.
+"""
+
+import importlib
+import sys
+import uuid
+from collections.abc import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.main import app
+from app.models.passage import Passage
+from app.models.preference import Preference
+from app.models.user import User
+
+
+@pytest.fixture
+def seed_client(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+) -> Generator[TestClient, None, None]:
+    """TestClient with the seed router temporarily mounted on the app.
+
+    The guard inside app/api/test_seed.py needs ENVIRONMENT=test (the
+    pytest default for our conftest is `development`, so set it
+    explicitly). After the test runs, the router is removed from the
+    app so other tests don't see it.
+    """
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    sys.modules.pop("app.api.test_seed", None)
+    test_seed = importlib.import_module("app.api.test_seed")
+
+    app.include_router(test_seed.router)
+    try:
+        yield client
+    finally:
+        # Remove the seed routes so subsequent tests don't see them.
+        # FastAPI doesn't expose a public "remove_router"; pop the
+        # routes we just added by path-prefix match.
+        app.router.routes = [
+            r
+            for r in app.router.routes
+            if not (
+                hasattr(r, "path") and r.path == "/test/seed-passage-and-login"  # type: ignore[attr-defined]
+            )
+        ]
+
+
+def test_seed_default_variant_creates_user_passage_no_preference(
+    seed_client: TestClient, session: Session
+) -> None:
+    """`default` is the no-Preference path — the reading view falls back
+    to DEFAULT_PREFERENCES without a row."""
+    response = seed_client.post(
+        "/test/seed-passage-and-login?variant=default", follow_redirects=False
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["variant"] == "default"
+    # passage_id is a parseable UUID.
+    uuid.UUID(body["passage_id"])
+
+    # Exactly one user + one passage + zero preferences.
+    assert len(session.exec(select(User)).all()) == 1
+    assert len(session.exec(select(Passage)).all()) == 1
+    assert len(session.exec(select(Preference)).all()) == 0
+
+    # Cookie was set so subsequent /read/{id} requests are authenticated.
+    assert "session" in response.cookies
+
+
+def test_seed_high_contrast_variant_writes_dark_bg_fg(
+    seed_client: TestClient, session: Session
+) -> None:
+    response = seed_client.post(
+        "/test/seed-passage-and-login?variant=high-contrast", follow_redirects=False
+    )
+    assert response.status_code == 200
+
+    prefs = session.exec(select(Preference)).all()
+    assert len(prefs) == 1
+    assert prefs[0].values == {"bg": "#1a1a1a", "fg": "#e8e8e8"}
+
+
+def test_seed_large_text_variant_writes_28px(
+    seed_client: TestClient, session: Session
+) -> None:
+    response = seed_client.post(
+        "/test/seed-passage-and-login?variant=large-text", follow_redirects=False
+    )
+    assert response.status_code == 200
+
+    prefs = session.exec(select(Preference)).all()
+    assert len(prefs) == 1
+    assert prefs[0].values == {"size": "28px"}
+
+
+def test_seed_bionic_variant_writes_bionic_enabled_true(
+    seed_client: TestClient, session: Session
+) -> None:
+    response = seed_client.post(
+        "/test/seed-passage-and-login?variant=bionic", follow_redirects=False
+    )
+    assert response.status_code == 200
+
+    prefs = session.exec(select(Preference)).all()
+    assert len(prefs) == 1
+    assert prefs[0].values == {"bionic_enabled": True}
+
+
+def test_seed_unknown_variant_returns_422(seed_client: TestClient) -> None:
+    """The route uses a typing.Literal for the variant param. FastAPI
+    rejects unknown values with 422 automatically."""
+    response = seed_client.post(
+        "/test/seed-passage-and-login?variant=does-not-exist",
+        follow_redirects=False,
+    )
+    assert response.status_code == 422
+
+
+def test_seed_creates_independent_users_across_calls(
+    seed_client: TestClient, session: Session
+) -> None:
+    """Each call creates a unique user (UUID-suffixed email) so
+    Playwright tests can run in parallel without colliding on the
+    email unique constraint."""
+    seed_client.post("/test/seed-passage-and-login?variant=default")
+    seed_client.post("/test/seed-passage-and-login?variant=default")
+
+    users = session.exec(select(User)).all()
+    assert len(users) == 2
+    assert users[0].email != users[1].email
+    assert all(u.email.startswith("a11y-") for u in users)

--- a/tests/test_seed_route.py
+++ b/tests/test_seed_route.py
@@ -95,9 +95,7 @@ def test_seed_high_contrast_variant_writes_dark_bg_fg(
     assert prefs[0].values == {"bg": "#1a1a1a", "fg": "#e8e8e8"}
 
 
-def test_seed_large_text_variant_writes_28px(
-    seed_client: TestClient, session: Session
-) -> None:
+def test_seed_large_text_variant_writes_28px(seed_client: TestClient, session: Session) -> None:
     response = seed_client.post(
         "/test/seed-passage-and-login?variant=large-text", follow_redirects=False
     )

--- a/tests/test_test_seed_guard.py
+++ b/tests/test_test_seed_guard.py
@@ -1,0 +1,60 @@
+"""Guard-rail test for the test-only seed router (A11Y-2 #25).
+
+`app/api/test_seed.py` must NEVER load in a non-test environment.
+The module's import-time guard raises RuntimeError unless one of:
+  - CUBROX_TEST_SEED_ENABLED=true (set explicitly by the a11y harness)
+  - ENVIRONMENT=test (set by the conftest in unit-test runs)
+
+This test simulates a production-like env (neither var set to a test
+value) and confirms the import fails.
+"""
+
+import importlib
+import sys
+
+import pytest
+
+
+def test_test_seed_refuses_to_load_in_non_test_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Belt-and-braces: even if someone bypasses the conditional import
+    in app/main.py and tries to import the module directly, the
+    module-level guard fires."""
+    monkeypatch.delenv("CUBROX_TEST_SEED_ENABLED", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "production")
+
+    # Drop any previously cached import so we re-execute the module body
+    # and re-run the guard.
+    sys.modules.pop("app.api.test_seed", None)
+
+    with pytest.raises(RuntimeError, match="non-test environment"):
+        importlib.import_module("app.api.test_seed")
+
+
+def test_test_seed_loads_when_explicitly_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sanity check: with the harness env var set, the import succeeds
+    and the router object is exposed. Mirrors what app/main.py does at
+    boot when CUBROX_TEST_SEED_ENABLED=true."""
+    monkeypatch.setenv("CUBROX_TEST_SEED_ENABLED", "true")
+    monkeypatch.setenv("ENVIRONMENT", "production")  # still allowed by the guard
+    sys.modules.pop("app.api.test_seed", None)
+
+    module = importlib.import_module("app.api.test_seed")
+    assert hasattr(module, "router")
+
+
+def test_test_seed_loads_in_test_environment_without_enable_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pytest conftest may not set CUBROX_TEST_SEED_ENABLED, but
+    setting ENVIRONMENT=test is sufficient. This is the "running under
+    pytest with explicit env=test" path."""
+    monkeypatch.delenv("CUBROX_TEST_SEED_ENABLED", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    sys.modules.pop("app.api.test_seed", None)
+
+    module = importlib.import_module("app.api.test_seed")
+    assert hasattr(module, "router")


### PR DESCRIPTION
Closes #25.

## Summary

Layers four axe-core assertions onto the A11Y-1 harness — one per representative preference variant — and adds the test-only seed route those assertions need to provision authenticated reading-view pages.

| Variant         | Preference row                                | Tests                       |
| --------------- | --------------------------------------------- | --------------------------- |
| \`default\`       | (no row — falls back to defaults)             | Default reading view        |
| \`high-contrast\` | \`{bg: "#1a1a1a", fg: "#e8e8e8"}\`              | Dark-mode contrast          |
| \`large-text\`    | \`{size: "28px"}\`                              | Low-vision text size        |
| \`bionic\`        | \`{bionic_enabled: true}\`                      | Bionicize transform         |

**Gate:** zero \`serious\` or \`critical\` violations under WCAG 2.0 A+AA rules. \`moderate\` and \`minor\` findings are surfaced to stdout for future-ticket triage but don't fail the build.

## The test-only seed route

New \`POST /test/seed-passage-and-login?variant=<v>\` route in \`app/api/test_seed.py\`. Provisions a fresh user + passage + (optional) Preference row, returns the session cookie + passage_id. **Production never sees this route**, gated by two layers:

1. **Module guard** — the import itself raises \`RuntimeError\` unless \`CUBROX_TEST_SEED_ENABLED=true\` OR \`ENVIRONMENT=test\`. Belt-and-braces against accidental import from anywhere.
2. **Registration guard** — \`app/main.py\` only imports + mounts the router when \`CUBROX_TEST_SEED_ENABLED=true\`. The Playwright \`webServer.env\` block sets this; Cloud Run revisions don't.

## Coverage discipline

The Playwright suite exercises the route end-to-end, but pytest gets 9 new Python tests too (3 import-guard + 6 route-variant) so regressions are caught in CI before Playwright even runs.

| Surface | Tests added |
| ------- | ----------- |
| Import-guard refuses non-test envs | 3 in \`tests/test_test_seed_guard.py\` |
| Route variant matrix + cookie + unknown-variant 422 | 6 in \`tests/test_seed_route.py\` |
| axe-core blockers per variant | 4 in \`tests/a11y/reading_surface.spec.ts\` |

## Test plan

- [x] All 4 reading-surface a11y tests pass locally (zero serious/critical violations across variants)
- [x] All 205 Python tests pass (96.62% coverage; \`app/api/test_seed.py\` at 100%)
- [x] \`ruff check\` + \`mypy\` clean
- [x] Smoke test from A11Y-1 still passes
- [x] Repo root still has no \`package.json\` (CI \`node\` job auto-skips)
- [ ] Manual: reviewer can run \`cd tests/a11y && CUBROX_TEST_SEED_ENABLED=true npx playwright test reading_surface.spec.ts\` and see 4 green tests
- [ ] Manual: confirm in FastAPI startup logs that the seed router is registered when env var is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)