### PR TITLE
feat(auth): wire Neon Auth env vars + AUTH_PROVIDER flag (#62)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,73 @@
+# Cubrox / Master Key — environment variables example
+#
+# Copy this file to `.env` and fill in real values for local development.
+# Never commit `.env`. Production reads these values from Google Secret
+# Manager (set during deploy via `.github/workflows/deploy.yml`).
+
+# === Runtime mode ===
+
+# "development" | "test" | "production" — selects validation strictness
+# in `app/config.py`. Leave as "development" locally.
+ENVIRONMENT=development
+
+# Public URL the app reports as itself (used in magic-link emails today,
+# in Neon Auth redirect URIs after the AUTH-7 migration).
+APP_URL=http://localhost:8080
+
+# === Database ===
+
+# SQLite default works for unit tests. Local dev pointing at a Neon
+# branch is fine. Production reads from PRODUCTION_DATABASE_URL secret.
+DATABASE_URL=sqlite:///./dev.db
+
+# === Auth provider selection (AUTH-7 / #62) ===
+
+# "resend" (current default; uses app/services/identity/magic_link.py +
+# Resend SDK) OR "neon" (Neon Auth via JWKS). Both code paths ship in the
+# same image; the flag selects which one /login dispatches to. Production
+# flip from resend → neon happens in T12 / AUTH-18 (#73).
+AUTH_PROVIDER=resend
+
+# === Resend magic-link (current auth path; eliminated after T13 cleanup) ===
+
+# Generate at https://resend.com/api-keys. Header-bound; the config
+# validator refuses non-ASCII characters (paste-mishap defense).
+RESEND_API_KEY=
+MAGIC_LINK_BASE_URL=http://localhost:8080
+MAGIC_LINK_FROM_EMAIL=onboarding@resend.dev
+
+# === Neon Auth (AUTH-7 / #62) ===
+
+# Captured per-environment in AUTH-6 / issue #61 from the Neon Console
+# (Project → Branch → Auth → Configuration). For local dev, use the
+# values from the `dev` branch.
+NEON_AUTH_BASE_URL=
+NEON_AUTH_JWKS_URL=
+# Mandatory since Neon Auth's 2026-01-30 breaking change. Generate ONCE
+# and share across environments — it's the cookie signer, not a
+# per-branch key. Generate with:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+NEON_AUTH_COOKIE_SECRET=
+# Per-branch server-side key for Neon Auth REST calls.
+STACK_SECRET_SERVER_KEY=
+# Per-branch publishable key, exposed to the browser via the sign-in
+# template. Public-by-design.
+STACK_PUBLISHABLE_CLIENT_KEY=
+
+# === Anthropic LLM (comprehension questions, ADR-001) ===
+
+# Generate at https://console.anthropic.com/. Optional — when missing,
+# the comprehension panel degrades to "temporarily unavailable" without
+# crashing the app.
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-haiku-4-5
+
+# === Session cookie signing (AUTH-2; still used during the migration) ===
+
+# Generate with:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+# The dev default "dev-only" is REJECTED by the config validator in
+# non-dev environments. Removed in T13-A after Neon Auth replaces it.
+SESSION_SECRET=dev-only
+SESSION_TTL_DAYS=30
+SESSION_COOKIE_SECURE=false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -187,6 +187,11 @@ jobs:
           #     sender, which can only deliver to the Resend account
           #     owner's address. Once a domain is verified at Resend,
           #     override this var with noreply@<verified-domain>.
+          # Neon Auth env vars (AUTH-7 / #62) are present for both auth
+          # providers. AUTH_PROVIDER selects which code path /login uses.
+          # Default 'resend' preserves current behavior; T12 / AUTH-18 (#73)
+          # flips production to 'neon' once the new path is dogfooded.
+          # Removal of the resend-path env vars happens in T13-C / AUTH-21.
           env_vars: |
             ENVIRONMENT=production
             DATABASE_URL=${{ secrets.PRODUCTION_DATABASE_URL }}
@@ -195,6 +200,12 @@ jobs:
             ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             MAGIC_LINK_BASE_URL=${{ vars.MAGIC_LINK_BASE_URL || 'https://agile-flow-app-heo5ry7rua-uc.a.run.app' }}
             MAGIC_LINK_FROM_EMAIL=${{ vars.MAGIC_LINK_FROM_EMAIL || 'onboarding@resend.dev' }}
+            AUTH_PROVIDER=${{ vars.AUTH_PROVIDER || 'resend' }}
+            NEON_AUTH_BASE_URL=${{ secrets.NEON_AUTH_PROD_BASE_URL }}
+            NEON_AUTH_JWKS_URL=${{ secrets.NEON_AUTH_PROD_JWKS_URL }}
+            NEON_AUTH_COOKIE_SECRET=${{ secrets.NEON_AUTH_COOKIE_SECRET }}
+            STACK_SECRET_SERVER_KEY=${{ secrets.NEON_AUTH_PROD_SERVER_KEY }}
+            STACK_PUBLISHABLE_CLIENT_KEY=${{ secrets.NEON_AUTH_PROD_PUBLISHABLE_KEY }}
 
       - name: Route traffic to latest revision
         # success() gates on all prior steps succeeding — without it,

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -190,6 +190,37 @@ jobs:
             ENV_VARS="${ENV_VARS};RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}"
           fi
 
+          # Neon Auth (AUTH-7 / #62). The AUTH_PROVIDER flag selects
+          # between the legacy Resend path and the new Neon Auth path;
+          # both code paths ship in the same image so a flip is a single
+          # env var update + revision restart (~30s rollback window).
+          # Default `resend` preserves current preview behavior — flip to
+          # `neon` via the repo variable AUTH_PROVIDER once T11 (#71)
+          # validates the path end-to-end on a preview.
+          #
+          # Neon Auth configuration is per-PROJECT, not per-branch (the
+          # JWKS URL and Stack server/publishable keys live at the project
+          # root in the Neon Console). So all PR previews share the dev
+          # project's values — there is no per-PR Neon Auth provisioning
+          # to do here. Laura captures these once in AUTH-6 (#61) and
+          # stores them as the NEON_AUTH_DEV_* repo secrets.
+          ENV_VARS="${ENV_VARS};AUTH_PROVIDER=${{ vars.AUTH_PROVIDER || 'resend' }}"
+          if [ -n "${{ secrets.NEON_AUTH_DEV_BASE_URL }}" ]; then
+            ENV_VARS="${ENV_VARS};NEON_AUTH_BASE_URL=${{ secrets.NEON_AUTH_DEV_BASE_URL }}"
+          fi
+          if [ -n "${{ secrets.NEON_AUTH_DEV_JWKS_URL }}" ]; then
+            ENV_VARS="${ENV_VARS};NEON_AUTH_JWKS_URL=${{ secrets.NEON_AUTH_DEV_JWKS_URL }}"
+          fi
+          if [ -n "${{ secrets.NEON_AUTH_COOKIE_SECRET }}" ]; then
+            ENV_VARS="${ENV_VARS};NEON_AUTH_COOKIE_SECRET=${{ secrets.NEON_AUTH_COOKIE_SECRET }}"
+          fi
+          if [ -n "${{ secrets.NEON_AUTH_DEV_SERVER_KEY }}" ]; then
+            ENV_VARS="${ENV_VARS};STACK_SECRET_SERVER_KEY=${{ secrets.NEON_AUTH_DEV_SERVER_KEY }}"
+          fi
+          if [ -n "${{ secrets.NEON_AUTH_DEV_PUBLISHABLE_KEY }}" ]; then
+            ENV_VARS="${ENV_VARS};STACK_PUBLISHABLE_CLIENT_KEY=${{ secrets.NEON_AUTH_DEV_PUBLISHABLE_KEY }}"
+          fi
+
           # --service-account pins the runtime SA to the deployer SA so
           # the revision can read mounted Secret Manager secrets and any
           # other resource the deployer SA already has access to. Without

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Thumbs.db
 # Environment and secrets
 .env
 .env.*
+!.env.example
 *.key
 *.pem
 credentials.json

--- a/app/config.py
+++ b/app/config.py
@@ -42,6 +42,30 @@ class Settings(BaseSettings):
     session_ttl_days: int = 30
     session_cookie_secure: bool = True
 
+    # Neon Auth (AUTH-7 / #62). Populated per-environment from the values
+    # captured by Laura in AUTH-6 / #61 via the Neon Console. Per Neon's
+    # 2026-01-30 breaking change, NEON_AUTH_COOKIE_SECRET became mandatory
+    # for session signing — generate once with
+    # `python -c "import secrets; print(secrets.token_urlsafe(32))"` and
+    # share across environments (it's the cookie signer, not a per-branch
+    # key).
+    #
+    # The migration ships behind the AUTH_PROVIDER flag (T6 / #66): both
+    # the Resend code path AND the Neon Auth code path live in the same
+    # image, and the flag selects which one /login dispatches to. Default
+    # `resend` preserves current behavior; T12 flips production to `neon`.
+    auth_provider: str = "resend"  # "resend" | "neon"
+    neon_auth_base_url: str = ""
+    neon_auth_jwks_url: str = ""
+    neon_auth_cookie_secret: str = ""
+    stack_secret_server_key: str = ""
+    # Publishable client key — public-by-design, exposed to the browser via
+    # the sign-in template. Name follows Neon's convention which mirrors
+    # Stack Auth's frontend-framework prefixes (NEXT_PUBLIC_ / VITE_); we
+    # don't host a JS bundler so we drop the framework prefix here and
+    # surface the value to Jinja via this single name.
+    stack_publishable_client_key: str = ""
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
@@ -92,6 +116,63 @@ class Settings(BaseSettings):
                 "var (production reads from the SESSION_SECRET secret in Secret "
                 "Manager). Without this, every session cookie is forgeable."
             )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_neon_auth_consistency(self) -> Self:
+        # When AUTH_PROVIDER is "neon", all five Neon Auth env vars must be
+        # populated. We refuse to start rather than 500ing on the first sign-in
+        # request. The AUTH_PROVIDER flag (T6) keeps the migration safely
+        # gated: default "resend" preserves current behavior; flipping to
+        # "neon" requires all values present.
+        if self.auth_provider not in ("resend", "neon"):
+            raise ValueError(
+                f"AUTH_PROVIDER must be 'resend' or 'neon' (got {self.auth_provider!r})."
+            )
+        if self.auth_provider == "neon":
+            missing = [
+                name
+                for name, value in (
+                    ("NEON_AUTH_BASE_URL", self.neon_auth_base_url),
+                    ("NEON_AUTH_JWKS_URL", self.neon_auth_jwks_url),
+                    ("NEON_AUTH_COOKIE_SECRET", self.neon_auth_cookie_secret),
+                    ("STACK_SECRET_SERVER_KEY", self.stack_secret_server_key),
+                    (
+                        "STACK_PUBLISHABLE_CLIENT_KEY",
+                        self.stack_publishable_client_key,
+                    ),
+                )
+                if not value
+            ]
+            if missing:
+                raise ValueError(
+                    f"AUTH_PROVIDER=neon requires all Neon Auth env vars; "
+                    f"missing: {', '.join(missing)}. See AUTH-6 / issue #61 for "
+                    "where these values come from (Neon Console)."
+                )
+        return self
+
+    @model_validator(mode="after")
+    def _refuse_non_ascii_in_secrets(self) -> Self:
+        # Defense-in-depth against paste-mishap bugs (the PR #50 `√` incident).
+        # Header-bound values MUST be ASCII or urllib3 raises UnicodeEncodeError
+        # at the first outbound HTTP call — invisible because background tasks
+        # swallow the error before it reaches the user.
+        header_bound_secrets = {
+            "RESEND_API_KEY": self.resend_api_key,
+            "STACK_SECRET_SERVER_KEY": self.stack_secret_server_key,
+            "STACK_PUBLISHABLE_CLIENT_KEY": self.stack_publishable_client_key,
+            "ANTHROPIC_API_KEY": self.anthropic_api_key,
+            "NEON_AUTH_COOKIE_SECRET": self.neon_auth_cookie_secret,
+        }
+        for name, value in header_bound_secrets.items():
+            if value and not value.isascii():
+                bad_char = next(c for c in value if ord(c) > 127)
+                raise ValueError(
+                    f"{name} contains non-ASCII char {bad_char!r} (likely a paste "
+                    "mishap — Word/clipboard autoformat introduces these silently). "
+                    "Re-copy the value from its source and re-set the secret."
+                )
         return self
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -151,3 +151,150 @@ def test_test_environment_allows_sqlite(monkeypatch: pytest.MonkeyPatch) -> None
 
     settings = Settings()
     assert settings.database_url == "sqlite://"
+
+
+# ── Neon Auth consistency validator (AUTH-7 / #62) ───────────────────
+
+
+def test_auth_provider_default_is_resend(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Backwards-compat: existing deploys without AUTH_PROVIDER set keep
+    # the Resend path. T12 (#71) flips production to "neon" by setting
+    # the repo variable; until then, omission must equal "resend".
+    monkeypatch.delenv("AUTH_PROVIDER", raising=False)
+    from app.config import Settings
+
+    assert Settings().auth_provider == "resend"
+
+
+def test_auth_provider_invalid_value_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTH_PROVIDER", "auth0")
+    from app.config import Settings
+
+    with pytest.raises(ValueError, match="AUTH_PROVIDER must be 'resend' or 'neon'"):
+        Settings()
+
+
+def test_auth_provider_neon_requires_all_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The migration-safety gate: flipping AUTH_PROVIDER=neon with any
+    # Neon Auth env var missing is a misconfiguration that would 500 on
+    # the first sign-in request. Refuse to start instead.
+    monkeypatch.setenv("AUTH_PROVIDER", "neon")
+    monkeypatch.delenv("NEON_AUTH_BASE_URL", raising=False)
+    monkeypatch.delenv("NEON_AUTH_JWKS_URL", raising=False)
+    monkeypatch.delenv("NEON_AUTH_COOKIE_SECRET", raising=False)
+    monkeypatch.delenv("STACK_SECRET_SERVER_KEY", raising=False)
+    monkeypatch.delenv("STACK_PUBLISHABLE_CLIENT_KEY", raising=False)
+    from app.config import Settings
+
+    with pytest.raises(ValueError, match="AUTH_PROVIDER=neon requires all Neon Auth env vars"):
+        Settings()
+
+
+def test_auth_provider_neon_partial_config_lists_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The error message must name the specific missing vars so operators
+    # don't have to bisect — `missing: STACK_SECRET_SERVER_KEY, ...`
+    # rather than a generic "config invalid".
+    monkeypatch.setenv("AUTH_PROVIDER", "neon")
+    monkeypatch.setenv("NEON_AUTH_BASE_URL", "https://example.neon.app")
+    monkeypatch.setenv("NEON_AUTH_JWKS_URL", "https://example.neon.app/.well-known/jwks.json")
+    monkeypatch.setenv("NEON_AUTH_COOKIE_SECRET", "test-cookie-secret-32-bytes-min-aaaa")
+    monkeypatch.delenv("STACK_SECRET_SERVER_KEY", raising=False)
+    monkeypatch.delenv("STACK_PUBLISHABLE_CLIENT_KEY", raising=False)
+    from app.config import Settings
+
+    with pytest.raises(
+        ValueError,
+        match=r"missing: STACK_SECRET_SERVER_KEY, STACK_PUBLISHABLE_CLIENT_KEY",
+    ):
+        Settings()
+
+
+def test_auth_provider_neon_with_all_vars_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTH_PROVIDER", "neon")
+    monkeypatch.setenv("NEON_AUTH_BASE_URL", "https://example.neon.app")
+    monkeypatch.setenv("NEON_AUTH_JWKS_URL", "https://example.neon.app/.well-known/jwks.json")
+    monkeypatch.setenv("NEON_AUTH_COOKIE_SECRET", "test-cookie-secret-32-bytes-min-aaaa")
+    monkeypatch.setenv("STACK_SECRET_SERVER_KEY", "ssk_test_abcdef")
+    monkeypatch.setenv("STACK_PUBLISHABLE_CLIENT_KEY", "spk_test_abcdef")
+    from app.config import Settings
+
+    settings = Settings()
+    assert settings.auth_provider == "neon"
+    assert settings.neon_auth_jwks_url == "https://example.neon.app/.well-known/jwks.json"
+
+
+def test_auth_provider_resend_does_not_require_neon_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Default path: AUTH_PROVIDER=resend means the Neon Auth code path is
+    # never exercised, so its env vars don't need to be populated. This
+    # is what every existing deploy looks like prior to T12.
+    monkeypatch.setenv("AUTH_PROVIDER", "resend")
+    monkeypatch.delenv("NEON_AUTH_BASE_URL", raising=False)
+    monkeypatch.delenv("STACK_SECRET_SERVER_KEY", raising=False)
+    from app.config import Settings
+
+    settings = Settings()
+    assert settings.auth_provider == "resend"
+
+
+# ── Non-ASCII secret validator (defense against PR #50 paste-mishap) ─
+
+
+def test_resend_api_key_with_non_ascii_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    # PR #50 incident: a `√` character snuck into RESEND_API_KEY via
+    # Word-style clipboard autoformat. urllib3 raised UnicodeEncodeError
+    # at the first outbound HTTP call, but background-task wrapping
+    # swallowed the error — magic-link emails silently failed in prod.
+    # Refuse the value at startup instead.
+    monkeypatch.setenv("RESEND_API_KEY", "re_abc√def")
+    from app.config import Settings
+
+    with pytest.raises(ValueError, match="RESEND_API_KEY contains non-ASCII char"):
+        Settings()
+
+
+def test_neon_auth_cookie_secret_with_non_ascii_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NEON_AUTH_COOKIE_SECRET", "secret-with-em-dash-—-inside")
+    from app.config import Settings
+
+    with pytest.raises(ValueError, match="NEON_AUTH_COOKIE_SECRET contains non-ASCII char"):
+        Settings()
+
+
+def test_stack_server_key_with_non_ascii_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STACK_SECRET_SERVER_KEY", "ssk_test_ñope")
+    from app.config import Settings
+
+    with pytest.raises(ValueError, match="STACK_SECRET_SERVER_KEY contains non-ASCII char"):
+        Settings()
+
+
+def test_empty_secrets_skip_ascii_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Empty values must not trigger the validator — the dev/test path
+    # leaves all five secrets empty and the validator should pass cleanly.
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    monkeypatch.delenv("STACK_SECRET_SERVER_KEY", raising=False)
+    monkeypatch.delenv("STACK_PUBLISHABLE_CLIENT_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("NEON_AUTH_COOKIE_SECRET", raising=False)
+    from app.config import Settings
+
+    Settings()  # must not raise
+
+
+def test_ascii_secrets_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Happy path: realistic-shaped ASCII values across every guarded
+    # secret slot pass through cleanly.
+    monkeypatch.setenv("RESEND_API_KEY", "re_abcdef123456")
+    monkeypatch.setenv("STACK_SECRET_SERVER_KEY", "ssk_test_abcdef")
+    monkeypatch.setenv("STACK_PUBLISHABLE_CLIENT_KEY", "spk_test_abcdef")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-abcdef")
+    monkeypatch.setenv("NEON_AUTH_COOKIE_SECRET", "0123456789abcdef0123456789abcdef")
+    from app.config import Settings
+
+    Settings()  # must not raise


### PR DESCRIPTION
## Summary

Wires the five Neon Auth env vars and the `AUTH_PROVIDER` feature flag across Pydantic Settings, both deploy workflows, and the env example. Default `AUTH_PROVIDER=resend` preserves current behavior — T12 (#71) is the planned flip.

Closes #62. Part of the [Neon Auth migration epic](https://github.com/vibeacademy/cubrox/issues/59).

## What changes

- **`app/config.py`** — adds 5 fields (`auth_provider`, `neon_auth_base_url`, `neon_auth_jwks_url`, `neon_auth_cookie_secret`, `stack_secret_server_key`, `stack_publishable_client_key`) and two model validators:
  - `_validate_neon_auth_consistency`: refuses to start when `AUTH_PROVIDER=neon` but any of the five Neon Auth env vars is empty. Error names the specific missing vars.
  - `_refuse_non_ascii_in_secrets`: catches the PR #50 paste-mishap class (the `√` in `RESEND_API_KEY` that silently broke outbound HTTP because background-task wrapping swallowed the `UnicodeEncodeError`). Extended to cover all header-bound secrets: `RESEND_API_KEY`, `STACK_*`, `ANTHROPIC_API_KEY`, `NEON_AUTH_COOKIE_SECRET`.
- **`.env.example`** — created (was missing). Documents every env var the app reads, including the new Neon Auth block with generation instructions for `NEON_AUTH_COOKIE_SECRET`.
- **`.gitignore`** — `!.env.example` negation so the example file checks in despite `.env.*` ignore.
- **`.github/workflows/deploy.yml`** — production deploy injects the 6 new env vars from `NEON_AUTH_PROD_*` + shared `NEON_AUTH_COOKIE_SECRET` secrets.
- **`.github/workflows/preview-deploy.yml`** — preview deploys inject from `NEON_AUTH_DEV_*` secrets via the existing conditional `if [ -n ... ]` pattern. `AUTH_PROVIDER` is always set (defaults to `resend` via `vars.AUTH_PROVIDER || 'resend'`).
- **`tests/test_config.py`** — 11 new cases covering default, invalid value, missing-var enumeration, happy path, and non-ASCII rejection for each header-bound secret.

## Why the design

- **Same image, two code paths.** Both Resend and Neon Auth ship in every Docker image; the flag selects which one `/login` dispatches to. Rollback is `gcloud run services update --update-env-vars AUTH_PROVIDER=resend` (~30s).
- **Fail-fast over silent misconfig.** The consistency validator rejects half-configured Neon at boot rather than 500ing on the first sign-in.
- **One cookie secret across environments.** `NEON_AUTH_COOKIE_SECRET` is the cookie signer, not a per-branch key — Neon's [2026-01-30 breaking change](https://neon.tech/docs/changelog) made it mandatory.

## Dependencies

Cannot be merged until **AUTH-6 (#61)** is complete (Laura captures the Neon Console values and creates the GitHub Secrets). This PR will not break anything if merged before — the conditional `if [ -n ... ]` gates skip injection when secrets are absent and the validator only fires when `AUTH_PROVIDER=neon` — but the Neon code path (AUTH-9/10/11) can't be exercised without the secrets in place.

## Test plan

- [x] `uv run pytest tests/test_config.py -v` — 24 passed (11 new)
- [x] `uv run pytest` — full suite 252 passed
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy app/` — clean
- [x] Pre-push hook passed
- [ ] CI green on this PR (waiting on push)
- [ ] After AUTH-6 secrets land, verify preview deploy injects `NEON_AUTH_*` env vars without error
- [ ] Manual: confirm `Settings()` fails fast with helpful message when `AUTH_PROVIDER=neon` and any var missing (covered by test, also worth a Cloud Run smoke once T11/#71 wires the route)

## IDE diagnostic warnings

`Context access might be invalid: NEON_AUTH_*` warnings on both workflows are expected — the IDE can't see GitHub Secrets that don't exist yet (AUTH-6 creates them). Same pattern as PR #50. CI runner doesn't care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)