### PR TITLE
fix(ui): show reading preferences open by default

### DIFF
--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -51,25 +51,23 @@
        aria-hidden="true"
        style="display:none"></div>
 
-  <aside class="reader-controls" aria-label="Reading preferences">
-    <details>
-      <summary>Reading preferences</summary>
+  <aside class="reader-controls" aria-labelledby="reading-preferences-heading">
+    <h2 id="reading-preferences-heading">Reading preferences</h2>
 
-      {% for key, options in preference_options.items() %}
-        <fieldset class="reader-control-group" data-pref-key="{{ key }}">
-          <legend>{{ key.replace('_', ' ').title() }}</legend>
-          {% for opt in options %}
-            <button
-              type="button"
-              hx-post="/preferences/{{ key }}"
-              hx-vals='{"value": "{{ value_for_form(opt) }}"}'
-              hx-target="#reading-surface-style"
-              hx-swap="outerHTML"
-              aria-pressed="{{ 'true' if prefs[key] == opt else 'false' }}"
-            >{{ label_for(key, opt) }}</button>
-          {% endfor %}
-        </fieldset>
-      {% endfor %}
-    </details>
+    {% for key, options in preference_options.items() %}
+      <fieldset class="reader-control-group" data-pref-key="{{ key }}">
+        <legend>{{ key.replace('_', ' ').title() }}</legend>
+        {% for opt in options %}
+          <button
+            type="button"
+            hx-post="/preferences/{{ key }}"
+            hx-vals='{"value": "{{ value_for_form(opt) }}"}'
+            hx-target="#reading-surface-style"
+            hx-swap="outerHTML"
+            aria-pressed="{{ 'true' if prefs[key] == opt else 'false' }}"
+          >{{ label_for(key, opt) }}</button>
+        {% endfor %}
+      </fieldset>
+    {% endfor %}
   </aside>
 {% endblock %}


### PR DESCRIPTION
## Summary

The reading-preferences panel was wrapped in `<details>`/`<summary>`, so the list of settings (font, contrast, line height, etc.) was hidden behind a disclosure toggle. Removed the wrapper so the controls render visible immediately when the reading view opens.

Quick-fix protocol (UI-only, no behavior change beyond visibility).

## What changed

- `templates/pages/reading.html` — removed the `<details>` wrapper. Replaced the aside's `aria-label="Reading preferences"` with `aria-labelledby="reading-preferences-heading"` pointing at a real `<h2>`, so:
  - The region still has an accessible name for screen readers.
  - The heading is now visible on screen (it was inside `<summary>` before, only visible as the toggle).

## Test plan

- [x] `uv run pytest tests/test_reading_view.py -v` — 12 passed, no regressions
- [x] No tests pin the `<details>`/`<summary>` shape (verified via grep)
- [ ] CI green
- [ ] Manual: open a passage in the reading view, confirm the preferences panel shows without clicking a toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)