### PR TITLE
Fix: bionic reading toggle applies immediately (no reload)

### DIFF
--- a/app/api/reading.py
+++ b/app/api/reading.py
@@ -109,6 +109,7 @@ def update_preference(
     user: CurrentUser,
     session: SessionDep,
     value: Annotated[str, Form()],
+    passage_id: Annotated[uuid.UUID | None, Form()] = None,
 ) -> HTMLResponse:
     """Set ONE preference and return the swappable <style> fragment.
 
@@ -120,6 +121,15 @@ def update_preference(
     be allow-listed. This is the dependent invariant the READ-1
     reviewer flagged: without it, the `| safe` filter in the template
     would let a user inject arbitrary CSS.
+
+    Bionic is the one preference that is NOT a CSS variable: it injects
+    server-rendered `<b>` markup into the passage text. A `<style>`-only
+    swap therefore can't apply it — the surface would stay stale until a
+    full reload. So when `bionic_enabled` changes and the caller passes
+    the `passage_id`, we also re-render the article and return it as an
+    out-of-band swap. `passage_id` is optional (CSS-only toggles and the
+    unit tests don't send it); an unknown or cross-user id simply yields
+    no OOB swap, never an error or an existence leak.
     """
     if key not in PREFERENCE_OPTIONS:
         raise HTTPException(status_code=422, detail=f"Unknown preference key: {key!r}")
@@ -139,10 +149,16 @@ def update_preference(
     stored_pref = session.get(Preference, user.id)
     prefs = with_defaults(stored_pref.values if stored_pref else None)
 
+    passage: Passage | None = None
+    if key == "bionic_enabled" and passage_id is not None:
+        passage = session.exec(
+            select(Passage).where(Passage.id == passage_id, Passage.owner_id == user.id)  # type: ignore[arg-type]
+        ).first()
+
     return templates.TemplateResponse(
         request=request,
-        name="fragments/reader_style.html",
-        context={"prefs": prefs},
+        name="fragments/preference_update.html",
+        context={"prefs": prefs, "passage": passage},
     )
 
 

--- a/templates/fragments/preference_update.html
+++ b/templates/fragments/preference_update.html
@@ -1,0 +1,12 @@
+{#
+  Response fragment for POST /preferences/{key}.
+
+  Always returns the swappable <style> block (HTMX primary target
+  #reading-surface-style). When a passage is supplied — i.e. the toggle
+  changed `bionic_enabled`, which alters server-rendered <b> markup in
+  the passage text rather than a CSS variable — it ALSO returns the
+  re-rendered article as an out-of-band swap so the surface updates
+  without a full page reload.
+#}
+{% include "fragments/reader_style.html" %}
+{% if passage is not none %}{% with oob = true %}{% include "fragments/reading_surface.html" %}{% endwith %}{% endif %}

--- a/templates/fragments/reading_surface.html
+++ b/templates/fragments/reading_surface.html
@@ -1,0 +1,1 @@
+<article id="reading-surface"{% if oob %} hx-swap-oob="true"{% endif %}>{% if prefs.bionic_enabled %}{{ passage.text | bionic }}{% else %}{{ passage.text }}{% endif %}</article>

--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -5,7 +5,7 @@
 {% block content %}
   {% include "fragments/reader_style.html" %}
 
-  <article id="reading-surface">{% if prefs.bionic_enabled %}{{ passage.text | bionic }}{% else %}{{ passage.text }}{% endif %}</article>
+  {% include "fragments/reading_surface.html" %}
 
   <div id="questions-panel"
        hx-get="/passages/{{ passage.id }}/questions"
@@ -61,7 +61,7 @@
           <button
             type="button"
             hx-post="/preferences/{{ key }}"
-            hx-vals='{"value": "{{ value_for_form(opt) }}"}'
+            hx-vals='{"value": "{{ value_for_form(opt) }}", "passage_id": "{{ passage.id }}"}'
             hx-target="#reading-surface-style"
             hx-swap="outerHTML"
             aria-pressed="{{ 'true' if prefs[key] == opt else 'false' }}"

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -344,3 +344,114 @@ def test_value_for_form_helper_handles_booleans_and_strings() -> None:
     assert value_for_form(False) == "false"
     assert value_for_form("18px") == "18px"
     assert value_for_form("#ffffff") == "#ffffff"
+
+
+# ---------------------------------------------------------------------------
+# Bionic immediate apply — the toggle must re-render the passage text, not
+# just the <style> block (bionic is server-rendered <b> markup, not CSS).
+# ---------------------------------------------------------------------------
+
+
+def test_bionic_toggle_oob_swaps_the_reading_surface(client: TestClient, session: Session) -> None:
+    """Turning bionic ON with a passage_id returns BOTH the <style> block
+    (primary swap) AND the re-rendered article as an out-of-band swap, so
+    the surface updates without a full reload. Without the OOB swap the
+    bionic emphasis only appeared after a manual reload."""
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+
+    response = client.post(
+        "/preferences/bionic_enabled",
+        data={"value": "true", "passage_id": str(passage.id)},
+    )
+
+    assert response.status_code == 200
+    body = response.text
+    # Primary swap target survives.
+    assert '<style id="reading-surface-style">' in body
+    # OOB-swapped, re-rendered article with bionic <b> markup.
+    assert 'hx-swap-oob="true"' in body
+    assert 'id="reading-surface"' in body
+    # "test passage" -> "<b>te</b>st <b>pass</b>age" under bionicize.
+    assert "<b>" in body
+
+
+def test_bionic_toggle_off_oob_swaps_back_to_plain_text(
+    client: TestClient, session: Session
+) -> None:
+    """Turning bionic OFF must also re-render the surface — back to plain
+    text with no <b> markup — via the same OOB swap."""
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+
+    response = client.post(
+        "/preferences/bionic_enabled",
+        data={"value": "false", "passage_id": str(passage.id)},
+    )
+
+    assert response.status_code == 200
+    body = response.text
+    assert 'hx-swap-oob="true"' in body
+    assert 'id="reading-surface"' in body
+    assert "<b>" not in body
+    assert "test passage" in body
+
+
+def test_non_bionic_toggle_does_not_oob_swap_surface(client: TestClient, session: Session) -> None:
+    """CSS-only preferences (e.g. size) change a `var(--reader-*)` value —
+    the <style> swap alone is enough, so re-sending the whole passage text
+    would be wasted bandwidth. Even when a passage_id is supplied, a
+    non-bionic toggle returns the style block only, no OOB article."""
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+
+    response = client.post(
+        "/preferences/size",
+        data={"value": "20px", "passage_id": str(passage.id)},
+    )
+
+    assert response.status_code == 200
+    body = response.text
+    assert "--reader-size: 20px" in body
+    assert 'hx-swap-oob="true"' not in body
+    # Only the <style id="reading-surface-style"> element exists; the bare
+    # article id must not appear.
+    assert 'id="reading-surface"' not in body
+
+
+def test_bionic_toggle_without_passage_id_returns_style_only(
+    client: TestClient, session: Session
+) -> None:
+    """Back-compat: callers that don't pass a passage_id (direct API use,
+    unit tests) still get a valid 200 with just the <style> block — no
+    OOB swap, no error."""
+    signed_in(session)
+
+    response = client.post("/preferences/bionic_enabled", data={"value": "true"})
+
+    assert response.status_code == 200
+    body = response.text
+    assert '<style id="reading-surface-style">' in body
+    assert 'hx-swap-oob="true"' not in body
+
+
+def test_bionic_toggle_with_other_users_passage_id_does_not_oob_swap(
+    client: TestClient, session: Session
+) -> None:
+    """A passage_id the user doesn't own yields no OOB swap (and no error
+    or existence leak) — the preference write still succeeds."""
+    from tests.conftest import make_user
+
+    other = make_user(session, email="other@example.com")
+    other_passage = _make_passage(session, other.id)
+
+    signed_in(session)  # swaps current_user to a fresh user
+    response = client.post(
+        "/preferences/bionic_enabled",
+        data={"value": "true", "passage_id": str(other_passage.id)},
+    )
+
+    assert response.status_code == 200
+    body = response.text
+    assert '<style id="reading-surface-style">' in body
+    assert 'hx-swap-oob="true"' not in body


### PR DESCRIPTION
## Summary

- **Bug:** enabling/disabling the Bionic reading preference did nothing until you reloaded the page. The toggle only swapped the inline `<style>` block (`#reading-surface-style`), but bionic emphasis is server-rendered `<b>` markup inside the passage text — not a CSS variable — so the visible text never changed.
- **Fix:** the `bionic_enabled` toggle now re-renders the passage article server-side and returns it as an HTMX **out-of-band swap** alongside the `<style>` block, so the emphasis appears/disappears the instant you click. Bionic stays server-side per the READ-3 guardrail in `app/services/reading/bionic.py` (no client-side transform).

## How

- Extracted the reading surface into `templates/fragments/reading_surface.html` (with an optional `hx-swap-oob` attribute) so both the full page and the toggle response render it from one place.
- `POST /preferences/{key}` now returns `fragments/preference_update.html` = the `<style>` block + (only when `bionic_enabled` changed and the button sent its `passage_id`) the OOB-swapped article.
- Preference buttons send `passage_id` in `hx-vals`. CSS-only preferences (color/size/width/font/line-height) are unchanged — style swap only — so a large passage isn't re-sent on every color tweak.
- `passage_id` is **optional**: direct/unit callers that omit it still get a valid 200 with just the `<style>` block; an unknown or cross-user `passage_id` yields no OOB swap (no error, no existence leak).

## Not changed (per request)

The "Sepia text" vs "Dark text" option — they are genuinely different values (`#3d2914` brown vs `#1a1a1a` near-black), just visually close. Left as-is.

## Test plan

- [x] 5 new tests in `tests/test_preferences.py`: bionic-on OOB swaps the surface with `<b>` markup; bionic-off OOB swaps back to plain text; non-bionic toggle does NOT OOB-swap; bionic without `passage_id` returns style-only; cross-user `passage_id` yields no OOB swap.
- [x] Full suite green (219 passed); ruff check + format clean.
- [x] Eyeballed the real rendered response: bionic-on returns `<style …>` + `<article id="reading-surface" hx-swap-oob="true">…<b>…</b>…</article>`; size change returns the style block only.
- [ ] Manual: in a browser, toggle Bionic on the reading view and confirm the emphasis applies without a reload (could not run a browser in this Codespace — no Docker/Supabase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)