### PR TITLE
chore(brand): landing-page epigraph naming the product

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -107,3 +107,20 @@
   color: var(--pico-muted-color);
   text-align: center;
 }
+
+/* Landing-page epigraph quote — names the source of "Master Key"
+   (Bahá'u'lláh's "the Word is the master key…"). Rendered below the
+   description paragraph in italics and a smaller size so it reads as
+   supporting context, not body copy. */
+.master-key-epigraph {
+  font-size: 0.875rem;
+  margin-top: 2.5rem;
+}
+
+.master-key-epigraph footer {
+  /* De-emphasize the attribution slightly so the quote itself
+     carries the focus. */
+  margin-top: 0.5rem;
+  font-style: normal;
+  color: var(--pico-muted-color);
+}

--- a/templates/home.html
+++ b/templates/home.html
@@ -16,6 +16,13 @@
        check at the end so you know what you absorbed.</p>
   </section>
 
+  <blockquote class="master-key-epigraph">
+    <em>"The Word is the master key for the whole world, inasmuch as
+       through its potency the doors of the hearts of men, which in
+       reality are the doors of heaven, are unlocked."</em>
+    <footer>(Bahá'u'lláh)</footer>
+  </blockquote>
+
   <form id="signin-form"
         hx-post="/login"
         hx-target="#signin-form"

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -128,6 +128,22 @@ def test_landing_page_mentions_product_name(client: TestClient) -> None:
     assert "Master Key" in body
 
 
+def test_landing_page_includes_master_key_epigraph(client: TestClient) -> None:
+    """The Bahá'u'lláh quote that gives the product its name is the
+    branding anchor for the landing page — pin both the quote text
+    and the attribution so a future refactor can't silently drop the
+    context behind the name."""
+    body = client.get("/").text
+    # Quote substring (chosen to be distinctive but not so long that
+    # a minor punctuation tweak would break the test).
+    assert "master key for the whole world" in body
+    # Attribution — visible to the visitor.
+    assert "Bahá'u'lláh" in body
+    # Rendered as a semantic blockquote, not inline body copy.
+    assert "<blockquote" in body
+    assert 'class="master-key-epigraph"' in body
+
+
 def test_landing_page_does_not_mention_todos(client: TestClient) -> None:
     """The todo demo was the starter scaffolding. Make sure no leftover
     text bleeds through into the landing page."""


### PR DESCRIPTION
Adds a Bahá'u'lláh quote below the landing-page description that explains where the 'Master Key' name comes from.

## The new element

Rendered as a semantic \`<blockquote class="master-key-epigraph">\` directly below the existing description \`<section>\`:

> *"The Word is the master key for the whole world, inasmuch as through its potency the doors of the hearts of men, which in reality are the doors of heaven, are unlocked."*
>
> (Bahá'u'lláh)

## Styling

New \`.master-key-epigraph\` class in \`static/style.css\`:
- Quote: \`0.875rem\` font-size (about 2 sizes smaller than the body), italicized via inline \`<em>\`
- Attribution (\`<footer>\`): Pico's muted color, non-italic, slight top margin to separate from the quote
- \`margin-top: 2.5rem\` on the blockquote to give visual breathing room from the description

## Why this matters

Two effects:
- **Names the source of the product name.** A visitor sees "Master Key" in the H1, reads the description, then immediately gets the scriptural reference that gave rise to the name. The branding feels grounded rather than arbitrary.
- **Reinforces the audience signal** from PR #54's body copy. The first paragraph names the audience explicitly; the epigraph confirms the product's intellectual origin.

## Merge-order note

This PR does NOT depend on PR #54 (the body-copy edit) and #54 doesn't depend on this. The epigraph sits below whichever version of the description paragraph is current. Both PRs are additive — merge in any order.

## Test plan

- [x] New test \`test_landing_page_includes_master_key_epigraph\` pins both the quote text and attribution
- [x] 11 landing-page tests pass locally
- [ ] CI green on this PR (a11y, python, lint, test)
- [ ] After merge: incognito visit shows the epigraph in italics below the description, attribution in muted color below the quote

🤖 Generated with [Claude Code](https://claude.com/claude-code)