### PR TITLE
fix(deploy): inject all production env vars (closes #49)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,9 +157,44 @@ jobs:
           # Manager — acceptable trade-off because preview already exposes
           # Neon URLs as literals; consistency between the pipelines is
           # more valuable than asymmetric hardening of just one. See #67.
+          # Every env var the production app needs at runtime is set here,
+          # explicitly, so the deployed revision never depends on whatever
+          # state was set manually on the Cloud Run service in the past.
+          # See issue #49 — production ran for the entire build-out arc
+          # with RESEND_API_KEY and SESSION_SECRET silently preserved
+          # from a one-time manual operation; this is the structural fix.
+          #
+          # deploy-cloudrun@v2 passes this block as --update-env-vars
+          # (merge semantics): vars not listed here are preserved, listed
+          # vars overwrite. Listing the full set (re)asserts production's
+          # intended config on every deploy — no more drift from manual
+          # interventions that nobody documented.
+          #
+          # Secrets sourced from GitHub Secrets:
+          #   - PRODUCTION_DATABASE_URL  → DATABASE_URL    (Neon production)
+          #   - SESSION_SECRET           → SESSION_SECRET  (cookie signer)
+          #   - RESEND_API_KEY           → RESEND_API_KEY  (magic-link email)
+          #   - ANTHROPIC_API_KEY (opt)  → ANTHROPIC_API_KEY (comp questions)
+          #
+          # Non-secret config sourced from GitHub repository Variables
+          # (with safe defaults so a fresh fork deploys without manual
+          # GitHub Settings touches):
+          #   - vars.MAGIC_LINK_BASE_URL   → MAGIC_LINK_BASE_URL
+          #     Default: the Cloud Run-issued URL. Override once a custom
+          #     domain is mapped to the service.
+          #   - vars.MAGIC_LINK_FROM_EMAIL → MAGIC_LINK_FROM_EMAIL
+          #     Default: onboarding@resend.dev — Resend's shared free-tier
+          #     sender, which can only deliver to the Resend account
+          #     owner's address. Once a domain is verified at Resend,
+          #     override this var with noreply@<verified-domain>.
           env_vars: |
             ENVIRONMENT=production
             DATABASE_URL=${{ secrets.PRODUCTION_DATABASE_URL }}
+            SESSION_SECRET=${{ secrets.SESSION_SECRET }}
+            RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
+            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
+            MAGIC_LINK_BASE_URL=${{ vars.MAGIC_LINK_BASE_URL || 'https://agile-flow-app-heo5ry7rua-uc.a.run.app' }}
+            MAGIC_LINK_FROM_EMAIL=${{ vars.MAGIC_LINK_FROM_EMAIL || 'onboarding@resend.dev' }}
 
       - name: Route traffic to latest revision
         # success() gates on all prior steps succeeding — without it,


### PR DESCRIPTION
Closes #49.

## Why

Production was running with `RESEND_API_KEY` and `SESSION_SECRET` quietly preserved on the Cloud Run service from a one-time manual operation that nobody documented. Today's discovery: trying to sign in with \`laura@lauraharley.com\` produced no email AND no Resend Activity entry — meaning the deployed app never successfully called Resend. Most likely cause: \`RESEND_API_KEY\` on the running revision is unset, empty, or stale.

The bigger finding: \`SESSION_SECRET\` defaults to the literal string \`"dev-only"\` per [app/config.py:41](app/config.py#L41), which is checked into the public source. If the deployed revision is in fact using that default, session cookies in production are forgeable by anyone with read access to the GitHub repo. **Critical reason not to share the production URL with any real user until this lands.**

Asymmetry was the root cause: [preview-deploy.yml:177-191](.github/workflows/preview-deploy.yml#L177-L191) already injects \`SESSION_SECRET\` and \`RESEND_API_KEY\` correctly. Production was just never updated to match.

## What changed

[deploy.yml](.github/workflows/deploy.yml) — the \`env_vars:\` block is now the source of truth for every env var the production app needs:

\`\`\`yaml
env_vars: |
  ENVIRONMENT=production
  DATABASE_URL=${{ secrets.PRODUCTION_DATABASE_URL }}
  SESSION_SECRET=${{ secrets.SESSION_SECRET }}
  RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
  ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
  MAGIC_LINK_BASE_URL=${{ vars.MAGIC_LINK_BASE_URL || 'https://agile-flow-app-heo5ry7rua-uc.a.run.app' }}
  MAGIC_LINK_FROM_EMAIL=${{ vars.MAGIC_LINK_FROM_EMAIL || 'onboarding@resend.dev' }}
\`\`\`

Sensitive values (DB URL, session secret, API keys) come from GitHub Secrets. Non-sensitive config (base URL, FROM email) comes from GitHub repository Variables with safe defaults — so a fresh fork can deploy without manual Settings touches, and overriding them later (e.g. for a custom domain or a verified Resend sender) is a single GitHub Settings click rather than a code change.

\`deploy-cloudrun@v2\`'s \`env_vars:\` translates to \`--update-env-vars\` (merge). Listing the full set on every deploy means production's intended config is asserted by the workflow rather than drifting from manual interventions.

## Action required AFTER merge

1. **Verify \`SESSION_SECRET\` GitHub Secret is a real 32-byte secret, not the literal \`"dev-only"\`.** If it's missing or set to \`"dev-only"\`, the new revision will fail to boot ([app/config.py:87-94](app/config.py#L87-L94) refuses it). Regenerate with:
   \`\`\`bash
   python -c "import secrets; print(secrets.token_urlsafe(32))"
   \`\`\`
   Then update the secret at \`Settings → Secrets and variables → Actions\`.

2. **After deploy succeeds, attempt a sign-in** at https://agile-flow-app-heo5ry7rua-uc.a.run.app with the email tied to your Resend account. The link should arrive within seconds. Resend Activity dashboard should show one delivered email.

3. **To deliver to anyone other than the Resend account owner**, verify a domain at Resend (e.g. \`lauraharley.com\` or \`cubrox.app\`), then set repository variable \`MAGIC_LINK_FROM_EMAIL=noreply@<verified-domain>\` at \`Settings → Secrets and variables → Actions → Variables\` and trigger a fresh deploy.

## Why the validator didn't catch the production misconfig

\`Settings._refuse_sqlite_outside_dev\` at [app/config.py:60-95](app/config.py#L60-L95) does check \`session_secret in ("", "dev-only")\` and raises. It fires at \`Settings()\` instantiation, which happens at [app/db.py:14](app/db.py#L14) during module import — i.e. on every uvicorn boot. The only way production has been booting cleanly is that the Cloud Run service does currently have a real \`SESSION_SECRET\` env var set (from a manual operation), even though the workflow never injects it. This PR makes that manual state unnecessary going forward; the workflow asserts the value on every deploy. If the manually-set value is somehow lost or rotated wrong, the new revision will refuse to start — which is the right loud-failure behavior.

## Test plan

- [x] \`actionlint\` clean on the updated workflow
- [x] Python suite still green (238 tests pass; no code changes outside the workflow)
- [ ] CI green on this PR (all four required checks: a11y, python, lint, test)
- [ ] After merge: production deploy succeeds, the new revision boots without the validator firing
- [ ] After merge: sign-in attempt at \`https://agile-flow-app-heo5ry7rua-uc.a.run.app\` with the Resend account owner's email produces a real magic link email within 30 seconds
- [ ] After merge: clicking the magic link results in a signed-in session with a cookie that verifies against the new \`SESSION_SECRET\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)