### PR TITLE
chore(brand): landing copy — name the audience (Bahá'í writings)

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -10,10 +10,11 @@
   </hgroup>
 
   <section>
-    <p>Paste any passage. Master Key renders it in a calm, configurable
-       reading surface with your choice of font, size, contrast, line
-       spacing, and column width — and offers a quick comprehension
-       check at the end so you know what you absorbed.</p>
+    <p>Paste or upload any passage from the Bahá'í writings or messages
+       from Bahá'í institutions. Master Key renders the text in a
+       comfortable, configurable reading surface with your choice of
+       font, size, contrast, line spacing, and column width — and offers
+       a quick comprehension check at the end so you know what you absorbed.</p>
   </section>
 
   <form id="signin-form"


### PR DESCRIPTION
User-requested copy edits to the landing-page body paragraph.

## What changed

| Before | After |
|--------|-------|
| "Paste any passage." | "Paste or upload any passage from the Bahá'í writings or messages from Bahá'í institutions." |
| "Master Key renders it in a calm, configurable" | "Master Key renders the text in a comfortable, configurable" |

## Why this matters

- The new opening sentence **names the audience explicitly** — visitors immediately know whether the product is for them. Also flags the upload path alongside paste so first-time visitors know both ingestion modes exist before they sign in.
- "Renders the text" replaces the ambiguous "renders it" — the original sentence's pronoun could refer to either "passage" or some implicit "your reading experience." "Comfortable" reads better than "calm" against "reading surface" (a calm surface is a slightly odd noun phrase; a comfortable surface is what we mean).

## Scope

Single template file, single paragraph. No other surfaces touched. No tests need updating — the only landing-page assertion pins "Master Key" in the body, which still holds.

## Test plan

- [x] 10 landing-page tests pass locally
- [ ] CI green on this PR (a11y, python, lint, test)
- [ ] After merge: incognito visit to the production URL shows the new paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)