### PR TITLE
chore(supabase): strip stale Neon references left after the replatform

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,7 +137,7 @@ jobs:
           # Both workflows now write DATABASE_URL as a literal. The
           # connection string is on the revision instead of in Secret
           # Manager — acceptable trade-off because preview already exposes
-          # Neon URLs as literals; consistency between the pipelines is
+          # database URLs as literals; consistency between the pipelines is
           # more valuable than asymmetric hardening of just one. See #67.
           # Every env var the production app needs at runtime is set here,
           # explicitly, so the deployed revision never depends on whatever
@@ -153,7 +153,7 @@ jobs:
           # interventions that nobody documented.
           #
           # Secrets sourced from GitHub Secrets:
-          #   - PRODUCTION_DATABASE_URL  → DATABASE_URL    (Neon production)
+          #   - PRODUCTION_DATABASE_URL  → DATABASE_URL    (Supabase production)
           #   - SESSION_SECRET           → SESSION_SECRET  (cookie signer)
           #   - RESEND_API_KEY           → RESEND_API_KEY  (magic-link email)
           #   - ANTHROPIC_API_KEY (opt)  → ANTHROPIC_API_KEY (comp questions)

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -51,7 +51,6 @@ jobs:
           else
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "auth_method=none" >> "$GITHUB_OUTPUT"
-            echo "neon_configured=false" >> "$GITHUB_OUTPUT"
             echo "No GCP auth configured — skipping preview deploy."
           fi
       - name: Checkout code
@@ -187,7 +186,7 @@ jobs:
 
           # Phase 1: app readiness — /api/health does NOT touch the DB,
           # so a passing probe means the container booted and is serving
-          # HTTP. Retry loop covers Cloud Run cold-start + Neon wake.
+          # HTTP. Retry loop covers Cloud Run cold-start.
           echo "Phase 1: $PREVIEW_URL/api/health"
 
           health_passed=false

--- a/app/api/health.py
+++ b/app/api/health.py
@@ -1,11 +1,11 @@
 """Health check endpoints.
 
 `/api/health` — fast probe used by Cloud Run readiness checks. Does NOT
-touch the database (Neon cold-wake on every probe is expensive).
+touch the database (a DB cold-wake on every probe is expensive).
 
 `/api/health/db` — DB-backed probe used by the preview-deploy smoke test
 to verify the deploy actually has a working database connection. Added
-in #78 because preview deploys without Neon configured were passing
+in #78 because preview deploys without a database configured were passing
 the no-DB `/api/health` probe and shipping a broken URL.
 """
 
@@ -28,7 +28,7 @@ async def health() -> JSONResponse:
     """Return 200 with a small JSON body.
 
     Deliberately does NOT touch the database — health checks must be
-    fast and not wake up the Neon compute endpoint on every probe.
+    fast and not wake up the database on every probe.
     """
     return JSONResponse({"status": "ok"})
 
@@ -40,7 +40,7 @@ def health_db(session: SessionDep) -> JSONResponse:
     Used by preview-deploy.yml to validate that the deployed revision
     can reach the database. Cheap (single round-trip, no schema), but
     distinct from `/api/health`: a revision with `DATABASE_URL=""` or
-    a misconfigured Neon branch fails this and passes `/api/health`.
+    a misconfigured database connection fails this and passes `/api/health`.
     Uses SQLAlchemy's `session.execute(text(...))` because SQLModel's
     typed `session.exec()` only accepts SQLModel statements.
     """

--- a/app/config.py
+++ b/app/config.py
@@ -48,8 +48,8 @@ class Settings(BaseSettings):
     @field_validator("database_url")
     @classmethod
     def _force_psycopg3_driver(cls, v: str) -> str:
-        # Neon emits postgresql:// URLs, which SQLAlchemy resolves to the
-        # psycopg2 driver. We ship psycopg3 only, so rewrite the scheme.
+        # Supabase emits postgresql:// URLs, which SQLAlchemy resolves to
+        # the psycopg2 driver. We ship psycopg3 only, so rewrite the scheme.
         if v.startswith("postgresql://"):
             return v.replace("postgresql://", "postgresql+psycopg://", 1)
         return v
@@ -62,24 +62,23 @@ class Settings(BaseSettings):
         # at startup with a clear message rather than 500ing on the
         # first DB query with `no such table: todo`. Originally only
         # gated `production`; #78 generalized after a 2026-04-30 dry-run
-        # showed previews silently fell through to SQLite when Neon was
-        # unconfigured. See #63 / #71 / #78.
+        # showed previews silently fell through to SQLite when the preview
+        # DB was unconfigured. See #63 / #71 / #78.
         if self.environment in ("development", "test"):
             return self
         if not self.database_url:
             raise ValueError(
                 f"DATABASE_URL is empty in {self.environment}. "
                 "Check that DATABASE_URL is set on the Cloud Run revision "
-                "(production reads from PRODUCTION_DATABASE_URL secret; "
-                "preview reads from the Neon branch action output)."
+                "(production reads from the PRODUCTION_DATABASE_URL secret; "
+                "preview reads DATABASE_URL set on the revision)."
             )
         if self.database_url.startswith("sqlite"):
             raise ValueError(
                 f"DATABASE_URL is SQLite in {self.environment}: {self.database_url!r}. "
                 "Non-dev environments must use Postgres. Likely cause: the "
-                "DATABASE_URL env var didn't override the dev default — for "
-                "previews, NEON_API_KEY may be unconfigured so the Neon branch "
-                "step was skipped."
+                "DATABASE_URL env var didn't override the dev default — the "
+                "deploy may not have set DATABASE_URL on the preview revision."
             )
         # SUPA-3: production must have Supabase credentials wired or
         # the new auth flow can't issue magic links / validate JWTs.

--- a/app/scripts/metric.py
+++ b/app/scripts/metric.py
@@ -10,7 +10,7 @@ endpoint, no per-user breakdown — this is the release-decision tool,
 not a dashboard.
 
 The script reads from the same `DATABASE_URL` the FastAPI app uses;
-running it against a Neon branch needs the branch's URL exported.
+running it against a Supabase branch needs the branch's URL exported.
 """
 
 import argparse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "agile-flow-gcp"
 version = "0.1.0"
-description = "Agile Flow GCP Edition — FastAPI + Jinja2 + HTMX starter for Cloud Run + Neon"
+description = "Agile Flow GCP Edition — FastAPI + Jinja2 + HTMX starter for Cloud Run + Supabase"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.115",
@@ -33,9 +33,6 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "B", "UP"]
-
-[tool.ruff.lint.per-file-ignores]
-"alembic/versions/*.py" = ["E501"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Context

Closes out the last loose end of the Supabase replatform epic (#79). The replatform removed Neon *functionally* — but stale references lingered in comments, an operator-facing error message, and a dead workflow output. This is a quick-fix (behavior-preserving, no logic change) so #79 can be closed cleanly.

## Why it's worth doing (not just cosmetic)

`app/config.py`'s DB-validator error messages told operators to "check `NEON_API_KEY`" and "the Neon branch action output" when a deploy came up without a database — but `NEON_API_KEY` and the Neon branch step were **deleted in SUPA-4**. Anyone debugging a failed deploy would chase a dead path.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | description Neon→Supabase; drop dead ruff per-file-ignore for the deleted `alembic/` dir |
| `app/config.py` | fix DB-validator error messages → current `DATABASE_URL`-on-revision guidance; relabel driver-rewrite comment |
| `app/api/health.py` | relabel "Neon cold-wake" rationale as generic DB |
| `app/scripts/metric.py` | Neon branch → Supabase branch (docstring) |
| `.github/workflows/deploy.yml` | correct "(Neon production)" → Supabase; "Neon URLs" → database URLs |
| `.github/workflows/preview-deploy.yml` | remove dead `neon_configured` output (read by nothing post-SUPA-4) |

**Deliberately kept:** accurate historical notes that document the *removal* of Neon (e.g. "the `neon_configured` gate is gone — Supabase auto-branching replaced it", "SUPA-4 removed the per-PR Neon branch"). Those are correct history, not stale claims.

## Verification

- Net −5 lines, all behavior-preserving (comments, error strings, dead output, dead config).
- `ruff check .` clean; full pre-push suite (230 tests) green.
- Remaining repo-wide `neon` matches in active code/workflows: **0**, except the 4 intentional historical notes above.

Refs #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)