### PR TITLE
Add back link from reading view to passage-input page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -22,6 +22,26 @@
   overflow-wrap: break-word;
 }
 
+/* Back link on the reading view — returns to /passages/new (the passage
+   input page). Aligned to the reading surface's centered column so it sits
+   above the text, not flush against the viewport edge. Lives outside
+   #reading-surface, so it uses the page's default colors (not the user's
+   chosen reader bg/fg). */
+.reading-nav {
+  max-width: var(--reader-max-width, 65ch);
+  margin: 1rem auto 0;
+}
+
+.back-link {
+  display: inline-block;
+  text-decoration: none;
+}
+
+.back-link:hover,
+.back-link:focus {
+  text-decoration: underline;
+}
+
 /* Preference-toggle sidebar — opens as a Pico <details> at the bottom
    of the reading view. Each <fieldset> is one preference key; each
    <button> is one allow-listed option. aria-pressed reflects the

--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -3,6 +3,10 @@
 {% block title %}Reading — Master Key{% endblock %}
 
 {% block content %}
+  <nav class="reading-nav" aria-label="Back">
+    <a href="/passages/new" class="back-link"><span aria-hidden="true">&larr;</span> Add a passage</a>
+  </nav>
+
   {% include "fragments/reader_style.html" %}
 
   {% include "fragments/reading_surface.html" %}

--- a/tests/test_reading_view.py
+++ b/tests/test_reading_view.py
@@ -106,6 +106,21 @@ def test_passage_renders_inside_reading_surface_article(
     assert '<article id="reading-surface">' in body
 
 
+def test_reading_view_has_back_link_to_passage_input(client: TestClient, session: Session) -> None:
+    """The reading view must offer a way back to the passage-input page
+    (/passages/new) — otherwise a reader is stranded with no navigation.
+    The link's accessible name is its visible text ('Add a passage'); the
+    arrow glyph is decorative (aria-hidden)."""
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+
+    response = client.get(f"/read/{passage.id}")
+    body = response.text
+
+    assert 'href="/passages/new"' in body
+    assert 'aria-hidden="true"' in body  # decorative arrow, not announced
+
+
 # ---------------------------------------------------------------------------
 # Defaults vs. stored preferences
 # ---------------------------------------------------------------------------

--- a/tests/test_reading_view.py
+++ b/tests/test_reading_view.py
@@ -118,7 +118,11 @@ def test_reading_view_has_back_link_to_passage_input(client: TestClient, session
     body = response.text
 
     assert 'href="/passages/new"' in body
-    assert 'aria-hidden="true"' in body  # decorative arrow, not announced
+    # Pin the link's exact shape: decorative arrow (aria-hidden, not
+    # announced) + the visible accessible name. A bare `aria-hidden`
+    # substring check wouldn't guard this — the page has aria-hidden
+    # elsewhere (the close beacon).
+    assert '<span aria-hidden="true">&larr;</span> Add a passage' in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The reading view (`/read/{id}`) had **no navigation** — once you were reading a passage, there was no way back to the page where you add passages/PDFs (`/passages/new`). This adds a back link at the top of the reading view.
- Link: visible text **"← Add a passage"**. The arrow (`←`) is decorative (`aria-hidden="true"`), so the link's accessible name is just "Add a passage" — matching the destination page's heading for orientation.
- A small `.reading-nav` rule aligns the link to the reading surface's centered column (it lives outside `#reading-surface`, so it uses the page's default colors, not the user's chosen reader bg/fg — no contrast surprises).

## Why this shape (accessibility)

This product targets neurodivergent + screen-reader users, so: discernible text link (not an icon-only button), decorative glyph hidden from assistive tech, and a `<nav aria-label="Back">` landmark so screen-reader users can jump to it.

## Test plan

- [x] New test `test_reading_view_has_back_link_to_passage_input` asserts `href="/passages/new"` and the decorative `aria-hidden` arrow are present.
- [x] Full suite green (229 passed); ruff check + format clean.
- [x] Rendered the real reading view and confirmed the nav appears above the reading surface linking to `/passages/new`.
- [ ] Manual: click the link in a browser from a reading page and confirm it lands on the add-passage page (couldn't run a browser here — no Docker/Supabase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)