### PR TITLE
fix(ui): update selected-button highlight immediately on click

### DIFF
--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -70,4 +70,25 @@
       </fieldset>
     {% endfor %}
   </aside>
+
+  <script>
+    // Reflect the just-clicked preference button as `aria-pressed=true`
+    // (and reset its siblings) immediately on click — without this, the
+    // selected-state visual stays on the old button until the page is
+    // reloaded, because the HTMX swap only replaces the inline
+    // <style> block, not the buttons themselves.
+    //
+    // Delegated on the document so it works after any future re-renders
+    // of the .reader-controls aside. The server-rendered aria-pressed
+    // values remain the source of truth at page load; this handler
+    // keeps them in sync with the user's clicks in between.
+    document.addEventListener("click", function (event) {
+      var btn = event.target.closest(".reader-control-group button[aria-pressed]");
+      if (!btn) return;
+      var siblings = btn.parentElement.querySelectorAll("button[aria-pressed]");
+      siblings.forEach(function (b) {
+        b.setAttribute("aria-pressed", b === btn ? "true" : "false");
+      });
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary

The reading-preferences "selected" indicator only updated on a full page reload. The HTMX swap on each button click only replaces the inline `<style>` block — the buttons themselves never re-render, so their server-rendered `aria-pressed` attributes stay stale.

Quick fix: a 10-line delegated click handler that updates `aria-pressed` immediately on click, mirroring what the server will do on next page-load.

## What changed

- **`templates/pages/reading.html`** — added an inline `<script>` at the bottom of the reading view. Listens for clicks on any `.reader-control-group button[aria-pressed]`, sets the clicked button's `aria-pressed` to `true`, and resets siblings to `false`. The CSS `[aria-pressed="true"]` rule then picks up the change with no server round-trip.

## Why client-side over server-side OOB

- Faster perceived feedback (no network round-trip wait before the visual updates).
- No route-layer changes; no new test surface.
- Matches the existing pattern of inline scripts in templates (see `app/api/auth.py`'s callback HTML for the sign-in flow).
- Server-rendered `aria-pressed` remains canonical at page load — this handler just keeps the UI in sync with clicks in between.

## Test plan

- [x] `uv run pytest tests/test_reading_view.py tests/test_preferences.py` — 31 passed
- [x] `uv run ruff check .` clean
- [x] Pre-push hook passed
- [ ] CI green (including a11y)
- [ ] Manual on a preview deploy: open a passage, click a preference button, confirm the selected highlight moves to the new button without reloading

## Quick-fix-protocol

UI-only template + inline JS work; no behavior change beyond the immediate-feedback fix. No tracking issue per quick-fix-protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)