### PR TITLE
feat(supabase): initial schema + RLS policies (SUPA-2, #81)

### DIFF
--- a/supabase/migrations/20260524015233_initial_schema.sql
+++ b/supabase/migrations/20260524015233_initial_schema.sql
@@ -1,0 +1,106 @@
+-- Initial Supabase schema for cubrox (SUPA-2 / #81).
+--
+-- Translation of alembic/versions/001-007. The `user` and
+-- `magic_link_token` tables are intentionally omitted — Supabase's
+-- built-in `auth.users` replaces them per SUPA-3 (#82). All
+-- user-scoped tables FK to `auth.users(id)` via `owner_id`.
+--
+-- This migration is ADDITIVE: it creates the new Supabase schema
+-- without removing anything on the legacy Neon side. The legacy
+-- SQLModels and alembic/ get deleted in SUPA-2b (#87) once SUPA-3
+-- swaps the auth layer.
+--
+-- pgcrypto is pre-installed on Supabase projects; gen_random_uuid()
+-- works without an explicit CREATE EXTENSION.
+
+-- ─────────────────────────────────────────────────────────────────
+-- Tenant-scoped tables (FK owner_id -> auth.users)
+-- ─────────────────────────────────────────────────────────────────
+
+-- passage: user-submitted reading passages (paste or PDF).
+-- Translated from alembic 004.
+CREATE TABLE public.passage (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_id        uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    text            text NOT NULL,
+    text_hash       bytea NOT NULL,
+    source_type     text NOT NULL,
+    source_filename text,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT passage_source_type_check CHECK (source_type IN ('paste', 'pdf'))
+);
+
+-- Newest-first per-owner listing (reading-history view).
+CREATE INDEX ix_passage_owner_id_created_at
+    ON public.passage (owner_id, created_at DESC);
+
+-- Content-addressable lookup for cross-user passage de-duplication
+-- + comprehension cache key (see comprehension_question_cache below).
+CREATE INDEX ix_passage_text_hash
+    ON public.passage (text_hash);
+
+
+-- preference: one row per user, JSON-shaped value bag.
+-- Translated from alembic 005. PK changes from user_id to owner_id.
+CREATE TABLE public.preference (
+    owner_id   uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    values     jsonb NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+
+-- reading_event: append-only event log for the "100k lines processed"
+-- PRD metric. Translated from alembic 007.
+CREATE TABLE public.reading_event (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_id        uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    passage_id      uuid NOT NULL REFERENCES public.passage(id) ON DELETE CASCADE,
+    lines_processed integer NOT NULL,
+    occurred_at     timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT reading_event_lines_processed_positive CHECK (lines_processed >= 1)
+);
+
+-- Aggregate query for METRIC-3 groups by date.
+CREATE INDEX ix_reading_event_occurred_at
+    ON public.reading_event (occurred_at);
+
+
+-- ─────────────────────────────────────────────────────────────────
+-- System / cross-user tables (no owner_id; service-role only)
+-- ─────────────────────────────────────────────────────────────────
+
+-- comprehension_question_cache: cross-user LLM-output cache keyed
+-- on (passage content hash, question type, model, prompt version).
+-- Translated from alembic 002. Server-managed only — never written
+-- from a user-bound session.
+CREATE TABLE public.comprehension_question_cache (
+    passage_hash    bytea NOT NULL,
+    question_type   text NOT NULL,
+    model_id        text NOT NULL,
+    prompt_version  integer NOT NULL,
+    questions       jsonb NOT NULL,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT comprehension_question_cache_pkey
+        PRIMARY KEY (passage_hash, question_type, model_id, prompt_version)
+);
+
+
+-- rate_bucket: per-key token bucket for /login + /auth/verify rate
+-- limiting. Translated from alembic 006. System table; the `key`
+-- column is opaque (e.g. "login:ip:203.0.113.7").
+CREATE TABLE public.rate_bucket (
+    key         varchar(255) PRIMARY KEY,
+    tokens      double precision NOT NULL,
+    refilled_at timestamptz NOT NULL
+);
+
+
+-- todo: workshop demo scaffold (alembic 001). Not user-scoped in the
+-- existing schema; carried over for parity until removed in a
+-- separate cleanup PR.
+CREATE TABLE public.todo (
+    id         serial PRIMARY KEY,
+    title      varchar(200) NOT NULL,
+    done       boolean NOT NULL DEFAULT false,
+    created_at timestamp NOT NULL DEFAULT now()
+);

--- a/supabase/migrations/20260524015234_rls_policies.sql
+++ b/supabase/migrations/20260524015234_rls_policies.sql
@@ -1,0 +1,105 @@
+-- Row-Level Security policies for the cubrox schema (SUPA-2 / #81).
+--
+-- Threat model: the anon key is published in client code. Any
+-- authenticated session calling the Data API gets the `authenticated`
+-- role and bears a JWT whose `sub` claim Supabase exposes as
+-- `auth.uid()`. RLS is the only thing standing between User A and
+-- User B's data.
+--
+-- Per Supabase guidance, every table in the `public` schema has RLS
+-- enabled. Tables that don't have a user-scoped access model
+-- (caches, system tables, scaffold) get RLS turned on with NO
+-- authenticated/anon policies — they remain accessible only via the
+-- service role, which bypasses RLS.
+
+-- ─────────────────────────────────────────────────────────────────
+-- Enable RLS on every table
+-- ─────────────────────────────────────────────────────────────────
+
+ALTER TABLE public.passage                       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.preference                    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.reading_event                 ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.comprehension_question_cache  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rate_bucket                   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.todo                          ENABLE ROW LEVEL SECURITY;
+
+
+-- ─────────────────────────────────────────────────────────────────
+-- passage — owner can do anything to own rows
+-- ─────────────────────────────────────────────────────────────────
+
+CREATE POLICY "owner can select own passages"
+    ON public.passage FOR SELECT
+    TO authenticated
+    USING (owner_id = auth.uid());
+
+CREATE POLICY "owner can insert own passages"
+    ON public.passage FOR INSERT
+    TO authenticated
+    WITH CHECK (owner_id = auth.uid());
+
+-- UPDATE needs USING (read row) + WITH CHECK (write row). Per
+-- Supabase guidance: without USING, an UPDATE silently affects 0 rows.
+CREATE POLICY "owner can update own passages"
+    ON public.passage FOR UPDATE
+    TO authenticated
+    USING (owner_id = auth.uid())
+    WITH CHECK (owner_id = auth.uid());
+
+CREATE POLICY "owner can delete own passages"
+    ON public.passage FOR DELETE
+    TO authenticated
+    USING (owner_id = auth.uid());
+
+
+-- ─────────────────────────────────────────────────────────────────
+-- preference — owner can do anything to own row (one row per user)
+-- ─────────────────────────────────────────────────────────────────
+
+CREATE POLICY "owner can select own preference"
+    ON public.preference FOR SELECT
+    TO authenticated
+    USING (owner_id = auth.uid());
+
+CREATE POLICY "owner can insert own preference"
+    ON public.preference FOR INSERT
+    TO authenticated
+    WITH CHECK (owner_id = auth.uid());
+
+CREATE POLICY "owner can update own preference"
+    ON public.preference FOR UPDATE
+    TO authenticated
+    USING (owner_id = auth.uid())
+    WITH CHECK (owner_id = auth.uid());
+
+CREATE POLICY "owner can delete own preference"
+    ON public.preference FOR DELETE
+    TO authenticated
+    USING (owner_id = auth.uid());
+
+
+-- ─────────────────────────────────────────────────────────────────
+-- reading_event — append-only domain; no UPDATE/DELETE policies on
+-- purpose. Owner can insert + select own events. The app's METRIC-3
+-- aggregate runs as the service role (cross-user date rollup).
+-- ─────────────────────────────────────────────────────────────────
+
+CREATE POLICY "owner can select own reading events"
+    ON public.reading_event FOR SELECT
+    TO authenticated
+    USING (owner_id = auth.uid());
+
+CREATE POLICY "owner can insert own reading events"
+    ON public.reading_event FOR INSERT
+    TO authenticated
+    WITH CHECK (owner_id = auth.uid());
+
+
+-- ─────────────────────────────────────────────────────────────────
+-- Service-role-only tables: RLS enabled, NO authenticated/anon
+-- policies. Reachable only via the service role (bypasses RLS).
+-- ─────────────────────────────────────────────────────────────────
+
+-- comprehension_question_cache: server-side cache, no user-bound access
+-- rate_bucket: system token bucket, no user-bound access
+-- todo: workshop scaffold, no access until removed


### PR DESCRIPTION
## Summary

Additive-only translation of `alembic/versions/001-007` into Supabase SQL migrations. Creates the new schema on the Supabase remote (via auto-branching for this PR) without touching the legacy Neon DB or any Python code. Per the revised scope of [SUPA-2 (#81)](https://github.com/vibeacademy/cubrox/issues/81); destructive cleanup follows in [SUPA-2b (#87)](https://github.com/vibeacademy/cubrox/issues/87).

## What's in the schema

**Tenant-scoped tables** — `owner_id` FK to `auth.users(id)`, full RLS by `auth.uid()`:
| Table | Source | Policies |
|---|---|---|
| `passage` | alembic 004 | SELECT / INSERT / UPDATE / DELETE |
| `preference` | alembic 005 (PK was `user_id`, now `owner_id`) | SELECT / INSERT / UPDATE / DELETE |
| `reading_event` | alembic 007 (append-only) | SELECT / INSERT only |

**System / cross-user tables** — RLS enabled with **no** `authenticated`/`anon` policies; reachable only via the service role:
- `comprehension_question_cache` (alembic 002) — server-managed LLM cache
- `rate_bucket` (alembic 006) — system token bucket
- `todo` (alembic 001) — workshop scaffold; carried over for code parity

**Omitted on purpose:** `user` and `magic_link_token`. Supabase's built-in `auth.users` replaces them after SUPA-3 (#82) swaps the auth layer.

## Why two files

```
supabase/migrations/
  20260524015233_initial_schema.sql   # creates tables
  20260524015234_rls_policies.sql     # references those tables
```

Sequential timestamps make the apply order explicit; the RLS file would fail if it ran first.

## Tests this PR is exercising

1. **Supabase auto-branching** — first PR with real migrations. The integration should create a `pr-N` branch and apply both files cleanly. If it doesn't, that's a SUPA-1 leftover blocker, not this PR's fault.
2. **RLS enabled on every public-schema table** — verifiable in the dashboard, or `SELECT tablename, rowsecurity FROM pg_tables WHERE schemaname='public'` against the branch.
3. **CI** — no Python touched, so existing 241 tests still pass against in-memory SQLite (Neon path unchanged).

## DoD status for #81 (revised scope)

| Item | Status |
|---|---|
| `supabase/migrations/` has the two migration files (scaffolded via `supabase migration new`) | ✅ |
| Supabase auto-branching applies both files cleanly | ⏳ verifies on push |
| Every user-scoped public table has RLS + `auth.uid()` policy | ✅ in SQL |
| `ruff` + `mypy` + `pytest` pass (no Python changed) | ✅ verified pre-push |
| Legacy `alembic/` + `User`/`MagicLinkToken` untouched (additive guardrail) | ✅ |
| Follow-on `SUPA-2b (#87)` referenced for destructive half | ✅ |

## Out of scope (handled elsewhere)

- Deleting `app/models/user.py`, `app/models/magic_link_token.py`, `alembic/` → **#87**
- Renaming `user_id` → `owner_id` in Python models → **#87**
- Swapping `app/db.py` to Supabase Postgres → **#82 (SUPA-3)**
- Rewriting auth flow to use Supabase GoTrue → **#82 (SUPA-3)**

Closes #81 once Supabase auto-branching verifies the apply.