### PR TITLE
fix(ui): rename Bg/Fg legends + make selected-button state visible everywhere

### DIFF
--- a/app/api/reading.py
+++ b/app/api/reading.py
@@ -43,6 +43,7 @@ from app.services.reading.options import (
     PREFERENCE_OPTIONS,
     coerce_value,
     label_for,
+    label_for_key,
     value_for_form,
 )
 from app.services.reading.preferences import upsert_preference
@@ -95,6 +96,7 @@ def read_passage(
             "prefs": prefs,
             "preference_options": PREFERENCE_OPTIONS,
             "label_for": label_for,
+            "label_for_key": label_for_key,
             "value_for_form": value_for_form,
         },
     )

--- a/app/services/reading/options.py
+++ b/app/services/reading/options.py
@@ -31,6 +31,14 @@ PREFERENCE_OPTIONS: dict[str, list[Any]] = {
     "bionic_enabled": [True, False],
 }
 
+# Friendly labels for sidebar UI section headings (the <legend> per
+# fieldset). Falls back to the title-cased key with underscores replaced
+# when no entry exists. Used by `label_for_key()` below.
+KEY_LABELS: dict[str, str] = {
+    "bg": "Background",
+    "fg": "Foreground",
+}
+
 # Friendly labels for sidebar UI buttons. Keyed by (preference_key, value).
 # Falls back to str(value) when no entry exists.
 PREFERENCE_LABELS: dict[tuple[str, Any], str] = {
@@ -75,6 +83,17 @@ def label_for(key: str, value: Any) -> str:
     sidebar template to render button text.
     """
     return PREFERENCE_LABELS.get((key, value), str(value))
+
+
+def label_for_key(key: str) -> str:
+    """Return a friendly UI label for a preference key (section heading).
+
+    Falls back to the title-cased key with underscores replaced when no
+    explicit label exists. Used by the sidebar template's <legend> for
+    each fieldset. Examples: `bg` -> "Background", `line_height` ->
+    "Line Height" (via fallback).
+    """
+    return KEY_LABELS.get(key, key.replace("_", " ").title())
 
 
 def value_for_form(value: Any) -> str:

--- a/static/style.css
+++ b/static/style.css
@@ -57,10 +57,20 @@
 }
 
 .reader-control-group button[aria-pressed="true"] {
-  /* Show the currently-active option with a clear visual marker.
-     Outline-based so it's distinct from Pico's hover/focus styling. */
-  outline: 2px solid var(--pico-primary);
-  outline-offset: 2px;
+  /* Show the currently-active option with a clear visual marker. Three
+     reinforcing cues so the selected state reads in any browser/theme:
+       1. Box-shadow (more reliably-rendered than outline; survives Pico
+          theme overrides and Safari outline quirks).
+       2. Bold font weight (works even if color rendering is off).
+       3. currentColor for the ring so it contrasts against whatever
+          text color the user has chosen via the fg/bg preferences —
+          avoids the prior bug where --pico-primary blended into the
+          background under some color combinations.
+     The earlier outline-only version was invisible on some screens
+     (likely a combination of --pico-primary not contrasting with the
+     active background + browser outline-rendering differences). */
+  box-shadow: inset 0 0 0 2px currentColor;
+  font-weight: 700;
 }
 
 .todo-list {

--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -56,7 +56,7 @@
 
     {% for key, options in preference_options.items() %}
       <fieldset class="reader-control-group" data-pref-key="{{ key }}">
-        <legend>{{ key.replace('_', ' ').title() }}</legend>
+        <legend>{{ label_for_key(key) }}</legend>
         {% for opt in options %}
           <button
             type="button"


### PR DESCRIPTION
## Summary

Two small UI fixes for the reading preferences panel:

1. The fieldset legends rendered as 'Bg' and 'Fg' (from `key.replace('_', ' ').title()` on the `bg`/`fg` preference keys). Now render as 'Background' and 'Foreground'.
2. The currently-selected option's visual marker was invisible on some browser/theme combinations (the 'works on some computers but not on others' issue you flagged). Reworked with three reinforcing visual cues that hold across all themes.

## What changed

- **`app/services/reading/options.py`** — added `KEY_LABELS` dict + `label_for_key(key)` helper. Only `bg` and `fg` get explicit overrides; everything else keeps the title-case fallback so future preference keys auto-render reasonably.
- **`app/api/reading.py`** — exposes `label_for_key` to the template via the render context.
- **`templates/pages/reading.html`** — `<legend>` now calls `{{ label_for_key(key) }}` instead of `{{ key.replace('_', ' ').title() }}`.
- **`static/style.css`** — selected-button state rewritten. Was `outline: 2px solid var(--pico-primary)` (relied on Pico's CSS variable which Pico themes / Safari outline rendering can both fail). Now:
  - `box-shadow: inset 0 0 0 2px currentColor` — currentColor adapts to the user's chosen foreground, so the ring always contrasts against the bg/fg pair they picked
  - `font-weight: 700` — visual reinforcement even if color rendering is off

## Test plan

- [x] `uv run pytest tests/test_reading_view.py tests/test_preferences.py -v` — 31 passed
- [x] `uv run ruff check .` clean, `uv run mypy app/` clean
- [x] Pre-push hook passed
- [ ] CI green
- [ ] Manual: visit a reading page, see "Background" and "Foreground" legends; click any preference button and confirm it visibly shows as selected; change bg/fg theme and confirm the selected indicator remains visible

## Quick-fix-protocol

UI-only template + label + CSS work; no behavior change beyond visibility/text. No tracking issue per quick-fix-protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)