### PR TITLE
Synthetic auth monitor for Supabase sign-in path (Refs #79)

### DIFF
--- a/.github/workflows/synthetic-monitor.yml
+++ b/.github/workflows/synthetic-monitor.yml
@@ -1,0 +1,140 @@
+name: Synthetic Auth Monitor
+
+# End-to-end auth smoke test against the LIVE production deploy. Mints a
+# throwaway Supabase session and drives the real app through
+# callback -> authed page -> reload -> logout (scripts/smoke_auth.py).
+#
+# Why scheduled (not just per-deploy): the regression this guards against
+# (#79) was production silently serving a stale, Neon-backed revision for
+# ~24h AFTER the cutover "shipped". A per-deploy check wouldn't have caught
+# drift that happens between deploys. Hourly catches it within the hour.
+#
+# Operator prerequisites (one-time):
+#   - The workflow's GCP identity needs `roles/run.viewer` (to read the
+#     service URL) and `roles/secretmanager.secretAccessor` on the
+#     supabase-url / supabase-anon-key / supabase-service-key secrets.
+#   - The Supabase project must allow email+password sign-in (Supabase
+#     default) — that's how the throwaway session is minted.
+
+on:
+  schedule:
+    # Hourly at :17 past, to avoid top-of-hour runner congestion.
+    - cron: '17 * * * *'
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Override target base URL (defaults to the resolved Cloud Run URL)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  monitor:
+    name: Probe production sign-in
+    runs-on: ubuntu-latest
+    # Don't run on the upstream template repo — only on configured forks.
+    if: github.repository != 'vibeacademy/agile-flow-gcp'
+
+    env:
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      GCP_REGION: ${{ vars.GCP_REGION || 'us-central1' }}
+      SERVICE_NAME: ${{ vars.CLOUD_RUN_SERVICE || 'agile-flow-app' }}
+
+    steps:
+      - name: Check for required secrets
+        id: check_secrets
+        # GitHub Actions rejects `secrets.*` inside `if:` expressions, so we
+        # promote presence checks into outputs the downstream gates read.
+        # Same pattern as deploy.yml.
+        run: |
+          if [ -z "${{ secrets.GCP_PROJECT_ID }}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "auth_method=none" >> "$GITHUB_OUTPUT"
+            echo "GCP_PROJECT_ID not configured -- skipping synthetic monitor."
+          elif [ -n "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "auth_method=wif" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ secrets.GCP_SA_KEY }}" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "auth_method=sa-key" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "auth_method=none" >> "$GITHUB_OUTPUT"
+            echo "Neither GCP_WORKLOAD_IDENTITY_PROVIDER nor GCP_SA_KEY configured -- skipping."
+          fi
+
+      - name: Checkout code
+        if: steps.check_secrets.outputs.skip != 'true'
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud (Workload Identity Federation)
+        if: steps.check_secrets.outputs.auth_method == 'wif'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Authenticate to Google Cloud (Service Account Key fallback)
+        if: steps.check_secrets.outputs.auth_method == 'sa-key'
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up gcloud
+        if: steps.check_secrets.outputs.skip != 'true'
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Resolve target URL + Supabase credentials
+        id: resolve
+        if: steps.check_secrets.outputs.skip != 'true'
+        env:
+          BASE_URL_INPUT: ${{ inputs.base_url }}
+        run: |
+          set -euo pipefail
+
+          # Target URL: manual-dispatch override wins, else the live Cloud Run URL.
+          if [ -n "${BASE_URL_INPUT:-}" ]; then
+            URL="$BASE_URL_INPUT"
+          else
+            URL=$(gcloud run services describe "${SERVICE_NAME}" \
+              --region="${GCP_REGION}" \
+              --format='value(status.url)')
+          fi
+          if [ -z "$URL" ]; then
+            echo "Could not resolve a target URL." >&2
+            exit 1
+          fi
+          echo "SMOKE_BASE_URL=$URL" >> "$GITHUB_ENV"
+          echo "Target: $URL"
+
+          # Pull Supabase creds from Secret Manager (same secrets deploy.yml
+          # mounts onto the Cloud Run revision). Mask before exporting so they
+          # never surface in logs.
+          SB_URL=$(gcloud secrets versions access latest --secret=supabase-url \
+            --project="${GCP_PROJECT_ID}")
+          SB_ANON=$(gcloud secrets versions access latest --secret=supabase-anon-key \
+            --project="${GCP_PROJECT_ID}")
+          SB_SERVICE=$(gcloud secrets versions access latest --secret=supabase-service-key \
+            --project="${GCP_PROJECT_ID}")
+          echo "::add-mask::$SB_ANON"
+          echo "::add-mask::$SB_SERVICE"
+          {
+            echo "SUPABASE_URL=$SB_URL"
+            echo "SUPABASE_ANON_KEY=$SB_ANON"
+            echo "SUPABASE_SERVICE_KEY=$SB_SERVICE"
+          } >> "$GITHUB_ENV"
+
+      - name: Install uv
+        if: steps.check_secrets.outputs.skip != 'true'
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        if: steps.check_secrets.outputs.skip != 'true'
+        run: uv sync
+
+      - name: Run synthetic auth monitor
+        if: steps.check_secrets.outputs.skip != 'true'
+        run: uv run python scripts/smoke_auth.py

--- a/scripts/smoke_auth.py
+++ b/scripts/smoke_auth.py
@@ -1,0 +1,258 @@
+"""Synthetic auth monitor — end-to-end smoke test for the Supabase sign-in path.
+
+Drives the *deployed* app through the full authenticated happy path and exits
+non-zero if any step misbehaves. Built for #79 (Supabase replatform epic): its
+Definition of Done requires demonstrating "magic-link login via Supabase →
+session persists across reloads → logout clears session." This script is that
+demonstration, runnable on a schedule so the guarantee keeps holding.
+
+It also guards the specific regression that bit us once: after the Neon→Supabase
+cutover, production silently kept serving the old Neon-backed revision for ~24h.
+Unit tests (which mock Supabase) could never have caught that — only something
+that hits the *real* deployed URL with a *real* Supabase session can.
+
+## What it does
+
+1. Mint a throwaway, email-confirmed Supabase user via the admin API and
+   exchange its password for a real session JWT. This is the same mechanism the
+   a11y test-seed route uses (`app/api/test_seed.py`) — proven against the local
+   Supabase stack in CI — so the token is byte-for-byte what `/auth/callback`
+   produces for a genuine magic-link sign-in.
+2. Hit the live app over HTTP:
+   - `GET /auth/callback?access_token=…&refresh_token=…` → expect a 303 to
+     `/passages/new` with an `sb-access-token` cookie set.
+   - `GET /passages/new` (cookie attached) → expect 200 + the authed page.
+   - `GET /passages/new` again → still 200, proving the session persists across
+     reloads.
+   - `GET /logout` → expect a 303 to `/` that clears the cookie.
+   - `GET /passages/new` (cookie now gone) → expect a 303 back to `/`, proving
+     the session is actually gone.
+3. Delete the throwaway user, always (even if an assertion fails).
+
+## What it deliberately does NOT cover
+
+- **Supabase's own email-link generation.** We mint the session server-side
+  rather than clicking a real emailed link. POST /login → `sign_in_with_otp`
+  is unit-tested separately; this monitor is about our token-validation,
+  session, and logout contract against the live deploy.
+- **The browser-side JS hash extractor** (`/auth/callback` stage 1). That moves
+  the token from the URL fragment into query params *in a real browser*; a
+  headless HTTP client has the token already, so it calls stage 2 directly. The
+  Playwright a11y suite exercises real browser rendering.
+
+## Configuration (all via environment)
+
+- `SMOKE_BASE_URL`        — base URL of the app to probe, e.g.
+                            `https://cubrox-xxxxx-uc.a.run.app` (no trailing /).
+- `SUPABASE_URL`          — Supabase project URL (to mint the session).
+- `SUPABASE_ANON_KEY`     — anon key (password sign-in).
+- `SUPABASE_SERVICE_KEY`  — service-role key (admin create/delete user).
+
+## Exit codes
+
+- 0 — every step passed.
+- 1 — a step failed, or configuration was missing. A clear `FAIL:` line names
+      the first thing that broke.
+
+## Local run
+
+Point it at a local app + local Supabase stack (needs Docker):
+
+    supabase start   # exports the local URL + keys
+    SMOKE_BASE_URL=http://127.0.0.1:8080 \
+    SUPABASE_URL=… SUPABASE_ANON_KEY=… SUPABASE_SERVICE_KEY=… \
+    uv run python scripts/smoke_auth.py
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+import uuid
+
+import httpx
+
+from supabase import create_client
+
+# Marks the throwaway accounts this monitor creates, so any that leak (e.g. a
+# crash between create and delete) are obvious in the Supabase user list.
+SMOKE_EMAIL_DOMAIN = "smoke.cubrox.test"
+
+EXPECTED_COOKIE = "sb-access-token"
+AUTHED_ENTRY_PATH = "/passages/new"
+# Stable marker from templates/pages/passages_new.html — the authed entry page.
+AUTHED_PAGE_MARKER = "Add a passage"
+
+HTTP_TIMEOUT_SECONDS = 30.0
+
+
+class SmokeFailure(Exception):
+    """Raised when a step's observed behavior doesn't match expectations."""
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise SmokeFailure(f"missing required environment variable: {name}")
+    return value
+
+
+def _step(message: str) -> None:
+    print(f"-> {message}", flush=True)
+
+
+def _cookie_header_clears(set_cookie_values: list[str]) -> bool:
+    """True if any Set-Cookie line expires/empties the session cookie.
+
+    `Response.delete_cookie` emits a Set-Cookie with an empty value plus a past
+    `expires`/`Max-Age=0`. We accept any of those signals rather than matching
+    Starlette's exact formatting, which has drifted across versions.
+    """
+    for raw in set_cookie_values:
+        if not raw.startswith(f"{EXPECTED_COOKIE}="):
+            continue
+        value_part = raw.split(";", 1)[0]
+        token = value_part.split("=", 1)[1].strip().strip('"')
+        lowered = raw.lower()
+        if token == "" or "max-age=0" in lowered or "expires=thu, 01 jan 1970" in lowered:
+            return True
+    return False
+
+
+def mint_session(supabase_url: str, anon_key: str, service_key: str) -> tuple[str, str, str]:
+    """Create a confirmed throwaway user and return (access_token, refresh_token, user_id).
+
+    Mirrors app/api/test_seed.py: admin.create_user(email_confirm=True) then a
+    password grant. The resulting JWT is identical in shape to what a real
+    magic-link sign-in yields, so `/auth/callback` and `current_user` accept it.
+    """
+    email = f"smoke-{uuid.uuid4()}@{SMOKE_EMAIL_DOMAIN}"
+    password = secrets.token_urlsafe(32)
+
+    service = create_client(supabase_url, service_key)
+    created = service.auth.admin.create_user(
+        {"email": email, "password": password, "email_confirm": True}
+    )
+    if created is None or created.user is None:
+        raise SmokeFailure("Supabase admin.create_user did not return a user")
+    user_id = str(created.user.id)
+
+    anon = create_client(supabase_url, anon_key)
+    auth_resp = anon.auth.sign_in_with_password({"email": email, "password": password})
+    if auth_resp is None or auth_resp.session is None:
+        # Best-effort cleanup before bailing: we already created the user.
+        service.auth.admin.delete_user(user_id)
+        raise SmokeFailure("Supabase sign-in did not return a session for the seeded user")
+
+    return auth_resp.session.access_token, auth_resp.session.refresh_token or "", user_id
+
+
+def run_flow(base_url: str, access_token: str, refresh_token: str) -> None:
+    """Drive the live app through callback → authed page → reload → logout.
+
+    Raises SmokeFailure on the first deviation from the expected contract.
+    """
+    base = base_url.rstrip("/")
+    with httpx.Client(timeout=HTTP_TIMEOUT_SECONDS, follow_redirects=False) as client:
+        _step("GET /auth/callback (stage 2) — expect 303 to /passages/new + session cookie")
+        callback = client.get(
+            f"{base}/auth/callback",
+            params={"access_token": access_token, "refresh_token": refresh_token},
+        )
+        if callback.status_code != 303:
+            raise SmokeFailure(f"/auth/callback returned {callback.status_code}, expected 303")
+        location = callback.headers.get("location", "")
+        if location != AUTHED_ENTRY_PATH:
+            raise SmokeFailure(
+                f"/auth/callback redirected to {location!r}, expected {AUTHED_ENTRY_PATH!r}"
+            )
+        if not any(
+            v.startswith(f"{EXPECTED_COOKIE}=") for v in callback.headers.get_list("set-cookie")
+        ):
+            raise SmokeFailure(f"/auth/callback did not set the {EXPECTED_COOKIE} cookie")
+        if EXPECTED_COOKIE not in client.cookies:
+            raise SmokeFailure(f"{EXPECTED_COOKIE} cookie was not stored after callback")
+
+        _step("GET /passages/new — expect 200 authed page")
+        authed = client.get(f"{base}{AUTHED_ENTRY_PATH}")
+        if authed.status_code != 200:
+            raise SmokeFailure(
+                f"{AUTHED_ENTRY_PATH} returned {authed.status_code} while authed, expected 200"
+            )
+        if AUTHED_PAGE_MARKER not in authed.text:
+            raise SmokeFailure(
+                f"{AUTHED_ENTRY_PATH} body missing expected marker {AUTHED_PAGE_MARKER!r}"
+            )
+
+        _step("GET /passages/new again — expect 200, session persists across reloads")
+        reload_resp = client.get(f"{base}{AUTHED_ENTRY_PATH}")
+        if reload_resp.status_code != 200:
+            raise SmokeFailure(
+                f"session did not persist across reload: {AUTHED_ENTRY_PATH} returned "
+                f"{reload_resp.status_code}, expected 200"
+            )
+
+        _step("GET /logout — expect 303 to / and a cleared session cookie")
+        logout = client.get(f"{base}/logout")
+        if logout.status_code != 303:
+            raise SmokeFailure(f"/logout returned {logout.status_code}, expected 303")
+        if logout.headers.get("location", "") != "/":
+            raise SmokeFailure(
+                f"/logout redirected to {logout.headers.get('location')!r}, expected '/'"
+            )
+        if not _cookie_header_clears(logout.headers.get_list("set-cookie")):
+            raise SmokeFailure("/logout did not clear the session cookie")
+
+        _step("GET /passages/new after logout — expect 303 to /, session is gone")
+        after_logout = client.get(f"{base}{AUTHED_ENTRY_PATH}")
+        if after_logout.status_code != 303:
+            raise SmokeFailure(
+                f"{AUTHED_ENTRY_PATH} returned {after_logout.status_code} after logout, "
+                "expected 303 (session should be gone)"
+            )
+        if after_logout.headers.get("location", "") != "/":
+            raise SmokeFailure(
+                f"post-logout redirect went to {after_logout.headers.get('location')!r}, "
+                "expected '/'"
+            )
+
+
+def main() -> int:
+    try:
+        base_url = _require_env("SMOKE_BASE_URL")
+        supabase_url = _require_env("SUPABASE_URL")
+        anon_key = _require_env("SUPABASE_ANON_KEY")
+        service_key = _require_env("SUPABASE_SERVICE_KEY")
+    except SmokeFailure as exc:
+        print(f"FAIL: {exc}", flush=True)
+        return 1
+
+    print(f"Synthetic auth monitor → {base_url}", flush=True)
+
+    user_id: str | None = None
+    service_client = create_client(supabase_url, service_key)
+    try:
+        access_token, refresh_token, user_id = mint_session(supabase_url, anon_key, service_key)
+        _step(f"minted throwaway session for user {user_id}")
+        run_flow(base_url, access_token, refresh_token)
+    except SmokeFailure as exc:
+        print(f"FAIL: {exc}", flush=True)
+        return 1
+    except httpx.HTTPError as exc:
+        print(f"FAIL: HTTP error reaching {base_url}: {exc}", flush=True)
+        return 1
+    finally:
+        if user_id is not None:
+            try:
+                service_client.auth.admin.delete_user(user_id)
+                _step(f"cleaned up throwaway user {user_id}")
+            except Exception as exc:  # noqa: BLE001 — cleanup must never mask the real result
+                print(f"WARN: failed to delete throwaway user {user_id}: {exc}", flush=True)
+
+    print("PASS: magic-link session → authed page → reload → logout all verified", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke_auth.py
+++ b/scripts/smoke_auth.py
@@ -73,7 +73,7 @@ import uuid
 
 import httpx
 
-from supabase import create_client
+from supabase import Client, create_client
 
 # Marks the throwaway accounts this monitor creates, so any that leak (e.g. a
 # crash between create and delete) are obvious in the Supabase user list.
@@ -120,32 +120,38 @@ def _cookie_header_clears(set_cookie_values: list[str]) -> bool:
     return False
 
 
-def mint_session(supabase_url: str, anon_key: str, service_key: str) -> tuple[str, str, str]:
-    """Create a confirmed throwaway user and return (access_token, refresh_token, user_id).
+def create_throwaway_user(service: Client) -> tuple[str, str, str]:
+    """Create a confirmed throwaway user; return (user_id, email, password).
 
-    Mirrors app/api/test_seed.py: admin.create_user(email_confirm=True) then a
-    password grant. The resulting JWT is identical in shape to what a real
-    magic-link sign-in yields, so `/auth/callback` and `current_user` accept it.
+    Split from sign-in deliberately: the caller must learn `user_id` the
+    instant the user exists, so its `finally` can always delete it — even if
+    the subsequent sign-in step raises. Folding create + sign-in into one
+    function hid the user_id until success and leaked the user on a sign-in
+    error.
+
+    Mirrors app/api/test_seed.py: admin.create_user(email_confirm=True).
     """
     email = f"smoke-{uuid.uuid4()}@{SMOKE_EMAIL_DOMAIN}"
     password = secrets.token_urlsafe(32)
 
-    service = create_client(supabase_url, service_key)
     created = service.auth.admin.create_user(
         {"email": email, "password": password, "email_confirm": True}
     )
     if created is None or created.user is None:
         raise SmokeFailure("Supabase admin.create_user did not return a user")
-    user_id = str(created.user.id)
+    return str(created.user.id), email, password
 
-    anon = create_client(supabase_url, anon_key)
+
+def sign_in(anon: Client, email: str, password: str) -> tuple[str, str]:
+    """Exchange the throwaway user's password for a session; return (access, refresh).
+
+    The resulting JWT is identical in shape to what a real magic-link sign-in
+    yields, so `/auth/callback` and `current_user` accept it identically.
+    """
     auth_resp = anon.auth.sign_in_with_password({"email": email, "password": password})
     if auth_resp is None or auth_resp.session is None:
-        # Best-effort cleanup before bailing: we already created the user.
-        service.auth.admin.delete_user(user_id)
         raise SmokeFailure("Supabase sign-in did not return a session for the seeded user")
-
-    return auth_resp.session.access_token, auth_resp.session.refresh_token or "", user_id
+    return auth_resp.session.access_token, auth_resp.session.refresh_token or ""
 
 
 def run_flow(base_url: str, access_token: str, refresh_token: str) -> None:
@@ -230,17 +236,29 @@ def main() -> int:
 
     print(f"Synthetic auth monitor → {base_url}", flush=True)
 
-    user_id: str | None = None
     service_client = create_client(supabase_url, service_key)
+    anon = create_client(supabase_url, anon_key)
+
+    # Learn user_id BEFORE sign-in so the finally below always cleans up,
+    # even if sign-in raises (a transient Supabase error). Initialized None
+    # so a create-user failure leaves nothing to delete.
+    user_id: str | None = None
     try:
-        access_token, refresh_token, user_id = mint_session(supabase_url, anon_key, service_key)
-        _step(f"minted throwaway session for user {user_id}")
+        user_id, email, password = create_throwaway_user(service_client)
+        _step(f"created throwaway user {user_id}")
+        access_token, refresh_token = sign_in(anon, email, password)
+        _step("minted session via password grant")
         run_flow(base_url, access_token, refresh_token)
     except SmokeFailure as exc:
         print(f"FAIL: {exc}", flush=True)
         return 1
     except httpx.HTTPError as exc:
         print(f"FAIL: HTTP error reaching {base_url}: {exc}", flush=True)
+        return 1
+    except Exception as exc:  # noqa: BLE001 — Supabase client errors (AuthApiError, etc.)
+        # A monitor's own crash should read as a clean FAIL, not a traceback —
+        # otherwise an upstream Supabase hiccup looks like a code bug.
+        print(f"FAIL: unexpected error: {type(exc).__name__}: {exc}", flush=True)
         return 1
     finally:
         if user_id is not None:

--- a/tests/test_smoke_auth.py
+++ b/tests/test_smoke_auth.py
@@ -1,0 +1,103 @@
+"""Unit tests for scripts/smoke_auth.py pure logic.
+
+The synthetic monitor itself can't run without a live Supabase + deployed
+app, but `_cookie_header_clears` is pure Set-Cookie parsing — the one piece
+of nontrivial logic that can drift silently (e.g. if Starlette changes how
+`delete_cookie` formats its header). Pin its behavior here.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import scripts.smoke_auth as smoke
+from scripts.smoke_auth import _cookie_header_clears
+
+
+def _set_required_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SMOKE_BASE_URL", "http://app.test")
+    monkeypatch.setenv("SUPABASE_URL", "http://sb.test")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "anon")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "service")
+
+
+def test_empty_value_counts_as_cleared() -> None:
+    assert _cookie_header_clears(["sb-access-token=; Path=/; HttpOnly; SameSite=lax"]) is True
+
+
+def test_max_age_zero_counts_as_cleared() -> None:
+    # Non-empty value but Max-Age=0 still means the browser drops it.
+    assert _cookie_header_clears(["sb-access-token=stale; Max-Age=0; Path=/"]) is True
+
+
+def test_epoch_expiry_counts_as_cleared() -> None:
+    assert (
+        _cookie_header_clears(
+            ["sb-access-token=stale; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/"]
+        )
+        is True
+    )
+
+
+def test_active_cookie_is_not_cleared() -> None:
+    assert (
+        _cookie_header_clears(["sb-access-token=realtoken123; Path=/; Max-Age=604800; HttpOnly"])
+        is False
+    )
+
+
+def test_other_cookies_are_ignored() -> None:
+    # A different cookie being cleared must not count as the session cookie
+    # being cleared.
+    assert _cookie_header_clears(["other=; Max-Age=0; Path=/"]) is False
+
+
+def test_empty_header_list_is_not_cleared() -> None:
+    assert _cookie_header_clears([]) is False
+
+
+def test_finds_clear_among_multiple_set_cookie_lines() -> None:
+    assert (
+        _cookie_header_clears(["csrftoken=abc; Path=/", "sb-access-token=; Max-Age=0; Path=/"])
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cleanup robustness — the throwaway user must never leak (runs hourly on prod)
+# ---------------------------------------------------------------------------
+
+
+def test_throwaway_user_deleted_when_sign_in_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If sign-in raises a transient Supabase error AFTER the user is created,
+    main() must still delete the user and report a clean FAIL (exit 1) — not
+    leak the user or crash with a traceback."""
+    _set_required_env(monkeypatch)
+
+    service_fake = MagicMock()
+    service_fake.auth.admin.create_user.return_value = SimpleNamespace(
+        user=SimpleNamespace(id="user-abc")
+    )
+    anon_fake = MagicMock()
+    anon_fake.auth.sign_in_with_password.side_effect = RuntimeError("supabase 503")
+
+    monkeypatch.setattr(smoke, "create_client", MagicMock(side_effect=[service_fake, anon_fake]))
+
+    assert smoke.main() == 1
+    service_fake.auth.admin.delete_user.assert_called_once_with("user-abc")
+
+
+def test_no_delete_when_user_creation_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If create_user never yields a user, there's nothing to clean up —
+    delete must not be called with a bogus/None id."""
+    _set_required_env(monkeypatch)
+
+    service_fake = MagicMock()
+    service_fake.auth.admin.create_user.return_value = SimpleNamespace(user=None)
+    anon_fake = MagicMock()
+
+    monkeypatch.setattr(smoke, "create_client", MagicMock(side_effect=[service_fake, anon_fake]))
+
+    assert smoke.main() == 1
+    service_fake.auth.admin.delete_user.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `scripts/smoke_auth.py` — an end-to-end synthetic monitor that drives the **live** app through the full authenticated happy path: `/auth/callback` → authed `/passages/new` → reload (session persists) → `/logout` (cookie cleared) → confirm session is gone.
- It mints a throwaway, email-confirmed Supabase session using the **same proven path** as the a11y test-seed route (`app/api/test_seed.py`): `admin.create_user(email_confirm=True)` + password grant. The resulting JWT is identical in shape to a real magic-link sign-in, so `/auth/callback` and `current_user` accept it. The throwaway user is deleted in a `finally` block.
- Adds `.github/workflows/synthetic-monitor.yml` — runs the monitor **hourly** (plus manual `workflow_dispatch`) against the production Cloud Run URL, sourcing the target URL and Supabase credentials from GCP at run time (no new GitHub secrets).

## Why

Closes the last engineering-side gap in the #79 DoD: *"a working preview demonstrates magic-link login via Supabase → session persists across reloads → logout clears session."* This makes that an **automated, repeating** check rather than a one-time manual click-through.

It specifically guards the regression that bit us during the migration: production silently kept serving the stale **Neon-backed** revision for ~24h after the cutover "shipped." Mock-based unit tests cannot detect that — only something hitting the real deployed URL with a real Supabase session can. Hourly scheduling means we'd catch a recurrence within the hour instead of by luck.

## Scope / honest caveats

- **Not verified end-to-end locally.** This Codespace has no Docker and no local Supabase stack, so I could not execute a real run here. Validated: `ruff check`, `ruff format --check`, AST parse, full `pytest` (214 pass), and `actionlint` on the new workflow. The two app behaviors the script asserts (`/auth/callback` → 303 `/passages/new`; unauthenticated `/passages/new` → 303 `/`) were confirmed by reading the handlers. **First real execution will be the first scheduled run or a manual `workflow_dispatch`.**
- **Operator prerequisite (one-time):** the workflow's GCP identity needs `roles/run.viewer` and `roles/secretmanager.secretAccessor` on the `supabase-url` / `supabase-anon-key` / `supabase-service-key` secrets. If that IAM isn't granted yet, the first scheduled run will fail on the secret-fetch step.
- **Deliberately out of scope:** Supabase's own email-link generation (we mint server-side; the POST `/login` → `sign_in_with_otp` path is unit-tested separately) and the browser-side JS hash-extractor in `/auth/callback` stage 1 (covered by the Playwright a11y suite). Documented in the script's module docstring.

## Test plan

- [ ] Merge, then trigger `Synthetic Auth Monitor` via **workflow_dispatch** once and confirm a green run end-to-end against production.
- [ ] Confirm the throwaway `smoke-*@smoke.cubrox.test` user is created and then deleted (no leaked users in the Supabase auth list).
- [ ] (Operator) confirm the workflow identity has the IAM bindings noted above.
- [ ] Let one scheduled (hourly) run fire and verify it's green.

Refs #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)