### PR TITLE
feat(metric): reading_event table + Alembic migration

### DIFF
--- a/alembic/versions/007_add_reading_event.py
+++ b/alembic/versions/007_add_reading_event.py
@@ -1,0 +1,80 @@
+"""add reading_event table
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-05-14
+
+Append-only event table for the "100k lines processed" PRD success
+metric (Epic #7). One row per beacon dispatched on passage-close
+(METRIC-2). The aggregate query (METRIC-3) groups by `occurred_at`
+date — hence the single-column index on that column.
+
+CASCADE on both FKs: a reading event without its user or its passage
+is unattributable, so it goes away with them. Append-only — no
+`updated_at` column, no UPDATE path expected.
+
+UUID handling mirrors revisions 003 and 004: native on Postgres,
+CHAR(36) on SQLite for the in-memory test database.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "007"
+down_revision: str | None = "006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_pg = bind.dialect.name == "postgresql"
+    uuid_type: sa.types.TypeEngine = sa.Uuid() if is_pg else sa.String(length=36)
+
+    op.create_table(
+        "reading_event",
+        sa.Column(
+            "id",
+            uuid_type,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()") if is_pg else None,
+        ),
+        sa.Column(
+            "user_id",
+            uuid_type,
+            sa.ForeignKey("user.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "passage_id",
+            uuid_type,
+            sa.ForeignKey("passage.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("lines_processed", sa.Integer(), nullable=False),
+        sa.Column(
+            "occurred_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        # Append-only domain: a 0-line event is meaningless noise.
+        # CHECK runs in both Postgres and SQLite.
+        sa.CheckConstraint(
+            "lines_processed >= 1",
+            name="reading_event_lines_processed_positive",
+        ),
+    )
+
+    # METRIC-3's aggregate query groups by date; this is the index that
+    # makes that fast. Per the ticket: do NOT add (user_id, occurred_at)
+    # until METRIC-3 surfaces a per-user query.
+    op.create_index("ix_reading_event_occurred_at", "reading_event", ["occurred_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_reading_event_occurred_at", table_name="reading_event")
+    op.drop_table("reading_event")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.magic_link_token import MagicLinkToken
 from app.models.passage import Passage
 from app.models.preference import Preference
 from app.models.rate_bucket import RateBucket
+from app.models.reading_event import ReadingEvent
 from app.models.todo import Todo
 from app.models.user import User
 
@@ -14,6 +15,7 @@ __all__ = [
     "Passage",
     "Preference",
     "RateBucket",
+    "ReadingEvent",
     "Todo",
     "User",
 ]

--- a/app/models/reading_event.py
+++ b/app/models/reading_event.py
@@ -1,0 +1,54 @@
+"""ReadingEvent model.
+
+Append-only record of "a user finished reading some lines of a
+passage". METRIC-2 (#22) writes one row per beacon dispatched on
+passage-close. METRIC-3 (#23) aggregates them for the "100,000 lines
+processed in three months" PRD success metric.
+
+Design choices:
+  - Append-only: no `updated_at` column, no UPDATE path anywhere.
+    Reading is observed, not edited.
+  - `lines_processed` is `INT NOT NULL, CHECK >= 1` — every event
+    must claim at least one line. Zero would just be noise.
+  - `occurred_at` is server-defaulted to `now()` so the writer in
+    METRIC-2 can rely on the database's clock (consistent across
+    Cloud Run instances).
+  - CASCADE on both FKs: deleting a user or a passage takes their
+    reading events too — orphan rows have no meaning.
+
+Indexes:
+  - `ix_reading_event_occurred_at` for the date-range aggregate in
+    METRIC-3. No composite (user_id, occurred_at) index yet — the
+    aggregate is cross-user, and adding indexes ahead of an
+    observed query is premature.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from sqlmodel import Field, SQLModel
+
+
+class ReadingEvent(SQLModel, table=True):
+    __tablename__ = "reading_event"
+    # Mirror the migration's CHECK constraint here too so
+    # `SQLModel.metadata.create_all` (used by the test conftest) also
+    # enforces the >=1 invariant. Without this, the tests would see a
+    # 0-line row succeed even though Alembic-managed Postgres rejects it.
+    __table_args__ = (
+        sa.CheckConstraint(
+            "lines_processed >= 1",
+            name="reading_event_lines_processed_positive",
+        ),
+    )
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    user_id: uuid.UUID = Field(foreign_key="user.id", nullable=False)
+    passage_id: uuid.UUID = Field(foreign_key="passage.id", nullable=False)
+    lines_processed: int = Field(nullable=False)
+    # Python-side default mirrors the migration's `server_default=now()`.
+    # Either layer alone would do the job; both means a stray
+    # `ReadingEvent(...)` without `occurred_at` works whether or not the
+    # writer relies on the DB's clock.
+    occurred_at: datetime = Field(default_factory=lambda: datetime.now(UTC), nullable=False)

--- a/tests/test_reading_event_migration.py
+++ b/tests/test_reading_event_migration.py
@@ -1,0 +1,209 @@
+"""Migration cycle test for the reading_event table (revision 007).
+
+Mirrors the existing migration tests, with an additional CASCADE-
+delete test that runs against the Alembic-applied schema (the default
+test engine in conftest.py does not enable SQLite FK enforcement, so
+CASCADE behavior can only be observed in an engine that explicitly
+turns it on).
+"""
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from sqlalchemy import Engine, create_engine, event, inspect, text
+
+from alembic import command
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _enable_sqlite_foreign_keys(engine: Engine) -> None:
+    """Force SQLite to enforce ON DELETE CASCADE.
+
+    Postgres enforces FKs unconditionally; SQLite only does so when the
+    `foreign_keys` PRAGMA is on, and the pragma is per-connection. The
+    event listener ensures every new connection from this engine pool
+    gets the pragma set before any DML runs.
+    """
+
+    @event.listens_for(engine, "connect")
+    def _set_pragma(dbapi_conn, _) -> None:  # noqa: ANN001 - SQLAlchemy callback signature
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+
+@pytest.fixture
+def alembic_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Config:
+    db_path = tmp_path / "reading_event_migration_test.db"
+    db_url = f"sqlite:///{db_path}"
+
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+
+    cfg = Config(str(REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(REPO_ROOT / "alembic"))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    return cfg
+
+
+def test_upgrade_creates_reading_event_table(alembic_cfg: Config) -> None:
+    command.upgrade(alembic_cfg, "007")
+
+    db_url = alembic_cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+    engine = create_engine(db_url)
+    inspector = inspect(engine)
+
+    assert "reading_event" in inspector.get_table_names()
+
+    cols = {c["name"] for c in inspector.get_columns("reading_event")}
+    assert cols == {"id", "user_id", "passage_id", "lines_processed", "occurred_at"}
+
+    pk = inspector.get_pk_constraint("reading_event")
+    assert pk["constrained_columns"] == ["id"]
+
+    # Both FKs land with the right referent.
+    fks = inspector.get_foreign_keys("reading_event")
+    fk_targets = {(fk["referred_table"], tuple(fk["referred_columns"])) for fk in fks}
+    assert ("user", ("id",)) in fk_targets
+    assert ("passage", ("id",)) in fk_targets
+
+    # The dashboard's date-range query in METRIC-3 leans on this index.
+    indexes = {ix["name"] for ix in inspector.get_indexes("reading_event")}
+    assert "ix_reading_event_occurred_at" in indexes
+
+    # Composite (user_id, occurred_at) MUST NOT exist yet — per ticket
+    # guardrail, premature index. Adding it later in METRIC-3 is fine.
+    assert not any(
+        set(ix["column_names"]) == {"user_id", "occurred_at"}
+        for ix in inspector.get_indexes("reading_event")
+    )
+
+
+def test_upgrade_downgrade_upgrade_cycle(alembic_cfg: Config) -> None:
+    command.upgrade(alembic_cfg, "007")
+    command.downgrade(alembic_cfg, "006")
+
+    db_url = alembic_cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+    engine = create_engine(db_url)
+    inspector = inspect(engine)
+
+    table_names = inspector.get_table_names()
+    assert "reading_event" not in table_names
+    # Earlier migrations untouched.
+    assert "user" in table_names
+    assert "passage" in table_names
+    assert "rate_bucket" in table_names
+
+    command.upgrade(alembic_cfg, "007")
+    inspector = inspect(engine)
+    assert "reading_event" in inspector.get_table_names()
+
+
+def test_delete_user_cascades_to_reading_events(alembic_cfg: Config) -> None:
+    """Deleting a User must take their ReadingEvent rows with them —
+    orphan events have no meaning. Verified against the
+    Alembic-applied schema with SQLite FK enforcement on."""
+    command.upgrade(alembic_cfg, "007")
+
+    db_url = alembic_cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+    engine = create_engine(db_url)
+    _enable_sqlite_foreign_keys(engine)
+
+    user_id = str(uuid.uuid4())
+    passage_id = str(uuid.uuid4())
+    event_id = str(uuid.uuid4())
+
+    with engine.begin() as conn:
+        conn.execute(
+            text("INSERT INTO user (id, email, created_at) VALUES (:id, :email, :ts)"),
+            {"id": user_id, "email": "drop@example.com", "ts": datetime.now(UTC)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO passage (id, user_id, text, text_hash, source_type) "
+                "VALUES (:id, :user_id, :text, :text_hash, :source_type)"
+            ),
+            {
+                "id": passage_id,
+                "user_id": user_id,
+                "text": "lorem",
+                "text_hash": b"\x00" * 32,
+                "source_type": "paste",
+            },
+        )
+        conn.execute(
+            text(
+                "INSERT INTO reading_event (id, user_id, passage_id, lines_processed) "
+                "VALUES (:id, :user_id, :passage_id, :lp)"
+            ),
+            {"id": event_id, "user_id": user_id, "passage_id": passage_id, "lp": 5},
+        )
+
+    with engine.begin() as conn:
+        conn.execute(text("DELETE FROM user WHERE id = :id"), {"id": user_id})
+
+    with engine.connect() as conn:
+        remaining = conn.execute(
+            text("SELECT COUNT(*) FROM reading_event WHERE id = :id"),
+            {"id": event_id},
+        ).scalar()
+    assert remaining == 0
+
+
+def test_delete_passage_cascades_to_reading_events(alembic_cfg: Config) -> None:
+    """Same CASCADE invariant for the passage parent."""
+    command.upgrade(alembic_cfg, "007")
+
+    db_url = alembic_cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+    engine = create_engine(db_url)
+    _enable_sqlite_foreign_keys(engine)
+
+    user_id = str(uuid.uuid4())
+    passage_id = str(uuid.uuid4())
+    event_id = str(uuid.uuid4())
+
+    with engine.begin() as conn:
+        conn.execute(
+            text("INSERT INTO user (id, email, created_at) VALUES (:id, :email, :ts)"),
+            {"id": user_id, "email": "drop-passage@example.com", "ts": datetime.now(UTC)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO passage (id, user_id, text, text_hash, source_type) "
+                "VALUES (:id, :user_id, :text, :text_hash, :source_type)"
+            ),
+            {
+                "id": passage_id,
+                "user_id": user_id,
+                "text": "lorem",
+                "text_hash": b"\x00" * 32,
+                "source_type": "paste",
+            },
+        )
+        conn.execute(
+            text(
+                "INSERT INTO reading_event (id, user_id, passage_id, lines_processed) "
+                "VALUES (:id, :user_id, :passage_id, :lp)"
+            ),
+            {"id": event_id, "user_id": user_id, "passage_id": passage_id, "lp": 5},
+        )
+
+    with engine.begin() as conn:
+        conn.execute(text("DELETE FROM passage WHERE id = :id"), {"id": passage_id})
+
+    with engine.connect() as conn:
+        remaining = conn.execute(
+            text("SELECT COUNT(*) FROM reading_event WHERE id = :id"),
+            {"id": event_id},
+        ).scalar()
+    assert remaining == 0

--- a/tests/test_reading_event_model.py
+++ b/tests/test_reading_event_model.py
@@ -1,0 +1,157 @@
+"""Tests for the ReadingEvent model (METRIC-1 #21).
+
+Covers persistence + the CHECK invariant. CASCADE behavior is tested
+in tests/test_reading_event_migration.py against an Alembic-applied
+schema with SQLite FK enforcement explicitly enabled — the default
+test engine does not enforce FKs.
+"""
+
+import time
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+import sqlalchemy.exc
+from sqlmodel import Session, select
+
+from app.models.passage import Passage
+from app.models.reading_event import ReadingEvent
+from app.models.user import User
+
+
+def _seed_user_and_passage(session: Session) -> tuple[User, Passage]:
+    user = User(email="reader@example.com")
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    passage = Passage(
+        user_id=user.id,
+        text="lorem ipsum",
+        text_hash=b"\x00" * 32,
+        source_type="paste",
+    )
+    session.add(passage)
+    session.commit()
+    session.refresh(passage)
+    return user, passage
+
+
+def test_insert_and_select_roundtrip(session: Session) -> None:
+    user, passage = _seed_user_and_passage(session)
+
+    event = ReadingEvent(
+        user_id=user.id,
+        passage_id=passage.id,
+        lines_processed=42,
+    )
+    session.add(event)
+    session.commit()
+
+    rows = session.exec(select(ReadingEvent)).all()
+    assert len(rows) == 1
+    saved = rows[0]
+    assert saved.user_id == user.id
+    assert saved.passage_id == passage.id
+    assert saved.lines_processed == 42
+
+
+def test_occurred_at_defaults_to_now_when_unset(session: Session) -> None:
+    """Both layers (model default_factory + migration's server_default
+    `now()`) cover this. Under the model-level test path, the
+    default_factory fires before INSERT, so we assert it lands close
+    to wall-clock time."""
+    user, passage = _seed_user_and_passage(session)
+    before = datetime.now(UTC)
+    time.sleep(0.001)  # ensure default is strictly between before/after
+
+    event = ReadingEvent(user_id=user.id, passage_id=passage.id, lines_processed=1)
+    session.add(event)
+    session.commit()
+    session.refresh(event)
+
+    occurred = event.occurred_at
+    if occurred.tzinfo is None:
+        # SQLite round-trips TIMESTAMPTZ as naive; treat as UTC.
+        occurred = occurred.replace(tzinfo=UTC)
+    after = datetime.now(UTC)
+    assert before <= occurred <= after
+    # Within 1 second of "now" per the ticket DoD.
+    assert (after - occurred).total_seconds() < 1.0
+
+
+def test_lines_processed_zero_is_rejected(session: Session) -> None:
+    """The CHECK constraint rejects 0 (and any negative). The error
+    surfaces from the DB at commit time as IntegrityError."""
+    user, passage = _seed_user_and_passage(session)
+
+    event = ReadingEvent(user_id=user.id, passage_id=passage.id, lines_processed=0)
+    session.add(event)
+    with pytest.raises(sqlalchemy.exc.IntegrityError):
+        session.commit()
+    session.rollback()
+
+
+def test_lines_processed_negative_is_rejected(session: Session) -> None:
+    """Belt-and-braces: the same CHECK that catches 0 also catches
+    negative values."""
+    user, passage = _seed_user_and_passage(session)
+
+    event = ReadingEvent(user_id=user.id, passage_id=passage.id, lines_processed=-5)
+    session.add(event)
+    with pytest.raises(sqlalchemy.exc.IntegrityError):
+        session.commit()
+    session.rollback()
+
+
+def test_explicit_occurred_at_is_respected(session: Session) -> None:
+    """If the writer (METRIC-2) chooses to supply `occurred_at`
+    explicitly — e.g. backfilling a historical event — the model
+    accepts it rather than overwriting with `now()`."""
+    user, passage = _seed_user_and_passage(session)
+    historical = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    event = ReadingEvent(
+        user_id=user.id,
+        passage_id=passage.id,
+        lines_processed=10,
+        occurred_at=historical,
+    )
+    session.add(event)
+    session.commit()
+    session.refresh(event)
+
+    saved = event.occurred_at
+    if saved.tzinfo is None:
+        saved = saved.replace(tzinfo=UTC)
+    assert saved == historical
+
+
+def test_distinct_user_passage_pairs_persist_independently(session: Session) -> None:
+    """A user can read many passages; two events for the same
+    (user, passage) pair are also fine — append-only by design, no
+    unique constraint."""
+    user, passage = _seed_user_and_passage(session)
+    session.add(ReadingEvent(user_id=user.id, passage_id=passage.id, lines_processed=3))
+    session.add(ReadingEvent(user_id=user.id, passage_id=passage.id, lines_processed=7))
+    session.commit()
+
+    rows = session.exec(select(ReadingEvent)).all()
+    assert len(rows) == 2
+    assert sum(r.lines_processed for r in rows) == 10
+
+
+def test_unique_ids_per_event(session: Session) -> None:
+    """Default `id=default_factory=uuid.uuid4` produces distinct PKs
+    so two rapid inserts don't collide on PK."""
+    user, passage = _seed_user_and_passage(session)
+    e1 = ReadingEvent(user_id=user.id, passage_id=passage.id, lines_processed=1)
+    e2 = ReadingEvent(user_id=user.id, passage_id=passage.id, lines_processed=1)
+    session.add_all([e1, e2])
+    session.commit()
+
+    assert e1.id != e2.id
+    # And both are valid UUIDs (sanity — caught by type but worth
+    # asserting at runtime in case anyone changes the default factory).
+    uuid.UUID(str(e1.id))
+    uuid.UUID(str(e2.id))


### PR DESCRIPTION
Closes #21.

## Summary

Lays the persistence layer for the PRD's "100,000 lines of text processed within 3 months" success metric. This PR is XS-sized and ships nothing user-visible — but it's the foundation that METRIC-2 (#22, writes events) and METRIC-3 (#23, aggregates them) build on.

## Schema

| Column            | Type         | Constraints                                |
| ----------------- | ------------ | ------------------------------------------ |
| \`id\`              | UUID         | PRIMARY KEY                                |
| \`user_id\`         | UUID         | FK → \`user(id)\` ON DELETE CASCADE          |
| \`passage_id\`      | UUID         | FK → \`passage(id)\` ON DELETE CASCADE       |
| \`lines_processed\` | INT          | NOT NULL, CHECK >= 1                       |
| \`occurred_at\`     | TIMESTAMPTZ  | NOT NULL, DEFAULT now()                    |

Plus an index on \`occurred_at\` for METRIC-3's date-range aggregate.

## Design choices flagged

- **Append-only by design.** No \`updated_at\` column. Reading is observed, not edited.
- **CASCADE on both FKs.** A reading event without its user OR its passage is unattributable — it goes away with them. Verified against the Alembic-applied schema (the default test engine doesn't enable SQLite FK enforcement; the cascade tests turn it on explicitly).
- **CHECK >= 1 in two places.** The migration declares it, AND the SQLModel \`__table_args__\` declares it. The duplication means \`SQLModel.metadata.create_all\` (the conftest path) enforces the same invariant Postgres will — so the rejection tests work in pytest.
- **No \`(user_id, occurred_at)\` index yet.** Per ticket guardrail: premature indexing. METRIC-3 may add it once a per-user query is observed.

## Test plan

- [x] 11 new tests across two files (7 model + 4 migration)
- [x] CASCADE delete tests for both \`user\` and \`passage\` parents
- [x] CHECK rejects 0 and negative values
- [x] \`occurred_at\` defaults to now() within 1 second
- [x] Migration up/down/up cycle clean
- [x] 216 total tests pass, 96.68% coverage, ruff/mypy clean
- [ ] Reviewer can: run \`uv run alembic upgrade head\` against a Neon branch, \`\\\\d reading_event\` in psql, confirm schema

## Test coverage notes

- \`app/models/reading_event.py\` at 100%
- The CASCADE test enables SQLite's \`PRAGMA foreign_keys=ON\` via an engine event listener (per-connection, fires on every new connection from the pool). Postgres enforces FKs unconditionally; the explicit pragma is SQLite-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)