### PR TITLE
fix(sync): UPSTREAM_REPO swap to gembaflow (unblocks /upgrade)

### DIFF
--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -31,7 +31,7 @@ if ! gh auth token >/dev/null 2>&1; then
   exit 1
 fi
 
-UPSTREAM_REPO="vibeacademy/agile-flow"
+UPSTREAM_REPO="vibeacademy/gembaflow"
 VERSION_FILE=".agile-flow-version"
 OVERRIDES_FILE=".agile-flow-overrides"
 RUNNING_SCRIPT_REL=$(python3 -c "import os,sys; print(os.path.relpath(os.path.realpath(sys.argv[1]), os.getcwd()))" "$0")


### PR DESCRIPTION
## Summary

Local-fork fix for the broken `/upgrade` flow. The upstream framework repo was renamed `vibeacademy/agile-flow` → `vibeacademy/gembaflow`. GitHub serves a 301 redirect on the old API URL, but [scripts/template-sync.sh:182](scripts/template-sync.sh#L182) uses `curl -sf` without `-L`, so it gets back the redirect-stub JSON and crashes with `KeyError: 'tag_name'`.

Upstream issue filed as [vibeacademy/gembaflow#351](https://github.com/vibeacademy/gembaflow/issues/351); this PR is the local-only one-line patch to unblock `/upgrade` on cubrox today.

## What changed

One line in `scripts/template-sync.sh`:

```diff
-UPSTREAM_REPO="vibeacademy/agile-flow"
+UPSTREAM_REPO="vibeacademy/gembaflow"
```

## Why this and not the `-L` flag

Both fixes work. Chose the repo-name swap because:
- It's a more semantically accurate fix — the old name is no longer canonical.
- When the upstream framework ships their fix, they'll likely do this same rename (since they renamed the repo themselves). Our diff with upstream will be zero after their fix lands.
- The `-L` flag would also work and is more defensive against future renames, but adds a behavioral nuance (silent redirect-following) that upstream might or might not adopt.

## Future divergence

This file is a framework-controlled file (synced from upstream). After this lands:
- The next upstream framework release will overwrite this file via the sync flow.
- If upstream adopts the same rename, the diff is zero.
- If upstream adopts the `-L` flag instead, the sync will replace our literal value with theirs. Either way the result works.

No long-term maintenance burden.

## Test plan

- [x] Verified the new URL works without `-L`:
  ```
  curl -sf https://api.github.com/repos/vibeacademy/gembaflow/releases/latest \
    | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])"
  ```
  Returns `v1.1.0`.
- [x] Pre-push hook passed
- [ ] CI green
- [ ] After merge: run `/upgrade` and confirm it produces a sync PR for v1.1.0 (next step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)