### PR TITLE
chore(ci): bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/agent-audit-report.yml
+++ b/.github/workflows/agent-audit-report.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for git log analysis
 

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Post review reminder
         uses: actions/github-script@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Lint Markdown files
         uses: DavidAnson/markdownlint-cli2-action@v18
@@ -31,7 +31,7 @@ jobs:
     name: typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate JSON files
         run: ./scripts/validation/validate-json.sh
@@ -43,7 +43,7 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
@@ -55,7 +55,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate command files
         run: ./scripts/validation/validate-commands.sh
@@ -67,7 +67,7 @@ jobs:
     name: lint-agent-policies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate agent policies
         run: ./scripts/validation/validate-agent-policies.sh
@@ -101,7 +101,7 @@ jobs:
     name: actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install actionlint
         id: get_actionlint
@@ -122,7 +122,7 @@ jobs:
     name: python
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check for Python project
         id: check_python
@@ -136,7 +136,7 @@ jobs:
 
       - name: Install uv
         if: steps.check_python.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Lint with ruff
         if: steps.check_python.outputs.skip != 'true'
@@ -175,7 +175,7 @@ jobs:
     name: node
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check for Node.js project
         id: check_node
@@ -228,10 +228,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install Python dependencies
         run: uv sync --extra dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,27 +52,27 @@ jobs:
 
       - name: Checkout code
         if: steps.check_secrets.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Authenticate to GCP. Prefers Workload Identity Federation (keyless).
       # Falls back to a service account JSON key if GCP_SA_KEY is set —
       # this is the workshop shortcut and is NOT recommended for production.
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         if: steps.check_secrets.outputs.auth_method == 'wif'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Authenticate to Google Cloud (Service Account Key fallback)
         if: steps.check_secrets.outputs.auth_method == 'sa-key'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up gcloud
         if: steps.check_secrets.outputs.skip != 'true'
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Configure Docker for Artifact Registry
         if: steps.check_secrets.outputs.skip != 'true'

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -48,20 +48,20 @@ jobs:
 
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         if: steps.check_secrets.outputs.auth_method == 'wif'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Authenticate to Google Cloud (Service Account Key fallback)
         if: steps.check_secrets.outputs.auth_method == 'sa-key'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up gcloud
         if: steps.check_secrets.outputs.gcp_configured == 'true'
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       # Removing a revision tag stops routing traffic to the preview
       # revision. The revision itself stays in the revision history but

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -56,7 +56,7 @@ jobs:
           fi
       - name: Checkout code
         if: steps.check_secrets.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Preview-DB plumbing: SUPA-4 (#83) removed the per-PR Neon branch
       # creation step that used to live here. Schema migrations for
@@ -76,20 +76,20 @@ jobs:
 
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         if: steps.check_secrets.outputs.auth_method == 'wif'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Authenticate to Google Cloud (Service Account Key fallback)
         if: steps.check_secrets.outputs.auth_method == 'sa-key'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up gcloud
         if: steps.check_secrets.outputs.skip != 'true'
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Configure Docker for Artifact Registry
         if: steps.check_secrets.outputs.skip != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -48,19 +48,19 @@ jobs:
 
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         if: steps.check_secrets.outputs.auth_method == 'wif'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Authenticate to Google Cloud (Service Account Key fallback)
         if: steps.check_secrets.outputs.auth_method == 'sa-key'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Find rollback target revision
         id: target

--- a/.github/workflows/synthetic-monitor.yml
+++ b/.github/workflows/synthetic-monitor.yml
@@ -68,24 +68,24 @@ jobs:
 
       - name: Checkout code
         if: steps.check_secrets.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         if: steps.check_secrets.outputs.auth_method == 'wif'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Authenticate to Google Cloud (Service Account Key fallback)
         if: steps.check_secrets.outputs.auth_method == 'sa-key'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up gcloud
         if: steps.check_secrets.outputs.skip != 'true'
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Resolve target URL + Supabase credentials
         id: resolve
@@ -129,7 +129,7 @@ jobs:
 
       - name: Install uv
         if: steps.check_secrets.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
         if: steps.check_secrets.outputs.skip != 'true'

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/verify-agent-restrictions.yml
+++ b/.github/workflows/verify-agent-restrictions.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup GitHub CLI
         run: |


### PR DESCRIPTION
## Summary

GitHub deprecated Node.js 20 for Actions: **forced switch to Node 24 on 2026-06-16**, full removal 2026-09-16. This PR bumps four actions across **11 workflow files** so everything runs on Node 24 before the cutover.

| Action | From | To | Notes |
|---|---|---|---|
| `actions/checkout` | `v4` | **`v6`** | major-tag, floats to latest patch |
| `astral-sh/setup-uv` | `v4` | **`v8.1.0`** | v8.0.0 stopped publishing major/minor tags (supply-chain hardening per release notes); exact pin is required, not a stylistic choice |
| `google-github-actions/auth` | `v2` | **`v3`** | major-tag, floats to latest patch |
| `google-github-actions/setup-gcloud` | `v2` | **`v3`** | major-tag, floats to latest patch |

35 line-edits, balanced (+35/-35). Files: `agent-audit-report.yml`, `auto-review.yml`, `ci.yml`, `deploy.yml`, `preview-cleanup.yml`, `preview-deploy.yml`, `release.yml`, `rollback-production.yml`, `synthetic-monitor.yml`, `template-sync.yml`, `verify-agent-restrictions.yml`.

## Breakage check (done before bumping)

Each major bump comes with potential breaking changes. Verified locally that **none apply here**:

- `auth@v3` removed `retries` / `backoff` / `backoff_limit` inputs — `grep -REn "^\s+(retries|backoff|backoff_limit):" .github/workflows/` → none.
- `setup-gcloud@v3` removed `skip_tool_cache` — `grep -REn "skip_tool_cache:" .github/workflows/` → none.
- `checkout@v5` swapped runtime to Node 24; `checkout@v6` persists credentials to a separate file rather than `.git/config` — `grep -REn "\.git/config|git config --get http" .github/workflows/` → none. We don't read `.git/config` directly anywhere.

`actionlint` passes against the bumped YAML.

## Test plan

- [x] `actionlint` (same v1.7.12 CI pins) — passes
- [x] Pre-push hook (lint + full pytest suite) — passes locally
- [ ] CI on this PR — particularly that `Deploy PR Preview` still authenticates to GCP via the bumped `auth@v3` (workload-identity-federation flow is the riskiest path)
- [ ] After merge: watch the next scheduled `Synthetic Auth Monitor` run and the next `Deploy to Production` run, both green

🤖 Generated with [Claude Code](https://claude.com/claude-code)