### PR TITLE
feat(metric): beacon endpoint on passage close

### DIFF
--- a/app/api/reading.py
+++ b/app/api/reading.py
@@ -5,6 +5,8 @@ POST /preferences/{key}             — set one preference, return the
                                        swappable <style> fragment
 GET  /passages/{passage_id}/questions — HTMX-lazy-loaded comprehension
                                         question fragment
+POST /passages/{passage_id}/close   — unload-time beacon recording one
+                                        reading_event row (METRIC-2)
 
 Owner check on the GET: a user can only view their own passages. Other
 users' passages return 404 (not 403) — same response shape as a
@@ -20,7 +22,7 @@ import logging
 import uuid
 from typing import TYPE_CHECKING, Annotated
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse
 from sqlmodel import Session, select
 
@@ -28,6 +30,7 @@ from app.config import Settings, get_settings
 from app.db import get_session
 from app.models.passage import Passage
 from app.models.preference import Preference
+from app.models.reading_event import ReadingEvent
 from app.models.user import User
 from app.services.comprehension.client import get_anthropic_client
 from app.services.comprehension.generator import (
@@ -203,3 +206,67 @@ def passage_questions(
         name="fragments/questions_panel.html",
         context={"questions": questions, "error": error},
     )
+
+
+# Inclusive bounds for client-supplied line counts. 1 is the natural
+# floor (zero lines processed is meaningless noise). 100_000 mirrors
+# INGEST-1's text-length cap — any value above that means the client
+# is lying or the column count broke.
+_MIN_LINES = 1
+_MAX_LINES = 100_000
+
+
+@router.post("/passages/{passage_id}/close")
+def passage_close(
+    passage_id: uuid.UUID,
+    user: CurrentUser,
+    session: SessionDep,
+    lines: Annotated[int, Form()],
+) -> Response:
+    """Record one `reading_event` row when the user closes a passage.
+
+    Fired by HTMX `hx-trigger="unload from:body"` on the reading view's
+    hidden beacon div. Returns 204 No Content — the response body is
+    irrelevant because the browser is already tearing down the page.
+
+    Ownership check is identical to GET /read: a user closing someone
+    else's passage gets a 404 (same body as a nonexistent UUID) so
+    we don't leak which IDs exist.
+
+    Validation is permissive: out-of-range `lines` values get a 204
+    with NO row inserted (logged but otherwise silent). The unload
+    path can't surface errors anyway, so a noisy 4xx would be wasted —
+    better to drop the bad data and move on.
+
+    Idempotency: this route does NOT deduplicate. Browser quirks
+    (back/forward cache, refresh, bfcache restore) will occasionally
+    double-fire. The PRD metric tolerates a small over-count; revisit
+    only if dogfooding shows material divergence from manual counts.
+    """
+    passage = session.exec(
+        select(Passage).where(Passage.id == passage_id, Passage.user_id == user.id)  # type: ignore[arg-type]
+    ).first()
+    if passage is None:
+        # Same 404 as cross-user/nonexistent on GET /read; preserves the
+        # "existence isn't leaked" invariant.
+        raise HTTPException(status_code=404, detail="Passage not found")
+
+    if not (_MIN_LINES <= lines <= _MAX_LINES):
+        logger.warning(
+            "passage_close.invalid_lines user_id=%s passage_id=%s lines=%s",
+            user.id,
+            passage_id,
+            lines,
+        )
+        return Response(status_code=204)
+
+    session.add(
+        ReadingEvent(
+            user_id=user.id,
+            passage_id=passage_id,
+            lines_processed=lines,
+        )
+    )
+    session.commit()
+
+    return Response(status_code=204)

--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -13,6 +13,44 @@
        hx-swap="outerHTML"
        aria-live="polite"></div>
 
+  {#
+    METRIC-2: emit one reading_event on unload. The inline <script>
+    measures the rendered <article>'s height in line-heights and stashes
+    the count on `window.cubroxLineCount`. The hidden <div> below uses
+    hx-trigger="unload from:body" so HTMX fires the POST when the user
+    leaves the page (close tab, navigate away, refresh). hx-vals 'js:'
+    pulls the count from the window at fire time, not at render time.
+    Failure modes are silent by design — the server returns 204 even on
+    out-of-range values; the unload path can't surface errors anyway.
+  #}
+  <script>
+    (function () {
+      var surface = document.getElementById("reading-surface");
+      if (!surface) {
+        window.cubroxLineCount = 1;
+        return;
+      }
+      // Use computed line-height so a user's preference change (toggled
+      // server-side after first paint) is reflected on the next close.
+      var cs = window.getComputedStyle(surface);
+      var lineHeight = parseFloat(cs.lineHeight);
+      if (!isFinite(lineHeight) || lineHeight <= 0) {
+        // Fallback: the browser returned "normal". Estimate from
+        // font-size * 1.2 (CSS default ratio).
+        lineHeight = parseFloat(cs.fontSize) * 1.2;
+      }
+      var lines = Math.max(1, Math.round(surface.scrollHeight / lineHeight));
+      window.cubroxLineCount = lines;
+    })();
+  </script>
+  <div id="reading-close-beacon"
+       hx-post="/passages/{{ passage.id }}/close"
+       hx-trigger="unload from:body"
+       hx-vals='js:{lines: window.cubroxLineCount}'
+       hx-swap="none"
+       aria-hidden="true"
+       style="display:none"></div>
+
   <aside class="reader-controls" aria-label="Reading preferences">
     <details>
       <summary>Reading preferences</summary>

--- a/tests/test_passage_close.py
+++ b/tests/test_passage_close.py
@@ -1,0 +1,252 @@
+"""Tests for POST /passages/{passage_id}/close (METRIC-2 #22).
+
+Covers the Definition of Done from issue #22:
+  - Happy path: 204 + one reading_event row with the right user/passage/lines
+  - Owner check: posting to another user's passage → 404, no row
+  - Validation: lines=0, lines=-1, lines=100001 silently rejected (204, no row)
+  - Auth: unauthenticated → HX-Redirect to landing page (per AUTH-3),
+    no row inserted
+  - Template wiring: GET /read/<id> contains the close-beacon div
+    pointed at the right URL pattern
+"""
+
+import hashlib
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.models.passage import Passage
+from app.models.reading_event import ReadingEvent
+from app.models.user import User
+from app.services.identity.session import SESSION_COOKIE_NAME, sign_session
+
+TEST_SECRET = "dev-only"
+
+
+def _signed_in(client: TestClient, session: Session, email: str = "reader@example.com") -> User:
+    user = User(email=email)
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    client.cookies.set(SESSION_COOKIE_NAME, sign_session(user_id=user.id, secret=TEST_SECRET))
+    return user
+
+
+def _make_passage(
+    session: Session, user_id: uuid.UUID, text: str = "Some lines\nto read."
+) -> Passage:
+    p = Passage(
+        user_id=user_id,
+        text=text,
+        text_hash=hashlib.sha256(text.encode("utf-8")).digest(),
+        source_type="paste",
+        source_filename=None,
+    )
+    session.add(p)
+    session.commit()
+    session.refresh(p)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_close_inserts_reading_event_and_returns_204(client: TestClient, session: Session) -> None:
+    user = _signed_in(client, session)
+    passage = _make_passage(session, user.id)
+
+    response = client.post(f"/passages/{passage.id}/close", data={"lines": 42})
+    assert response.status_code == 204
+    # 204 by spec carries no body.
+    assert response.text == ""
+
+    rows = session.exec(select(ReadingEvent)).all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.user_id == user.id
+    assert row.passage_id == passage.id
+    assert row.lines_processed == 42
+
+
+def test_close_with_lines_at_lower_bound_persists(client: TestClient, session: Session) -> None:
+    """`lines=1` is the minimum allowed value (the route's CHECK is >= 1)."""
+    user = _signed_in(client, session)
+    passage = _make_passage(session, user.id)
+
+    response = client.post(f"/passages/{passage.id}/close", data={"lines": 1})
+    assert response.status_code == 204
+
+    rows = session.exec(select(ReadingEvent)).all()
+    assert len(rows) == 1
+    assert rows[0].lines_processed == 1
+
+
+def test_close_with_lines_at_upper_bound_persists(client: TestClient, session: Session) -> None:
+    """`lines=100_000` is the maximum allowed value (matches the
+    INGEST-1 paste cap)."""
+    user = _signed_in(client, session)
+    passage = _make_passage(session, user.id)
+
+    response = client.post(f"/passages/{passage.id}/close", data={"lines": 100_000})
+    assert response.status_code == 204
+
+    rows = session.exec(select(ReadingEvent)).all()
+    assert len(rows) == 1
+    assert rows[0].lines_processed == 100_000
+
+
+# ---------------------------------------------------------------------------
+# Owner check
+# ---------------------------------------------------------------------------
+
+
+def test_close_on_other_users_passage_returns_404_no_row(
+    client: TestClient, session: Session
+) -> None:
+    """Same 404 + same body as cross-user GET /read. Existence isn't
+    leaked, and crucially no reading_event row is attributed to the
+    wrong user."""
+    _signed_in(client, session)
+    # The signed-in user is irrelevant to the passage we'll target —
+    # create a separate user and a passage they own.
+    other = User(email="someone-else@example.com")
+    session.add(other)
+    session.commit()
+    session.refresh(other)
+    other_passage = _make_passage(session, other.id)
+
+    response = client.post(f"/passages/{other_passage.id}/close", data={"lines": 5})
+    assert response.status_code == 404
+
+    rows = session.exec(select(ReadingEvent)).all()
+    assert rows == []
+
+
+def test_close_on_nonexistent_passage_returns_404_no_row(
+    client: TestClient, session: Session
+) -> None:
+    """A UUID that doesn't exist gets the same 404 as a cross-user
+    passage. Same code path."""
+    _signed_in(client, session)
+    response = client.post(
+        f"/passages/{uuid.uuid4()}/close",
+        data={"lines": 5},
+    )
+    assert response.status_code == 404
+    assert session.exec(select(ReadingEvent)).all() == []
+
+
+# ---------------------------------------------------------------------------
+# Validation — out-of-range silently rejected
+# ---------------------------------------------------------------------------
+
+
+def test_close_with_lines_zero_silently_rejected(client: TestClient, session: Session) -> None:
+    """`lines=0` is meaningless noise. The unload path can't surface
+    errors, so the route returns 204 + drops the data + logs a WARN."""
+    user = _signed_in(client, session)
+    passage = _make_passage(session, user.id)
+
+    response = client.post(f"/passages/{passage.id}/close", data={"lines": 0})
+    assert response.status_code == 204
+    assert session.exec(select(ReadingEvent)).all() == []
+
+
+def test_close_with_lines_negative_silently_rejected(client: TestClient, session: Session) -> None:
+    user = _signed_in(client, session)
+    passage = _make_passage(session, user.id)
+
+    response = client.post(f"/passages/{passage.id}/close", data={"lines": -1})
+    assert response.status_code == 204
+    assert session.exec(select(ReadingEvent)).all() == []
+
+
+def test_close_with_lines_over_max_silently_rejected(client: TestClient, session: Session) -> None:
+    """100_001 is one above the cap. Mirrors INGEST-1's text-length
+    limit; anything higher means the client is lying or the
+    measurement broke."""
+    user = _signed_in(client, session)
+    passage = _make_passage(session, user.id)
+
+    response = client.post(
+        f"/passages/{passage.id}/close",
+        data={"lines": 100_001},
+    )
+    assert response.status_code == 204
+    assert session.exec(select(ReadingEvent)).all() == []
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def test_close_unauthenticated_redirects_no_row(client: TestClient, session: Session) -> None:
+    """Unauth requests get the AUTH-3 redirect (HX-Redirect when the
+    request is HTMX, 303 otherwise — both target the landing page `/`
+    since PR #40, not `/login`). No reading_event row is created.
+
+    Note: ticket text references `/login` from before the redirect-fix
+    PR landed. The current production behavior is `/`. Tests pin the
+    real target."""
+    passage_id = uuid.uuid4()
+
+    # HTMX-style request (matches the unload beacon in production).
+    response = client.post(
+        f"/passages/{passage_id}/close",
+        data={"lines": 5},
+        headers={"HX-Request": "true"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 200
+    assert response.headers.get("hx-redirect") == "/"
+    assert session.exec(select(ReadingEvent)).all() == []
+
+    # Browser-style request (no HX-Request header) → 303 to landing.
+    response = client.post(
+        f"/passages/{passage_id}/close",
+        data={"lines": 5},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert response.headers["location"] == "/"
+    assert session.exec(select(ReadingEvent)).all() == []
+
+
+# ---------------------------------------------------------------------------
+# Template wiring
+# ---------------------------------------------------------------------------
+
+
+def test_reading_view_template_contains_close_beacon(client: TestClient, session: Session) -> None:
+    """The reading view must emit the hidden close-beacon div pointed
+    at the right URL. Without this, the route exists but no client
+    ever calls it."""
+    user = _signed_in(client, session)
+    passage = _make_passage(session, user.id)
+
+    response = client.get(f"/read/{passage.id}")
+    body = response.text
+    assert f'hx-post="/passages/{passage.id}/close"' in body
+    assert 'hx-trigger="unload from:body"' in body
+    # The hx-vals JS expression pulls from the inline-script-set global.
+    assert "window.cubroxLineCount" in body
+
+
+def test_reading_view_template_contains_line_count_script(
+    client: TestClient, session: Session
+) -> None:
+    """The inline <script> that measures the rendered <article>'s
+    height and sets window.cubroxLineCount must be present. Pin it
+    so a future refactor doesn't silently drop the measurement."""
+    user = _signed_in(client, session)
+    passage = _make_passage(session, user.id)
+
+    body = client.get(f"/read/{passage.id}").text
+    assert "window.cubroxLineCount" in body
+    # The script reads computed line-height — pin the property reference
+    # so a refactor that drops it surfaces here, not in production.
+    assert "lineHeight" in body


### PR DESCRIPTION
Closes #22.

## Summary

Adds the unload-time beacon that records one \`reading_event\` row when a user leaves the reading view. With METRIC-1's table from PR #46 and this PR, the "100,000 lines read in three months" PRD success metric is now **observable** — METRIC-3 (#23) will surface the aggregate query.

## Server side

- New \`POST /passages/{passage_id}/close\` route in [app/api/reading.py](app/api/reading.py)
- Auth + ownership check (404 same body shape as cross-user / missing — no existence leak, mirrors GET /read)
- Validates \`1 ≤ lines ≤ 100_000\`; **out-of-range silently dropped** with 204 + a WARN log, because the unload path can't surface errors anyway
- Inserts one \`reading_event\` row, returns **204 No Content**

## Client side

Two template additions in [templates/pages/reading.html](templates/pages/reading.html):

1. **Inline \`<script>\`** that measures the rendered \`<article>\`'s scrollHeight ÷ computed line-height to estimate the visible-line count. Stashes the value on \`window.cubroxLineCount\`. Plain ES2015 — no framework, no build step (ADR-005).
2. **Hidden \`<div hx-trigger="unload from:body">\`** that POSTs to the new route. Uses \`hx-vals='js:{lines: window.cubroxLineCount}'\` so the count is read **at fire time**, not at render time — a preference toggle that changes line-height between page load and close still gets reflected.

## No deduplication (by design)

The route does NOT deduplicate. Refreshes, back/forward cache, browser quirks will occasionally double-fire. Per ticket guardrail, the PRD metric tolerates a small over-count for MVP; revisit only if dogfooding shows material divergence from manual line-counts.

## Note on the unauth-redirect test

The ticket DoD says "unauthenticated request returns 200 with \`HX-Redirect: /login\`". PR #40 (2026-05-12) changed the AUTH-3 redirect target from \`/login\` to \`/\` because \`/login\` is POST-only. **Tests pin the current production target (\`/\`)**, not the stale ticket reference. Same discrepancy noted in test docstring.

## Test plan

- [x] 11 new tests covering happy path, owner check, validation bounds, auth redirect (both HTMX and browser), template wiring
- [x] 227 total tests pass, 96.74% coverage, ruff/mypy clean
- [x] All four newly-enforced required checks (a11y, python, lint, test) green expected on CI
- [ ] Manual: open a reading view, close the tab, see one new \`reading_event\` row in psql with \`lines_processed\` close to the visible line count

🤖 Generated with [Claude Code](https://claude.com/claude-code)