### PR TITLE
ci(a11y): add a11y job to ci.yml gating PRs on axe-core violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,3 +204,81 @@ jobs:
       - name: Build
         if: steps.check_node.outputs.skip != 'true'
         run: npm run build
+
+  a11y:
+    # Accessibility & WCAG gate (A11Y-3 #26). Boots the FastAPI app with
+    # CUBROX_TEST_SEED_ENABLED=true so the test-only seed router is
+    # mounted, then runs Playwright + axe-core against the reading
+    # surface across four preference variants. Zero serious/critical
+    # WCAG 2.0 A+AA violations is the merge gate.
+    #
+    # Scope: only triggers on the workflow's existing triggers (push to
+    # main, pull_request to main, workflow_call from preview-deploy.yml).
+    # No path filters — a change to templates/, app/, or pyproject.toml
+    # can all regress the surface, so always run.
+    name: a11y
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install Python dependencies
+        run: uv sync --extra dev
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'tests/a11y/package-lock.json'
+
+      - name: Install Node dependencies
+        working-directory: tests/a11y
+        run: npm ci
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        working-directory: tests/a11y
+        # Read the pinned version from package-lock.json so the cache
+        # key changes when the bump lands.
+        run: |
+          version=$(node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers + OS deps
+        working-directory: tests/a11y
+        # `--with-deps` runs apt-get install for libglib/libnss/etc. on
+        # every job (not cached), but the heavy browser-binary download
+        # is gated by the cache step above.
+        run: npx playwright install --with-deps chromium
+
+      - name: Run accessibility tests
+        working-directory: tests/a11y
+        # CUBROX_TEST_SEED_ENABLED, SESSION_COOKIE_SECURE, and
+        # ENVIRONMENT are also set inside playwright.config.ts >
+        # webServer.env, so the FastAPI subprocess sees them
+        # regardless of whether the job-level env propagates.
+        env:
+          CUBROX_TEST_SEED_ENABLED: 'true'
+          SESSION_COOKIE_SECURE: 'false'
+          ENVIRONMENT: 'test'
+        run: npx playwright test
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a11y-report-${{ github.sha }}
+          path: tests/a11y/playwright-report/
+          retention-days: 14
+          if-no-files-found: ignore


### PR DESCRIPTION
Closes #26.

## Summary

Adds an \`a11y\` job to \`.github/workflows/ci.yml\` that runs the Playwright + axe-core suite from A11Y-1/A11Y-2 on every workflow trigger (push to main, pull_request to main, workflow_call from \`preview-deploy.yml\`).

With this in place, the **Accessibility & WCAG epic is complete** — every PR is gated on zero serious/critical WCAG 2.0 A+AA violations across the four preference variants (\`default\`, \`high-contrast\`, \`large-text\`, \`bionic\`).

## What the job does

1. Checkout + setup uv + \`uv sync --extra dev\` (FastAPI deps for the test webServer)
2. Setup Node 20 with npm cache keyed on \`tests/a11y/package-lock.json\`
3. \`npm ci\` in \`tests/a11y/\`
4. Resolve Playwright version from the lockfile, restore browser cache keyed on it
5. \`npx playwright install --with-deps chromium\` (browser cached; apt deps re-run every job ~60s)
6. \`npx playwright test\` with \`CUBROX_TEST_SEED_ENABLED=true\` etc. in the env
7. On failure: upload \`tests/a11y/playwright-report/\` as artifact \`a11y-report-<sha>\` (14-day retention)

## Database choice

SQLite. The existing seed router calls \`create_db_and_tables()\` at app boot when \`CUBROX_TEST_SEED_ENABLED=true\`, so a fresh ephemeral runner has a working DB on first request. No Postgres service container needed. This matches the local-dev path from A11Y-2.

## What I deliberately did NOT do

- **No path filters** (per ticket guardrail): a change to \`templates/\`, \`app/\`, or \`pyproject.toml\` can all regress the reading surface, so the job runs on every PR.
- **No root \`package.json\`**: the existing \`node\` job's auto-skip continues to fire. Node is still scoped to \`tests/a11y/\`.
- **No devcontainer changes**: \`npx playwright install --with-deps\` handles OS-level deps in CI on its own. The local dev story is still "run \`sudo npx playwright install-deps chromium\` once" — documented in \`tests/a11y/README.md\`.

## ACTION REQUIRED — branch protection (manual, after merge)

The new \`a11y\` check needs to be added to the required-checks list on \`main\` so PRs are actually blocked from merge. This PR doesn't change protection (agents can't); the first PR opened **after this merges** will show \`a11y\` in its status checks list — that's the cue to add it.

Without this manual step, PRs can still merge with a red a11y job. The check will run and report, but won't gate.

## Test plan

- [x] \`actionlint\` clean on the updated \`ci.yml\`
- [x] \`./scripts/validation/validate-scripts.sh\` passes
- [ ] Watch this PR's CI: the new \`a11y\` job should appear and pass (the 4 reading-surface tests + 1 smoke = 5 green)
- [ ] After merge: confirm the first PR opened against \`main\` shows \`a11y\` in its status checks
- [ ] Maintainer: add \`a11y\` to required checks on \`main\` branch protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)