### PR TITLE
chore(brand): rename user-facing 'Cubrox' to 'Master Key'

### DIFF
--- a/app/services/identity/magic_link.py
+++ b/app/services/identity/magic_link.py
@@ -106,7 +106,7 @@ def send_magic_link_email(
         {
             "from": from_email,
             "to": [email],
-            "subject": "Sign in to Cubrox",
+            "subject": "Sign in to Master Key",
             "html": _build_html(link),
             "text": _build_text(link),
         }
@@ -117,11 +117,11 @@ def _build_html(link: str) -> str:
     # Inline styles only — most email clients strip <style> blocks.
     return (
         '<div style="font-family: system-ui, sans-serif; line-height: 1.5;">'
-        "<p>Click below to sign in to Cubrox.</p>"
+        "<p>Click below to sign in to Master Key.</p>"
         f'<p><a href="{link}" '
         'style="display:inline-block;padding:12px 20px;background:#1a73e8;'
         'color:#fff;text-decoration:none;border-radius:4px;">'
-        "Sign in to Cubrox</a></p>"
+        "Sign in to Master Key</a></p>"
         "<p>This link expires in 15 minutes. "
         "If you didn't request it, you can safely ignore this email.</p>"
         "</div>"
@@ -130,7 +130,7 @@ def _build_html(link: str) -> str:
 
 def _build_text(link: str) -> str:
     return (
-        "Sign in to Cubrox\n\n"
+        "Sign in to Master Key\n\n"
         f"{link}\n\n"
         "This link expires in 15 minutes. "
         "If you didn't request it, you can safely ignore this email."

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,16 +1,16 @@
 {% extends "base.html" %}
 
-{% block title %}Cubrox — A calmer way to read{% endblock %}
+{% block title %}Master Key — A calmer way to read{% endblock %}
 
 {% block content %}
   <hgroup>
-    <h1>Cubrox</h1>
+    <h1>Master Key</h1>
     <p>A reading experience tuned for neurodivergent readers — and anyone
        else who finds long-form text hard to stay with.</p>
   </hgroup>
 
   <section>
-    <p>Paste any passage. Cubrox renders it in a calm, configurable
+    <p>Paste any passage. Master Key renders it in a calm, configurable
        reading surface with your choice of font, size, contrast, line
        spacing, and column width — and offers a quick comprehension
        check at the end so you know what you absorbed.</p>

--- a/templates/pages/passages_new.html
+++ b/templates/pages/passages_new.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Add a passage — Cubrox{% endblock %}
+{% block title %}Add a passage — Master Key{% endblock %}
 
 {% block content %}
   <hgroup>

--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Reading — Cubrox{% endblock %}
+{% block title %}Reading — Master Key{% endblock %}
 
 {% block content %}
   {% include "fragments/reader_style.html" %}

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -118,12 +118,14 @@ def test_landing_page_signin_form_swaps_inline(client: TestClient) -> None:
     assert 'id="signin-form"' in body
 
 
-def test_landing_page_mentions_cubrox(client: TestClient) -> None:
+def test_landing_page_mentions_product_name(client: TestClient) -> None:
     """Basic branding sanity check — visiting the URL should make it
-    obvious you're looking at Cubrox, not the starter template's todo
-    demo."""
+    obvious you're looking at Master Key (the public product name),
+    not the starter template's todo demo. 'Cubrox' remains the
+    internal codebase identifier (repo name, package name) but is
+    no longer surfaced to users."""
     body = client.get("/").text
-    assert "Cubrox" in body
+    assert "Master Key" in body
 
 
 def test_landing_page_does_not_mention_todos(client: TestClient) -> None:


### PR DESCRIPTION
Product name change requested by Laura.

## Scope

All user-visible surfaces switch from **Cubrox** → **Master Key**. The internal codebase (repo name, package name, folder structure, docstrings, GitHub org) keeps the historical `cubrox` identifier for continuity — only what a visitor reads is updated.

## What changed

| Surface | Change |
|---------|--------|
| Landing page H1 | `Cubrox` → `Master Key` |
| Landing page browser tab title | `Cubrox — A calmer way to read` → `Master Key — A calmer way to read` |
| Landing page body description | one sentence mentioning the product name |
| Paste/upload page browser tab title | `Add a passage — Cubrox` → `Add a passage — Master Key` |
| Reading view browser tab title | `Reading — Cubrox` → `Reading — Master Key` |
| Magic-link email subject | `Sign in to Cubrox` → `Sign in to Master Key` |
| Magic-link email body | both HTML and plaintext versions |
| Test assertion + docstring | `tests/test_home.py` — renamed test, updated assertion, expanded docstring to note the internal/external naming split |

## What did NOT change

- Repo name (\`vibeacademy/cubrox\`)
- Python package name (\`app/\`)
- Database name, table names, column names
- Module / class / function names (all keep their existing names; no symbol renames)
- Docstrings and code comments mentioning Cubrox (they describe the internal codebase; not user-visible)
- README, CLAUDE.md, session journals (technical / historical docs)
- Memory MCP entities, GitHub Issues/PRs/comments (immutable history)

## Test plan

- [x] All 240 tests pass; ruff clean
- [x] Test that previously pinned 'Cubrox' in landing-page body now pins 'Master Key'; docstring updated to explain the split
- [ ] CI green on this PR (a11y, python, lint, test)
- [ ] After merge: visit production URL in incognito → see 'Master Key' on the landing page
- [ ] After merge: send a sign-in to your own email → email subject reads 'Sign in to Master Key'

🤖 Generated with [Claude Code](https://claude.com/claude-code)