### PR TITLE
test(comprehension): encode epic #6 cost-acceptance criterion as regression guard

### DIFF
--- a/tests/test_comprehension_generator.py
+++ b/tests/test_comprehension_generator.py
@@ -142,6 +142,33 @@ def test_second_call_after_miss_is_a_cache_hit(session: Session) -> None:
     assert client.messages.create.call_count == 1  # only the first call
 
 
+def test_epic6_cost_acceptance_10_passages_5_rereads_is_10_calls(session: Session) -> None:
+    """Epic #6 acceptance criterion, encoded as a regression guard:
+
+        "LLM cost test (10 distinct passages, 5 re-reads each) shows
+         exactly 10 API calls."
+
+    The whole ADR-001 cost story is that re-reads are free. Ten distinct
+    passages read five times each is fifty reads but must cost only ten
+    Anthropic calls — one per distinct passage, the rest served from the
+    cache. A single shared mock client counts every call across the run.
+    """
+    client = _make_mock_client()
+    passages = [f"{TEST_PASSAGE} (variation {i})" for i in range(10)]
+
+    for _reread in range(5):
+        for passage in passages:
+            generate_questions(
+                passage_text=passage,
+                question_type="recall",
+                client=client,
+                model_id=TEST_MODEL_ID,
+                session=session,
+            )
+
+    assert client.messages.create.call_count == 10  # 50 reads, 10 distinct → 10 calls
+
+
 # ---------------------------------------------------------------------------
 # Input-cap contract — the runaway-cost prevention
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

Epic #6 (Comprehension Questions) is code-complete — all three child tickets (COMP-1 #18, COMP-2 #19, COMP-3 #20) shipped and survived the Alembic→Supabase migration cleanly. This PR closes the last verification gap before the epic can be retired.

## What

The epic's headline acceptance criterion is:

> LLM cost test (10 distinct passages, 5 re-reads each) shows **exactly 10 API calls**.

That cost-containment promise (ADR-001) was proven *implicitly* by the per-passage cache-first tests, but never pinned as a single explicit guard. This adds `test_epic6_cost_acceptance_10_passages_5_rereads_is_10_calls`, which runs 50 reads (10 distinct passages × 5 re-reads) through the **real** generator with a shared counting mock client and asserts exactly 10 Anthropic calls — locking the behavior against regression.

## Verification

- New test passes: 50 reads → exactly 10 calls.
- Full comprehension suite green (43 tests).
- Full pre-push suite green (230 tests), lint clean.
- Latency note: the 50 generations run in ~0.06s (~1ms each incl. SQLite), so our own per-cold-call overhead is negligible — the epic's "<2s cold" budget is entirely Haiku response time, not our code.

No production code changed — test-only.

Refs #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)