### PR TITLE
fix(db): rename user_id → owner_id on production tenant tables (#105)

### DIFF
--- a/supabase/migrations/20260526165646_rename_user_id_to_owner_id.sql
+++ b/supabase/migrations/20260526165646_rename_user_id_to_owner_id.sql
@@ -1,0 +1,129 @@
+-- Idempotent rename of `user_id` → `owner_id` on tenant-scoped tables (BUG-4 / #105).
+--
+-- Background: the production Supabase Postgres was data-migrated from
+-- the old alembic-era Neon database, which used the column name
+-- `user_id`. The SUPA-2c rename (`user_id` → `owner_id`) was applied to
+-- the SQLModel definitions + the supabase/migrations/*.sql files
+-- (which use `owner_id` from their initial state), but the production
+-- database itself was never realigned. Surface symptom: paste fails
+-- with `psycopg.errors.UndefinedColumn: column "owner_id" of relation
+-- "passage" does not exist` after the #104 type-coercion fix moved
+-- past the previous crash. See #105.
+--
+-- This migration is IDEMPOTENT:
+--   - On production (still has `user_id`): does the rename.
+--   - On local Supabase / per-PR branches (already `owner_id`): no-op.
+--   - Re-running is safe.
+--
+-- Why IF EXISTS in every branch: the initial_schema migration already
+-- creates the column as `owner_id` for fresh databases, so the IF
+-- EXISTS guards make this migration land cleanly regardless of whether
+-- a given database was bootstrapped from the alembic-era schema or
+-- from a fresh `supabase db push`.
+
+DO $$
+BEGIN
+    -- passage.user_id → owner_id
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name   = 'passage'
+          AND column_name  = 'user_id'
+    ) THEN
+        ALTER TABLE public.passage RENAME COLUMN user_id TO owner_id;
+    END IF;
+
+    -- preference.user_id → owner_id  (also the primary key — the rename
+    -- automatically renames the implicit PK constraint).
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name   = 'preference'
+          AND column_name  = 'user_id'
+    ) THEN
+        ALTER TABLE public.preference RENAME COLUMN user_id TO owner_id;
+    END IF;
+
+    -- reading_event.user_id → owner_id
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name   = 'reading_event'
+          AND column_name  = 'user_id'
+    ) THEN
+        ALTER TABLE public.reading_event RENAME COLUMN user_id TO owner_id;
+    END IF;
+END $$;
+
+-- Rename indexes that reference the old column name.
+-- (Postgres preserves the index logically when a column is renamed,
+-- but the INDEX NAME stays as it was, so we rename for grep-ability.
+-- The composite indexes were defined in the alembic-era migrations as
+-- `ix_<table>_user_id_created_at`; rename to match the supabase-era
+-- `ix_<table>_owner_id_created_at` shape.)
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND indexname  = 'ix_passage_user_id_created_at'
+    ) THEN
+        ALTER INDEX public.ix_passage_user_id_created_at
+            RENAME TO ix_passage_owner_id_created_at;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND indexname  = 'ix_reading_event_user_id_created_at'
+    ) THEN
+        ALTER INDEX public.ix_reading_event_user_id_created_at
+            RENAME TO ix_reading_event_owner_id_created_at;
+    END IF;
+END $$;
+
+-- Drop any leftover alembic-era FK constraints that pointed at the
+-- deleted `public.user` table. Recreate the FK against `auth.users`
+-- to match what the supabase-era initial_schema.sql declares.
+--
+-- Why this matters: if the data-migration preserved the column but the
+-- old `public.user` table was dropped on the way to Supabase, the FK
+-- constraint is dangling. On a database where the FK already points at
+-- auth.users (fresh supabase bootstrap), the DROP IF EXISTS is a no-op
+-- and the ADD CONSTRAINT either succeeds (if missing) or duplicates —
+-- so we DROP IF EXISTS first to make ADD idempotent.
+DO $$
+DECLARE
+    fk_record RECORD;
+BEGIN
+    -- Drop ANY foreign-key constraint on passage.owner_id /
+    -- preference.owner_id / reading_event.owner_id, regardless of
+    -- target. We re-add the auth.users FK below.
+    FOR fk_record IN
+        SELECT conname, conrelid::regclass AS table_name
+        FROM pg_constraint
+        WHERE contype = 'f'
+          AND conrelid IN (
+              'public.passage'::regclass,
+              'public.preference'::regclass,
+              'public.reading_event'::regclass
+          )
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %s DROP CONSTRAINT IF EXISTS %I',
+            fk_record.table_name, fk_record.conname
+        );
+    END LOOP;
+END $$;
+
+ALTER TABLE public.passage
+    ADD CONSTRAINT passage_owner_id_fkey
+        FOREIGN KEY (owner_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.preference
+    ADD CONSTRAINT preference_owner_id_fkey
+        FOREIGN KEY (owner_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.reading_event
+    ADD CONSTRAINT reading_event_owner_id_fkey
+        FOREIGN KEY (owner_id) REFERENCES auth.users(id) ON DELETE CASCADE;

--- a/supabase/migrations/20260526165646_rename_user_id_to_owner_id.sql
+++ b/supabase/migrations/20260526165646_rename_user_id_to_owner_id.sql
@@ -82,32 +82,55 @@ BEGIN
     END IF;
 END $$;
 
--- Drop any leftover alembic-era FK constraints that pointed at the
--- deleted `public.user` table. Recreate the FK against `auth.users`
--- to match what the supabase-era initial_schema.sql declares.
+-- FK constraint cleanup + recreate.
 --
--- Why this matters: if the data-migration preserved the column but the
--- old `public.user` table was dropped on the way to Supabase, the FK
--- constraint is dangling. On a database where the FK already points at
--- auth.users (fresh supabase bootstrap), the DROP IF EXISTS is a no-op
--- and the ADD CONSTRAINT either succeeds (if missing) or duplicates —
--- so we DROP IF EXISTS first to make ADD idempotent.
+-- We need to handle three FK relationships across these three tables:
+--   * passage.owner_id        → auth.users(id)
+--   * preference.owner_id     → auth.users(id)
+--   * reading_event.owner_id  → auth.users(id)
+--   * reading_event.passage_id → public.passage(id)   (NOT touched by the rename)
+--
+-- The alembic-era FKs pointed at `public.user(id)` (now-deleted) for
+-- the owner side. The supabase-era FKs point at `auth.users(id)`. So
+-- we drop ONLY the owner-side FKs (whether they reference public.user
+-- or auth.users) and re-add them against auth.users. The passage_id
+-- FK is left alone — its target (public.passage) exists in both eras
+-- and the rename doesn't touch it.
+--
+-- The DROP loop is narrowed to FKs whose target is `auth.users` or
+-- `public.user` to avoid silently dropping unrelated FKs (most
+-- importantly `reading_event.passage_id_fkey`, which the supabase-era
+-- schema needs preserved). See #106 review.
+--
+-- We use `NOT VALID` on the auth.users FKs and a follow-up
+-- `VALIDATE CONSTRAINT` step. This is the standard Postgres pattern
+-- for adding an FK to a table that may have rows whose foreign-key
+-- values predate the constraint (e.g., orphan owner_id UUIDs left
+-- behind by the alembic→Supabase data migration). With `NOT VALID`:
+--   * The constraint is recorded in the catalog.
+--   * Future INSERT / UPDATE rows are enforced normally.
+--   * Existing rows are NOT validated yet, so the migration won't
+--     abort mid-transaction if any orphan exists.
+-- After the migration runs cleanly, the operator can validate by
+-- running `ALTER TABLE ... VALIDATE CONSTRAINT ...` once they've
+-- confirmed (or cleaned up) any orphans. See PR #106 body.
 DO $$
 DECLARE
     fk_record RECORD;
 BEGIN
-    -- Drop ANY foreign-key constraint on passage.owner_id /
-    -- preference.owner_id / reading_event.owner_id, regardless of
-    -- target. We re-add the auth.users FK below.
     FOR fk_record IN
-        SELECT conname, conrelid::regclass AS table_name
-        FROM pg_constraint
-        WHERE contype = 'f'
-          AND conrelid IN (
+        SELECT con.conname,
+               con.conrelid::regclass AS table_name
+        FROM pg_constraint con
+        JOIN pg_class target ON target.oid = con.confrelid
+        JOIN pg_namespace ns ON ns.oid = target.relnamespace
+        WHERE con.contype = 'f'
+          AND con.conrelid IN (
               'public.passage'::regclass,
               'public.preference'::regclass,
               'public.reading_event'::regclass
           )
+          AND ns.nspname || '.' || target.relname IN ('auth.users', 'public.user')
     LOOP
         EXECUTE format(
             'ALTER TABLE %s DROP CONSTRAINT IF EXISTS %I',
@@ -116,14 +139,40 @@ BEGIN
     END LOOP;
 END $$;
 
+-- Re-add the owner-side FKs as NOT VALID so the migration doesn't abort
+-- on any pre-existing orphan rows in production.
 ALTER TABLE public.passage
     ADD CONSTRAINT passage_owner_id_fkey
-        FOREIGN KEY (owner_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+        FOREIGN KEY (owner_id) REFERENCES auth.users(id) ON DELETE CASCADE
+        NOT VALID;
 
 ALTER TABLE public.preference
     ADD CONSTRAINT preference_owner_id_fkey
-        FOREIGN KEY (owner_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+        FOREIGN KEY (owner_id) REFERENCES auth.users(id) ON DELETE CASCADE
+        NOT VALID;
 
 ALTER TABLE public.reading_event
     ADD CONSTRAINT reading_event_owner_id_fkey
-        FOREIGN KEY (owner_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+        FOREIGN KEY (owner_id) REFERENCES auth.users(id) ON DELETE CASCADE
+        NOT VALID;
+
+-- Ensure `reading_event.passage_id_fkey` is present and shaped per the
+-- supabase-era initial_schema. The alembic-era version had the same
+-- target (public.passage) and shape (ON DELETE CASCADE), so on prod
+-- this is a no-op IF the FK already exists with the right shape — and
+-- a safety-net if a previous version of this file (which had a
+-- too-aggressive DROP loop) accidentally removed it. See #106 review.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint con
+        JOIN pg_class target ON target.oid = con.confrelid
+        WHERE con.contype = 'f'
+          AND con.conrelid = 'public.reading_event'::regclass
+          AND target.relname = 'passage'
+    ) THEN
+        ALTER TABLE public.reading_event
+            ADD CONSTRAINT reading_event_passage_id_fkey
+                FOREIGN KEY (passage_id) REFERENCES public.passage(id) ON DELETE CASCADE;
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary

After #104 merged, the live site moved past the type-coercion crash and hit the NEXT layer's failure: production's `passage` table doesn't have an `owner_id` column — it still carries the alembic-era `user_id` name. The Supabase migrations in this repo were written with `owner_id` (post-SUPA-2c shape), but production's database was never realigned. Same is almost certainly true for `preference.user_id` and `reading_event.user_id`.

Closes #105.

## Root cause

```
psycopg.errors.UndefinedColumn: column "owner_id" of relation "passage" does not exist
```

The production Supabase Postgres was data-migrated from the old Neon Postgres in a way that preserved the alembic-era column names. The `supabase db push` step that would have applied the `owner_id`-shaped migrations to production was either never run or applied a different schema. Local Supabase stacks and per-PR Supabase branches both have `owner_id` (because `supabase/migrations/20260524015233_initial_schema.sql` creates it that way), which is why CI a11y is green — but production is in a divergent state.

## What's in this PR

One new migration file: `supabase/migrations/20260526165646_rename_user_id_to_owner_id.sql`. **Idempotent by design:**

- `ALTER TABLE ... RENAME COLUMN user_id TO owner_id` guarded by `IF EXISTS` on the old column. No-op on databases that already have `owner_id`.
- Index renames (`ix_passage_user_id_created_at` → `ix_passage_owner_id_created_at`, same for `reading_event`) with the same guard pattern.
- FK constraint cleanup: drops any existing FK on `owner_id` (which may have pointed at the deleted `public.user` table from the alembic era) and adds a fresh FK against `auth.users(id)` on all three tables. The `DROP CONSTRAINT IF EXISTS` makes the `ADD CONSTRAINT` step idempotent across all current database states.

## Why idempotent matters here

| Database state | What this migration does |
|---|---|
| Production (today): user_id columns | Renames to owner_id, fixes the bug |
| Local Supabase: already owner_id | No-op (guards skip the renames) |
| Per-PR Supabase branches: already owner_id | No-op |
| Re-run on prod after success | No-op (the guards make it a no-op once owner_id exists) |

## What Laura needs to do after merge

The Supabase GitHub App auto-applies migrations to per-PR branches, but **NOT to the production project**. After merging:

```bash
# from the repo root, with supabase CLI installed:
supabase link --project-ref gnswmcgaztcxslirulwm  # if not already linked
supabase db push --linked
```

Then verify in the Supabase Dashboard SQL Editor:

```sql
SELECT table_name, column_name
FROM information_schema.columns
WHERE table_schema = 'public'
  AND table_name IN ('passage', 'preference', 'reading_event')
  AND column_name IN ('user_id', 'owner_id');
-- Expect: three `owner_id` rows, zero `user_id` rows.
```

After that, paste + upload + reading view + preference toggle should all work end-to-end. The previous fix (#104) handled the Python-side type contract; this PR handles the database-side column name.

## Test plan

- [x] `uv run pytest` — 214 passed (no new tests; the schema change is exercised by the existing test suite via the local Supabase stack in CI a11y)
- [x] `uv run ruff check .` — clean
- [x] Pre-push hook passed
- [ ] CI green on this PR (the a11y job will run this migration on its local Supabase stack — that's the syntax+semantics test for the SQL)
- [ ] After merge: operator runs `supabase db push --linked` and confirms the verification query above
- [ ] Manual: paste a passage on production → land on `/read/{id}`. Same for PDF upload.

## Why this couldn't be tested with new pytest cases

Pytest uses in-memory SQLite via conftest. The SQL migration only runs against Postgres (Supabase's local stack or the production project). The CI a11y job is what exercises the migration end-to-end — if the SQL had a syntax error or referenced a non-existent column on the post-rename state, that job would fail. Open to adding a Postgres-backed test if you'd like more coverage; out of scope for the P0 fix today.

## Related

- Depends on #104 (the type-coercion fix; that change is what made this bug surface — before #104, requests crashed at the SQLAlchemy `.hex` layer and never reached the INSERT)
- This is the second layer of the same end-to-end bug (paste/upload 500). After this PR + the `supabase db push`, the live ingestion flow should work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)