### PR TITLE
fix(auth): post-login routing — drop authed users on the app (closes #51)

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -124,7 +124,11 @@ def verify(
     session.commit()
 
     cookie_value = sign_session(user_id=user_id, secret=settings.session_secret)
-    response = RedirectResponse(url="/", status_code=303)
+    # Drop the freshly-signed-in user on the paste/upload page (the
+    # actual app entry point), NOT the landing page. The landing page
+    # also redirects authed visitors here, but going via `/` would
+    # cause a needless second hop. See BUG-2 (#51).
+    response = RedirectResponse(url="/passages/new", status_code=303)
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=cookie_value,

--- a/app/api/home.py
+++ b/app/api/home.py
@@ -1,22 +1,42 @@
 """Landing-page route.
 
-GET / renders the Cubrox landing page with a sign-in form. The form
-posts to /login (AUTH-1) via HTMX, so a successful submit swaps the
-form for the "check your inbox" fragment without a page reload.
+GET / serves two audiences in one URL:
 
-Public route — no authentication required. This is the only URL on
-the site a person can find without already being signed in.
+  - **Anonymous visitors** see the Cubrox landing page with the
+    sign-in form. The form posts to /login (AUTH-1) via HTMX, so a
+    successful submit swaps the form for the "check your inbox"
+    fragment without a page reload.
+
+  - **Already-signed-in visitors** are redirected straight to
+    /passages/new (the paste/upload entry point). Without this branch,
+    a returning user clicking a bookmarked URL would land on the
+    sign-in form and assume the page was broken — see BUG-2 (#51).
+
+Public route in the sense that it doesn't REQUIRE authentication; the
+soft-auth `try_current_user` dependency returns `None` rather than
+raising when no valid session is present.
 """
 
-from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from typing import Annotated
 
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import RedirectResponse, Response
+
+from app.models.user import User
+from app.services.identity.session import try_current_user
 from app.templates import templates
 
 router = APIRouter()
 
+OptionalUser = Annotated[User | None, Depends(try_current_user)]
 
-@router.get("/", response_class=HTMLResponse)
-def landing(request: Request) -> HTMLResponse:
-    """Render the landing page with the sign-in form."""
+
+@router.get("/")
+def landing(request: Request, user: OptionalUser) -> Response:
+    """Render the landing page for anonymous visitors; redirect
+    signed-in visitors to the paste/upload page."""
+    if user is not None:
+        # Already signed in: skip the sign-in form, drop them on the
+        # actual app entry point. 303 matches the post-verify redirect.
+        return RedirectResponse(url="/passages/new", status_code=303)
     return templates.TemplateResponse(request=request, name="home.html")

--- a/app/services/identity/session.py
+++ b/app/services/identity/session.py
@@ -150,3 +150,31 @@ def current_user(
                 )
 
     return user
+
+
+def try_current_user(
+    request: Request,
+    response: Response,
+    session: Annotated[Session, Depends(get_session)],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> User | None:
+    """Soft-auth variant of `current_user`: returns `User | None` instead of
+    raising on no/invalid session.
+
+    Use this when a route needs to render differently for signed-in vs.
+    anonymous visitors but should NOT trigger the AUTH-3 redirect for
+    anonymous ones (e.g. the landing page, which renders the sign-in
+    form for anonymous visitors and redirects authed visitors away).
+
+    Shares all cookie-verification logic with `current_user` so the
+    "is this session valid" rules stay in one place.
+    """
+    try:
+        return current_user(
+            request=request,
+            response=response,
+            session=session,
+            settings=settings,
+        )
+    except UnauthenticatedError:
+        return None

--- a/tests/test_auth_verify.py
+++ b/tests/test_auth_verify.py
@@ -65,14 +65,18 @@ def _seed_active_token(
 # ---------------------------------------------------------------------------
 
 
-def test_valid_token_returns_303_redirect_to_root(
+def test_valid_token_returns_303_redirect_to_passages_new(
     client: TestClient,
     session: Session,
 ) -> None:
+    """Per BUG-2 (#51), the post-verify redirect lands on the
+    paste/upload page (the actual app entry point) rather than the
+    landing page (which would otherwise show the sign-in form to a
+    user who just signed in)."""
     _, raw_token = _seed_active_token(session)
     response = client.get(f"/auth/verify?token={raw_token}", follow_redirects=False)
     assert response.status_code == 303
-    assert response.headers["location"] == "/"
+    assert response.headers["location"] == "/passages/new"
 
 
 def test_valid_token_sets_session_cookie(

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1,14 +1,26 @@
-"""Tests for the public landing page at GET /.
+"""Tests for the landing page at GET /.
 
-This is the ONLY public page on Cubrox — it must work without
-authentication and serve as the on-ramp to the magic-link sign-in
-flow (AUTH-1/2/3).
+The route serves two audiences:
+  - Anonymous visitors see the sign-in form (the on-ramp to AUTH-1/2/3).
+  - Signed-in visitors are redirected to /passages/new — the actual app
+    entry point. Without this branch, a returning user clicking a
+    bookmarked URL would land on the sign-in form and assume the page
+    was broken (BUG-2 #51).
+
+Tests in this file that don't seed a session cookie exercise the
+anonymous path; the dedicated `test_signed_in_visitor_redirects_to_passages_new`
+test exercises the signed-in branch.
 """
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlmodel import Session
 
+from app.models.user import User
 from app.services.identity import magic_link
+from app.services.identity.session import SESSION_COOKIE_NAME, sign_session
+
+TEST_SECRET = "dev-only"
 
 
 @pytest.fixture(autouse=True)
@@ -33,12 +45,50 @@ def test_landing_page_returns_200_and_html(client: TestClient) -> None:
 
 
 def test_landing_page_does_not_require_auth(client: TestClient) -> None:
-    """The landing page is the only public URL. Unauthenticated requests
-    must NOT redirect to /login (that would be a redirect loop, since
-    /login is where someone gets the form to sign in from)."""
+    """The landing page is the public URL anonymous visitors see first.
+    A request with no session cookie must render the sign-in form (200),
+    NOT redirect anywhere — there's nowhere safe to redirect them to
+    (the sign-in form lives ON this page)."""
     response = client.get("/", follow_redirects=False)
     assert response.status_code == 200
     assert response.headers.get("location") is None
+
+
+def test_signed_in_visitor_redirects_to_passages_new(
+    client: TestClient,
+    session: Session,
+) -> None:
+    """Per BUG-2 (#51): a visitor with a valid session cookie should
+    skip the landing page and land directly on the paste/upload entry
+    point. Without this, returning users clicking bookmarked `/` see
+    the sign-in form and assume the site is broken."""
+    user = User(email="returning@example.com")
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    client.cookies.set(SESSION_COOKIE_NAME, sign_session(user_id=user.id, secret=TEST_SECRET))
+
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/passages/new"
+    # Critically, we did NOT render the sign-in form.
+    assert "<form" not in response.text
+
+
+def test_invalid_cookie_falls_back_to_landing_page(
+    client: TestClient,
+) -> None:
+    """A session cookie that doesn't verify (forged, expired, signed
+    with the wrong secret) should be treated as no-cookie — render
+    the sign-in form rather than 4xx the visitor. The soft-auth
+    `try_current_user` dep returns None for any verify failure."""
+    client.cookies.set(SESSION_COOKIE_NAME, "this-is-not-a-valid-cookie")
+
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 200
+    # Sign-in form rendered; no redirect.
+    assert response.headers.get("location") is None
+    assert "<form" in response.text
 
 
 def test_landing_page_renders_signin_form(client: TestClient) -> None:


### PR DESCRIPTION
Closes #51 (BUG-2).

## Why

When laura@lauraharley.com clicked her magic-link today, she landed on the sign-in form instead of the app. Investigation showed the cookie was being set correctly, but the post-verify redirect target (\`/\`) is the same page that always renders the sign-in form. From the user's perspective: "I clicked the link and got dropped back at the login page."

This PR is **option 2** from the analysis we discussed: fix both the email-link case and the bookmark/return-later case in one shot.

## What changed

| File | Change |
|------|--------|
| [app/api/auth.py](app/api/auth.py) | \`/auth/verify\` redirect target: \`/\` → \`/passages/new\` (the app's actual entry point) |
| [app/api/home.py](app/api/home.py) | \`/\` route now detects a valid session via the new \`try_current_user\` dep; signed-in visitors get redirected to \`/passages/new\` instead of seeing the sign-in form |
| [app/services/identity/session.py](app/services/identity/session.py) | New \`try_current_user\` dependency — returns \`User \| None\` instead of raising. Shares all cookie-verification logic with \`current_user\` so "is this session valid" stays in one place |
| [tests/test_auth_verify.py](tests/test_auth_verify.py) | Redirect-target assertion + test rename |
| [tests/test_home.py](tests/test_home.py) | Two new tests: signed-in-visitor-redirects (the new branch) AND invalid-cookie-falls-back-to-landing (defensive) |

## Behavior summary

| Scenario | Before | After |
|----------|--------|-------|
| Click magic-link email (just signed in) | Drops on \`/\` (sign-in form) | Drops on \`/passages/new\` ✓ |
| Bookmark \`/\` and visit while signed in | Sees sign-in form (confusing) | Auto-redirected to \`/passages/new\` ✓ |
| Visit \`/\` while NOT signed in | Sign-in form shown ✓ | Sign-in form shown ✓ (unchanged) |
| Visit with a forged/expired cookie | Sign-in form shown ✓ | Sign-in form shown ✓ (defensive — covered by new test) |

## Why \`try_current_user\` instead of duplicating logic

The landing page is the first route in the codebase that needs **optional** auth — it renders for both signed-in and anonymous visitors but routes them differently. Rather than copy-paste the cookie-verification code path, the new \`try_current_user\` dependency wraps \`current_user\` and catches \`UnauthenticatedError\` to return \`None\`. Single source of truth for session validation. Future routes that need optional auth (e.g., a public reading view that personalizes if the visitor's signed in) can reuse it.

## Test plan

- [x] 240 tests pass locally; 96.85% coverage; ruff + mypy clean
- [x] Two new tests cover the new branches (signed-in redirect; invalid-cookie fallback)
- [x] Existing landing-page tests still pin the anonymous-renders-form contract
- [ ] CI green on this PR (a11y, python, lint, test)
- [ ] After merge: deploy completes; sign in with laura@lauraharley.com; land on \`/passages/new\` (NOT the sign-in form)
- [ ] After merge: close the tab, reopen the production URL; land directly on \`/passages/new\` without seeing the sign-in form

🤖 Generated with [Claude Code](https://claude.com/claude-code)