### PR TITLE
test(a11y): restore Playwright seed via Supabase admin (#97)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,32 @@ jobs:
       - name: Install Python dependencies
         run: uv sync --extra dev
 
+      # Local Supabase stack for the a11y harness (#97). The seed
+      # router calls the real Supabase admin + auth APIs to mint a
+      # session JWT; without a backend to talk to those calls would
+      # fail. The CLI's local stack runs in Docker (pre-installed on
+      # ubuntu-latest), applies supabase/migrations/*.sql automatically,
+      # and exposes itself on http://127.0.0.1:54321.
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start local Supabase stack
+        # `supabase status -o json` returns the freshly-generated keys
+        # for the local stack; we export them to GITHUB_ENV so the
+        # Playwright step (and the uvicorn subprocess it spawns) can
+        # read them via SUPABASE_URL / SUPABASE_ANON_KEY /
+        # SUPABASE_SERVICE_KEY without hard-coding the local-default
+        # JWTs (which can drift across CLI versions).
+        run: |
+          supabase start
+          {
+            echo "SUPABASE_URL=$(supabase status -o json | jq -r '.API_URL')"
+            echo "SUPABASE_ANON_KEY=$(supabase status -o json | jq -r '.ANON_KEY')"
+            echo "SUPABASE_SERVICE_KEY=$(supabase status -o json | jq -r '.SERVICE_ROLE_KEY')"
+          } >> "$GITHUB_ENV"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -276,6 +302,9 @@ jobs:
         # ENVIRONMENT are also set inside playwright.config.ts >
         # webServer.env, so the FastAPI subprocess sees them
         # regardless of whether the job-level env propagates.
+        # SUPABASE_* come from $GITHUB_ENV (set by the "Start local
+        # Supabase stack" step above) and are forwarded into the
+        # uvicorn subprocess by playwright.config.ts.
         env:
           CUBROX_TEST_SEED_ENABLED: 'true'
           SESSION_COOKIE_SECURE: 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,17 +249,23 @@ jobs:
 
       - name: Start local Supabase stack
         # `supabase status -o json` returns the freshly-generated keys
-        # for the local stack; we export them to GITHUB_ENV so the
-        # Playwright step (and the uvicorn subprocess it spawns) can
-        # read them via SUPABASE_URL / SUPABASE_ANON_KEY /
-        # SUPABASE_SERVICE_KEY without hard-coding the local-default
-        # JWTs (which can drift across CLI versions).
+        # + DB URL for the local stack; we export them to GITHUB_ENV
+        # so the Playwright step (and the uvicorn subprocess it spawns)
+        # can read them without hard-coding values (the local-default
+        # JWTs drift across CLI versions).
+        #
+        # DATABASE_URL points at the local Supabase Postgres so the
+        # Passage / Preference INSERTs land in the same DB the migrations
+        # already populated. Without this the subprocess falls back to
+        # `sqlite:///./dev.db` (the pydantic default) which has no
+        # schema applied — INSERTs fail with `no such table: passage`.
         run: |
           supabase start
           {
             echo "SUPABASE_URL=$(supabase status -o json | jq -r '.API_URL')"
             echo "SUPABASE_ANON_KEY=$(supabase status -o json | jq -r '.ANON_KEY')"
             echo "SUPABASE_SERVICE_KEY=$(supabase status -o json | jq -r '.SERVICE_ROLE_KEY')"
+            echo "DATABASE_URL=$(supabase status -o json | jq -r '.DB_URL')"
           } >> "$GITHUB_ENV"
 
       - name: Setup Node.js

--- a/app/api/test_seed.py
+++ b/app/api/test_seed.py
@@ -1,0 +1,185 @@
+"""Test-only seed router for the WCAG harness (A11Y-2 #25, restored for SUPA-2c follow-up #97).
+
+Provides POST /test/seed-passage-and-login: provisions a fresh Supabase
+Auth user + Passage row (+ optional Preference row) and returns the
+Supabase session JWT as the `sb-access-token` cookie + the new passage
+id. Playwright hits this once per test to set up an authenticated,
+parameterized reading surface without going through the magic-link
+email flow.
+
+## Difference from the pre-SUPA-2c version
+
+Identity now lives in Supabase `auth.users`, not a local `User` SQLModel
+(deleted in SUPA-2c #91). To mint a session JWT we:
+
+  1. `service_client().auth.admin.create_user(...)` — privileged admin
+     call that creates a confirmed user without an email round-trip.
+  2. `anon_client().auth.sign_in_with_password(...)` — exchange the
+     known password for an access token. We do this instead of
+     `admin.generate_link` because the password-grant path returns a
+     ready-to-use JWT directly; `generate_link` returns a URL that
+     still requires the hash-fragment callback dance to exchange.
+
+The Passage and Preference rows still go in our local DB and reference
+the Supabase user UUID via `owner_id` (renamed from `user_id` in
+SUPA-2c).
+
+## Two-layer guard
+
+This router must never load in production:
+
+1. **Module-level guard** (this file): the import itself raises
+   `RuntimeError` unless `CUBROX_TEST_SEED_ENABLED=true` OR
+   `ENVIRONMENT=test`. Belt-and-braces — even a stray `import` from
+   anywhere in the codebase fails loudly.
+
+2. **Registration-level guard** (app/main.py): the import + router
+   registration is wrapped in `if os.environ.get(...) == "true": ...`.
+   So unless the env var is explicitly set, the module is never
+   imported in the first place.
+
+The CI a11y job sets `CUBROX_TEST_SEED_ENABLED=true` on the FastAPI
+process via `playwright.config.ts > webServer.env`. Production Cloud
+Run revisions do not set this var; the seed router cannot be reached.
+"""
+
+import os
+import secrets
+import uuid
+from datetime import UTC, datetime
+from typing import Annotated, Any, Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
+from sqlmodel import Session
+
+from app.config import Settings, get_settings
+from app.db import get_session
+from app.integrations.supabase.auth import SUPABASE_COOKIE_NAME
+from app.integrations.supabase.client import anon_client, service_client
+from app.models.passage import Passage
+from app.models.preference import Preference
+
+_SEED_ENABLED = os.environ.get("CUBROX_TEST_SEED_ENABLED") == "true"
+_TEST_ENV = os.environ.get("ENVIRONMENT") == "test"
+if not (_SEED_ENABLED or _TEST_ENV):
+    raise RuntimeError(
+        "app.api.test_seed loaded in non-test environment. "
+        "Set CUBROX_TEST_SEED_ENABLED=true (test envs only) or "
+        "ENVIRONMENT=test to enable."
+    )
+
+
+router = APIRouter()
+
+SessionDep = Annotated[Session, Depends(get_session)]
+SettingsDep = Annotated[Settings, Depends(get_settings)]
+
+Variant = Literal["default", "high-contrast", "large-text", "bionic"]
+
+# Representative passage with multiple paragraphs so axe-core has a
+# real surface to analyze — headings, paragraph spacing, line wrap,
+# and color contrast over substantive content.
+SEED_PASSAGE_TEXT = (
+    "O Son of Spirit!\n\n"
+    "My first counsel is this: Possess a pure, kindly and radiant heart, "
+    "that thine may be a sovereignty ancient, imperishable and everlasting.\n\n"
+    "O Son of Spirit!\n\n"
+    "The best beloved of all things in My sight is Justice. Turn not away "
+    "therefrom if thou desirest Me, and neglect it not that I may confide in thee."
+)
+
+
+# Per-variant overrides to the stored Preference values. `default` is
+# empty (no row created — the reading view falls back to the
+# DEFAULT_PREFERENCES path). The other three exercise one axis each so
+# any a11y regression points clearly at which preference broke.
+_PREFS_FOR_VARIANT: dict[str, dict[str, Any]] = {
+    "default": {},
+    "high-contrast": {"bg": "#1a1a1a", "fg": "#e8e8e8"},
+    "large-text": {"size": "28px"},
+    "bionic": {"bionic_enabled": True},
+}
+
+
+@router.post("/test/seed-passage-and-login")
+def seed_passage_and_login(
+    variant: Variant,
+    session: SessionDep,
+    settings: SettingsDep,
+) -> JSONResponse:
+    """Seed a fresh Supabase user + passage + (optional) preference;
+    return the Supabase access token as the `sb-access-token` cookie +
+    passage id in JSON.
+
+    Each invocation creates an independent throwaway user (UUID-suffixed
+    email) so concurrent Playwright tests don't collide on the email
+    unique constraint in Supabase Auth.
+    """
+    email = f"a11y-{uuid.uuid4()}@example.test"
+    # Supabase requires a password on admin.create_user (even with
+    # email_confirm=True). We mint a random one — it's never persisted
+    # outside this function; the test only needs the JWT it unlocks.
+    password = secrets.token_urlsafe(32)
+
+    admin = service_client().auth.admin
+    admin.create_user(
+        {
+            "email": email,
+            "password": password,
+            "email_confirm": True,
+        }
+    )
+
+    # Exchange the password for a real Supabase session JWT — same
+    # shape `/auth/callback` produces, so `current_user` (which calls
+    # `anon_client().auth.get_user(token)`) accepts it identically.
+    auth_resp = anon_client().auth.sign_in_with_password({"email": email, "password": password})
+    if auth_resp is None or auth_resp.session is None or auth_resp.user is None:
+        raise HTTPException(
+            status_code=500,
+            detail="Supabase sign-in did not return a session for seeded user.",
+        )
+    access_token: str = auth_resp.session.access_token
+    user_id = uuid.UUID(str(auth_resp.user.id))
+
+    passage = Passage(
+        owner_id=user_id,
+        # Placeholder hash — the read path doesn't validate it; only
+        # the comprehension-cache uses text_hash, which the a11y tests
+        # don't exercise (the questions panel makes a network call we
+        # don't care about for visual a11y).
+        text_hash=b"\x00" * 32,
+        text=SEED_PASSAGE_TEXT,
+        source_type="paste",
+        source_filename=None,
+    )
+    session.add(passage)
+
+    prefs_overrides = _PREFS_FOR_VARIANT[variant]
+    if prefs_overrides:
+        session.add(
+            Preference(
+                owner_id=user_id,
+                values=prefs_overrides,
+                updated_at=datetime.now(UTC),
+            )
+        )
+
+    session.commit()
+    session.refresh(passage)
+
+    response = JSONResponse({"passage_id": str(passage.id), "variant": variant})
+    response.set_cookie(
+        key=SUPABASE_COOKIE_NAME,
+        value=access_token,
+        # Match the /auth/callback cookie's max-age so the test session
+        # behaves the same as a real sign-in.
+        max_age=7 * 24 * 60 * 60,
+        httponly=True,
+        # Test harness runs over plain HTTP on localhost. Production
+        # cookies stay `secure=True` via the normal /auth/callback path.
+        secure=settings.session_cookie_secure,
+        samesite="lax",
+    )
+    return response

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ Run locally:
 Production (Cloud Run) runs the same command — see Dockerfile.
 """
 
+import os
 from pathlib import Path
 
 from fastapi import FastAPI, Request
@@ -54,8 +55,13 @@ app.include_router(auth.router)
 app.include_router(passages.router)
 app.include_router(reading.router)
 
-# Test-only seed router (A11Y-2 #25) was DELETED in SUPA-2c (#91)
-# because it depended on the legacy itsdangerous cookie-signing path.
-# The Playwright a11y harness will need a follow-up ticket to seed
-# users via Supabase Auth's admin API instead. Until then, the
-# CUBROX_TEST_SEED_ENABLED env var is a no-op.
+# Test-only seed router (A11Y-2 #25, restored in #97). Only mounts when
+# CUBROX_TEST_SEED_ENABLED=true — the CI a11y job sets this via
+# playwright.config.ts > webServer.env. Production Cloud Run revisions
+# never set it, so the router is unreachable in prod. The router file
+# itself has a second module-level guard so a stray `import` would
+# also fail loudly.
+if os.environ.get("CUBROX_TEST_SEED_ENABLED") == "true":
+    from app.api import test_seed
+
+    app.include_router(test_seed.router)

--- a/tests/a11y/playwright.config.ts
+++ b/tests/a11y/playwright.config.ts
@@ -1,6 +1,24 @@
 import { defineConfig, devices } from "@playwright/test";
 
 /**
+ * Only forward an env var to the spawned uvicorn process if it's
+ * actually set in our own environment. Used for the SUPABASE_* keys:
+ * in CI they come from `$GITHUB_ENV` (set by the "Start local Supabase
+ * stack" step), so we forward them explicitly. In local dev, the
+ * developer's `.env` file is read directly by pydantic-settings inside
+ * the subprocess — forwarding empty strings here would override that
+ * `.env` value with `""` and break the config validator.
+ */
+function envIfSet(...keys: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const key of keys) {
+    const value = process.env[key];
+    if (value) result[key] = value;
+  }
+  return result;
+}
+
+/**
  * Playwright config for Cubrox accessibility tests.
  *
  * The harness spawns the real FastAPI app via `uv run uvicorn` and
@@ -52,6 +70,13 @@ export default defineConfig({
       // cookies are verifiable. Config's _refuse_sqlite_outside_dev
       // gate trips on "dev-only" outside development/test envs.
       ENVIRONMENT: "test",
+      // Supabase backend the seed router talks to. In CI these are
+      // exported by the "Start local Supabase stack" step in ci.yml.
+      // In local dev the developer's .env file is read directly by
+      // pydantic-settings (see envIfSet doc above) — we only forward
+      // when actually present in process.env to avoid overriding .env
+      // with empty strings.
+      ...envIfSet("SUPABASE_URL", "SUPABASE_ANON_KEY", "SUPABASE_SERVICE_KEY"),
     },
   },
 });

--- a/tests/a11y/playwright.config.ts
+++ b/tests/a11y/playwright.config.ts
@@ -70,13 +70,20 @@ export default defineConfig({
       // cookies are verifiable. Config's _refuse_sqlite_outside_dev
       // gate trips on "dev-only" outside development/test envs.
       ENVIRONMENT: "test",
-      // Supabase backend the seed router talks to. In CI these are
-      // exported by the "Start local Supabase stack" step in ci.yml.
-      // In local dev the developer's .env file is read directly by
-      // pydantic-settings (see envIfSet doc above) — we only forward
-      // when actually present in process.env to avoid overriding .env
-      // with empty strings.
-      ...envIfSet("SUPABASE_URL", "SUPABASE_ANON_KEY", "SUPABASE_SERVICE_KEY"),
+      // Supabase backend the seed router talks to + local DATABASE_URL
+      // (Postgres inside the local Supabase stack — has the migrated
+      // schema, so Passage / Preference INSERTs land in a real table).
+      // In CI all four are exported by the "Start local Supabase stack"
+      // step in ci.yml. In local dev the developer's .env file is read
+      // directly by pydantic-settings (see envIfSet doc above) — we
+      // only forward when actually present in process.env to avoid
+      // overriding .env with empty strings.
+      ...envIfSet(
+        "SUPABASE_URL",
+        "SUPABASE_ANON_KEY",
+        "SUPABASE_SERVICE_KEY",
+        "DATABASE_URL",
+      ),
     },
   },
 });

--- a/tests/a11y/reading_surface.spec.ts
+++ b/tests/a11y/reading_surface.spec.ts
@@ -25,14 +25,6 @@ import { seedAndLogin, type Variant } from "./fixtures/seed";
 
 const VARIANTS: Variant[] = ["default", "high-contrast", "large-text", "bionic"];
 
-// SUPA-2c (#91) deleted app/api/test_seed.py — the route this fixture
-// relied on. The Playwright a11y harness needs a replacement seeding
-// mechanism that uses Supabase's admin API to create a user and mint
-// a session JWT, then sets the sb-access-token cookie on the browser
-// context. Tracked in a follow-up ticket; until then, skip these
-// tests so the CI gate doesn't permanently block the migration epic.
-test.skip(true, "needs Supabase-admin-based seeding; see SUPA-2c follow-up");
-
 for (const variant of VARIANTS) {
   test(`reading surface a11y: ${variant}`, async ({ page, context, request }) => {
     const { passageId } = await seedAndLogin(request, context, variant);

--- a/tests/test_seed_route.py
+++ b/tests/test_seed_route.py
@@ -1,0 +1,246 @@
+"""Route-level tests for the test-only seed endpoint (A11Y-2 #25, restored in #97).
+
+These tests exercise the actual POST /test/seed-passage-and-login
+route. The conftest doesn't normally register this router (the
+conditional in `app/main.py` only fires when `CUBROX_TEST_SEED_ENABLED=true`
+at app boot), so we mount the router onto the existing test app via
+FastAPI's `include_router` for the duration of each test.
+
+This is functional coverage of the seed handler — the variant matrix,
+the cookie shape, the row counts that the Playwright suite implicitly
+relies on. Pytest catches regressions before Playwright has to. The
+Supabase admin/sign-in calls are mocked by the conftest's
+`supabase_mock` fixture — see conftest.py for the shape.
+"""
+
+import importlib
+import sys
+import uuid
+from collections.abc import Generator
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.main import app
+from app.models.passage import Passage
+from app.models.preference import Preference
+
+
+def _wire_supabase_for_seed(supabase_mock: MagicMock, user_id: str | None = None) -> str:
+    """Wire the supabase_mock so admin.create_user no-ops and
+    sign_in_with_password returns a session for a known user UUID.
+
+    Returns the UUID string so callers can assert that ownership rows
+    on Passage / Preference match.
+    """
+    uid = user_id or str(uuid.uuid4())
+    supabase_mock.auth.sign_in_with_password.return_value = SimpleNamespace(
+        user=SimpleNamespace(id=uid, email="ignored-by-route@example.test"),
+        session=SimpleNamespace(access_token=f"fake-jwt-{uid[:8]}"),
+    )
+    return uid
+
+
+@pytest.fixture
+def seed_client(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+) -> Generator[TestClient, None, None]:
+    """TestClient with the seed router temporarily mounted on the app.
+
+    The guard inside app/api/test_seed.py needs ENVIRONMENT=test (the
+    pytest default for our conftest is `development`, so set it
+    explicitly). After the test runs, the router is removed from the
+    app so other tests don't see it.
+    """
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    sys.modules.pop("app.api.test_seed", None)
+    test_seed = importlib.import_module("app.api.test_seed")
+
+    app.include_router(test_seed.router)
+    try:
+        yield client
+    finally:
+        # Remove the seed routes so subsequent tests don't see them.
+        # FastAPI doesn't expose a public "remove_router"; pop the
+        # routes we just added by path-prefix match.
+        app.router.routes = [
+            r
+            for r in app.router.routes
+            if not (
+                hasattr(r, "path") and r.path == "/test/seed-passage-and-login"  # type: ignore[attr-defined]
+            )
+        ]
+
+
+def test_seed_default_variant_creates_passage_no_preference(
+    seed_client: TestClient, session: Session, supabase_mock: MagicMock
+) -> None:
+    """`default` is the no-Preference path — the reading view falls back
+    to DEFAULT_PREFERENCES without a row."""
+    _wire_supabase_for_seed(supabase_mock)
+
+    response = seed_client.post(
+        "/test/seed-passage-and-login?variant=default", follow_redirects=False
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["variant"] == "default"
+    # passage_id is a parseable UUID.
+    uuid.UUID(body["passage_id"])
+
+    # Exactly one passage, zero preferences. (User identity now lives
+    # in Supabase, not a local table, so we don't count User rows.)
+    assert len(session.exec(select(Passage)).all()) == 1
+    assert len(session.exec(select(Preference)).all()) == 0
+
+    # Cookie is the Supabase access-token cookie, carrying the fake JWT
+    # the mock returned. Subsequent /read/{id} requests will hit the
+    # `current_user` dependency, which is independently mocked.
+    assert "sb-access-token" in response.cookies
+
+
+def test_seed_creates_supabase_user_via_admin_api(
+    seed_client: TestClient, supabase_mock: MagicMock
+) -> None:
+    """The route MUST go through service_client().auth.admin.create_user
+    so the user has `email_confirm=True` and no email round-trip
+    happens. Lock down the API call shape so a future refactor
+    (e.g. accidentally switching to sign_up) breaks loudly."""
+    _wire_supabase_for_seed(supabase_mock)
+
+    response = seed_client.post("/test/seed-passage-and-login?variant=default")
+    assert response.status_code == 200
+
+    create_user_call = supabase_mock.auth.admin.create_user.call_args
+    assert create_user_call is not None, "admin.create_user was never invoked"
+    payload = create_user_call.args[0]
+    assert payload["email"].startswith("a11y-")
+    assert payload["email"].endswith("@example.test")
+    assert payload["email_confirm"] is True
+    # A random password is generated and passed to Supabase, then
+    # immediately exchanged via sign_in_with_password. We don't pin
+    # the value, just that one was set.
+    assert payload["password"]
+
+
+def test_seed_uses_password_grant_for_session_jwt(
+    seed_client: TestClient, supabase_mock: MagicMock
+) -> None:
+    """After admin.create_user, the route must call
+    anon_client().auth.sign_in_with_password to get a real JWT. The
+    alternative (generate_link) returns a URL that still requires a
+    callback exchange, so the password-grant path is the right one."""
+    _wire_supabase_for_seed(supabase_mock)
+
+    seed_client.post("/test/seed-passage-and-login?variant=default")
+
+    sign_in_call = supabase_mock.auth.sign_in_with_password.call_args
+    assert sign_in_call is not None, "sign_in_with_password was never invoked"
+    payload = sign_in_call.args[0]
+    assert payload["email"].startswith("a11y-")
+    assert payload["password"]
+
+
+def test_seed_high_contrast_variant_writes_dark_bg_fg(
+    seed_client: TestClient, session: Session, supabase_mock: MagicMock
+) -> None:
+    _wire_supabase_for_seed(supabase_mock)
+    response = seed_client.post(
+        "/test/seed-passage-and-login?variant=high-contrast", follow_redirects=False
+    )
+    assert response.status_code == 200
+
+    prefs = session.exec(select(Preference)).all()
+    assert len(prefs) == 1
+    assert prefs[0].values == {"bg": "#1a1a1a", "fg": "#e8e8e8"}
+
+
+def test_seed_large_text_variant_writes_28px(
+    seed_client: TestClient, session: Session, supabase_mock: MagicMock
+) -> None:
+    _wire_supabase_for_seed(supabase_mock)
+    response = seed_client.post(
+        "/test/seed-passage-and-login?variant=large-text", follow_redirects=False
+    )
+    assert response.status_code == 200
+
+    prefs = session.exec(select(Preference)).all()
+    assert len(prefs) == 1
+    assert prefs[0].values == {"size": "28px"}
+
+
+def test_seed_bionic_variant_writes_bionic_enabled_true(
+    seed_client: TestClient, session: Session, supabase_mock: MagicMock
+) -> None:
+    _wire_supabase_for_seed(supabase_mock)
+    response = seed_client.post(
+        "/test/seed-passage-and-login?variant=bionic", follow_redirects=False
+    )
+    assert response.status_code == 200
+
+    prefs = session.exec(select(Preference)).all()
+    assert len(prefs) == 1
+    assert prefs[0].values == {"bionic_enabled": True}
+
+
+def test_seed_unknown_variant_returns_422(
+    seed_client: TestClient, supabase_mock: MagicMock
+) -> None:
+    """The route uses a typing.Literal for the variant param. FastAPI
+    rejects unknown values with 422 automatically — and short-circuits
+    before any Supabase call."""
+    _wire_supabase_for_seed(supabase_mock)
+    response = seed_client.post(
+        "/test/seed-passage-and-login?variant=does-not-exist",
+        follow_redirects=False,
+    )
+    assert response.status_code == 422
+    # Confirm we didn't waste a Supabase call on a bad variant.
+    supabase_mock.auth.admin.create_user.assert_not_called()
+
+
+def test_seed_creates_independent_users_across_calls(
+    seed_client: TestClient, session: Session, supabase_mock: MagicMock
+) -> None:
+    """Each call creates a unique user (UUID-suffixed email) so
+    Playwright tests can run in parallel without colliding on Supabase
+    Auth's email unique constraint. We also verify the two created
+    passages are owned by distinct UUIDs (since each call mints a
+    different fake user in the mock)."""
+    uid_1 = _wire_supabase_for_seed(supabase_mock)
+    seed_client.post("/test/seed-passage-and-login?variant=default")
+
+    uid_2 = _wire_supabase_for_seed(supabase_mock)
+    seed_client.post("/test/seed-passage-and-login?variant=default")
+
+    assert uid_1 != uid_2
+
+    # Two admin.create_user calls with two distinct emails.
+    calls = supabase_mock.auth.admin.create_user.call_args_list
+    assert len(calls) == 2
+    emails = [c.args[0]["email"] for c in calls]
+    assert emails[0] != emails[1]
+    assert all(e.startswith("a11y-") for e in emails)
+
+    # Two passages, each owned by the respective Supabase user UUID.
+    passages = session.exec(select(Passage)).all()
+    assert len(passages) == 2
+    owner_ids = {str(p.owner_id) for p in passages}
+    assert owner_ids == {uid_1, uid_2}
+
+
+def test_seed_500s_when_supabase_sign_in_returns_no_session(
+    seed_client: TestClient, supabase_mock: MagicMock
+) -> None:
+    """Defensive guard: if Supabase's sign_in_with_password returns
+    `None` or a response without a session, we 500 instead of trying
+    to set a cookie with `None` as its value."""
+    supabase_mock.auth.sign_in_with_password.return_value = None
+    response = seed_client.post(
+        "/test/seed-passage-and-login?variant=default", follow_redirects=False
+    )
+    assert response.status_code == 500

--- a/tests/test_test_seed_guard.py
+++ b/tests/test_test_seed_guard.py
@@ -1,0 +1,61 @@
+"""Guard-rail test for the test-only seed router (A11Y-2 #25, restored in #97).
+
+`app/api/test_seed.py` must NEVER load in a non-test environment.
+The module's import-time guard raises RuntimeError unless one of:
+  - CUBROX_TEST_SEED_ENABLED=true (set explicitly by the a11y harness)
+  - ENVIRONMENT=test (set by the conftest in unit-test runs)
+
+These tests simulate a production-like env (neither var set to a test
+value) and confirm the import fails — belt-and-braces defense even if
+the conditional include in `app/main.py` is somehow bypassed.
+"""
+
+import importlib
+import sys
+
+import pytest
+
+
+def test_test_seed_refuses_to_load_in_non_test_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Belt-and-braces: even if someone bypasses the conditional import
+    in app/main.py and tries to import the module directly, the
+    module-level guard fires."""
+    monkeypatch.delenv("CUBROX_TEST_SEED_ENABLED", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "production")
+
+    # Drop any previously cached import so we re-execute the module body
+    # and re-run the guard.
+    sys.modules.pop("app.api.test_seed", None)
+
+    with pytest.raises(RuntimeError, match="non-test environment"):
+        importlib.import_module("app.api.test_seed")
+
+
+def test_test_seed_loads_when_explicitly_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sanity check: with the harness env var set, the import succeeds
+    and the router object is exposed. Mirrors what app/main.py does at
+    boot when CUBROX_TEST_SEED_ENABLED=true."""
+    monkeypatch.setenv("CUBROX_TEST_SEED_ENABLED", "true")
+    monkeypatch.setenv("ENVIRONMENT", "production")  # still allowed by the guard
+    sys.modules.pop("app.api.test_seed", None)
+
+    module = importlib.import_module("app.api.test_seed")
+    assert hasattr(module, "router")
+
+
+def test_test_seed_loads_in_test_environment_without_enable_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pytest conftest may not set CUBROX_TEST_SEED_ENABLED, but
+    setting ENVIRONMENT=test is sufficient. This is the "running under
+    pytest with explicit env=test" path."""
+    monkeypatch.delenv("CUBROX_TEST_SEED_ENABLED", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    sys.modules.pop("app.api.test_seed", None)
+
+    module = importlib.import_module("app.api.test_seed")
+    assert hasattr(module, "router")


### PR DESCRIPTION
## Summary

Restores the 4 reading-surface accessibility tests that were skipped in SUPA-2c (#91) when the legacy test-seed router was deleted. Closes #97.

The new router uses Supabase's admin API to create a confirmed user without an email round-trip, then exchanges a known password for a real session JWT — same shape `/auth/callback` produces, so `current_user` accepts it identically.

## What changes

- **`app/api/test_seed.py`** (new) — `POST /test/seed-passage-and-login`. Creates a throwaway Supabase user via `service_client().auth.admin.create_user`, signs in with the random password, then seeds a Passage (+ optional Preference) row owned by the Supabase user UUID. Two-layer guard preserved (module-level `RuntimeError` + conditional include in `app/main.py`).
- **`app/main.py`** — conditional `include_router(test_seed.router)` gated on `CUBROX_TEST_SEED_ENABLED=true`.
- **`tests/test_test_seed_guard.py`** (new, 3 tests) — pins the import-time guard: rejects non-test env, accepts `CUBROX_TEST_SEED_ENABLED=true`, accepts `ENVIRONMENT=test`.
- **`tests/test_seed_route.py`** (new, 9 tests) — variant matrix, cookie shape, admin-API call shape, password-grant call shape, 422 on unknown variant, independent users across calls, 500 when Supabase returns no session.
- **`tests/a11y/reading_surface.spec.ts`** — removed the `test.skip(true, …)` SUPA-2c stub. All 4 variants now run.
- **`tests/a11y/playwright.config.ts`** — forwards `SUPABASE_URL` / `SUPABASE_ANON_KEY` / `SUPABASE_SERVICE_KEY` to the uvicorn subprocess **only when set in `process.env`**, so local dev's `.env`-based config isn't overridden with empty strings.
- **`.github/workflows/ci.yml`** — a11y job now installs Supabase CLI, runs `supabase start` (Docker stack, ~30s), and exports the local keys via `$GITHUB_ENV` for the Playwright step to forward.

## Why the design

- **`admin.create_user` + `sign_in_with_password`** instead of `admin.generate_link` because the password-grant path returns a ready-to-use JWT directly. `generate_link` returns a URL that still requires the hash-fragment callback dance to exchange — extra moving parts for no benefit.
- **Local Supabase stack in CI** instead of using a shared dev project — avoids cross-PR pollution of `auth.users` and keeps the test bed deterministic. Same stack the docs already point developers to (`supabase start` in CLAUDE.md).
- **Forward env vars only when set** in `playwright.config.ts` so the local-dev path (developer's `.env` file read by pydantic-settings inside the subprocess) keeps working unchanged.

## Test plan

- [x] `uv run pytest` — 222 passed (12 new)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy app/` — clean
- [x] `npx playwright test --list` parses the config; the 4 reading-surface tests now appear (no longer skipped)
- [x] Pre-push hook passed
- [ ] CI a11y job green — verifies the `supabase start` wiring and that all 4 variants pass axe-core under WCAG 2.0 A+AA
- [ ] Manual local verification: `supabase start` + `(cd tests/a11y && npx playwright test)` shows 4 variants green

## Notes

- The `supabase start` step adds ~30s to the a11y job (Docker stack boot, no caching across runs). Acceptable trade-off for a real backend.
- Supabase CLI version is `latest` for now — happy to pin if you prefer (would need to pick a known-good version).
- If CI fails on the a11y job because of missing GitHub Action permissions for `supabase/setup-cli@v1`, that'd be the first thing to debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)