### PR TITLE
chore(brand): move epigraph below sign-in form + tighten tagline

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -6,7 +6,7 @@
   <hgroup>
     <h1>Master Key</h1>
     <p>A reading experience tuned for neurodivergent readers — and anyone
-       else who finds long-form text hard to stay with.</p>
+       else who struggles to focus on long-form text.</p>
   </hgroup>
 
   <section>
@@ -16,13 +16,6 @@
        font, size, contrast, line spacing, and column width — and offers
        a quick comprehension check at the end so you know what you absorbed.</p>
   </section>
-
-  <blockquote class="master-key-epigraph">
-    <em>"The Word is the master key for the whole world, inasmuch as
-       through its potency the doors of the hearts of men, which in
-       reality are the doors of heaven, are unlocked."</em>
-    <footer>(Bahá'u'lláh)</footer>
-  </blockquote>
 
   <form id="signin-form"
         hx-post="/login"
@@ -43,4 +36,11 @@
 
     <button type="submit">Send me a sign-in link</button>
   </form>
+
+  <blockquote class="master-key-epigraph">
+    <em>"The Word is the master key for the whole world, inasmuch as
+       through its potency the doors of the hearts of men, which in
+       reality are the doors of heaven, are unlocked."</em>
+    <footer>(Bahá'u'lláh)</footer>
+  </blockquote>
 {% endblock %}


### PR DESCRIPTION
Two user-requested landing-page edits.

## What changed

1. **Moved the Bahá'u'lláh epigraph** from between the description and the sign-in form, to the bottom of the page (after the "Send me a sign-in link" button).
2. **Tagline rewording**: "and anyone else who finds long-form text hard to stay with." → "and anyone else who struggles to focus on long-form text."

## Why

**Reordering:** the previous layout had description → epigraph → form. The epigraph interrupted the scan-to-form flow for a first-time visitor whose primary intent was to sign in. Moving it below the form puts the sign-in CTA above the fold and reframes the epigraph as a contemplative closer rather than navigation friction.

**Tagline:** "struggles to focus on long-form text" centers the user's experience (focus) rather than the text's attribute (hard to stay with). Tighter and more direct.

## Test plan

- [x] All 11 landing-page tests pass (epigraph test pins existence + content, not position; tagline isn't pinned by any test)
- [ ] CI green on this PR (a11y, python, lint, test)
- [ ] After merge: incognito visit shows new tagline in the hero, sign-in form right under the description, epigraph at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)