### PR TITLE
docs(journal): log 2026-06-02 board-reconciliation session

### DIFF
--- a/reports/session-journals/2026-06-02.md
+++ b/reports/session-journals/2026-06-02.md
@@ -1,0 +1,115 @@
+# Session Journal — 2026-06-02
+
+## 1. Session Summary
+
+A **board-reconciliation session**: discovered that the GitHub board had
+fallen badly out of sync with the codebase — seven epics were marked OPEN
+while every one of their child tickets had already shipped and merged.
+Verified each against the actual code, then closed them with evidence
+(#3, #4, #5, #6, #7, #8, #79) plus a stale security alert (#29). Along
+the way, hardened the comprehension epic with a missing cost-acceptance
+regression test (PR #118, merged) and stripped the last stale Neon
+references left after the Supabase replatform (PR #119, in review). Net
+board change: **8 open issues → 1** (only the intentionally-deferred #99
+remains).
+
+## 2. Tickets Delivered
+
+| Ticket | PR | What changed | Files touched | Tests |
+|---|---|---|---|---|
+| #6 EPIC Comprehension (cost-acceptance guard) | #118 | Encoded the epic's headline acceptance criterion ("10 distinct passages × 5 re-reads = exactly 10 API calls") as an explicit regression test — runs 50 reads through the real generator with a shared counting mock, asserts 10 Anthropic calls | `tests/test_comprehension_generator.py` | +1 (the cost-acceptance test) |
+
+*(Epics #3, #4, #5, #6, #7, #8, #79 and alert #29 were closed this session
+as already-complete — their implementing PRs merged in prior sessions; see
+§7 board state.)*
+
+## 3. Tickets In Review
+
+| Ticket | PR | What changed | Files touched | Tests |
+|---|---|---|---|---|
+| #79 EPIC Supabase (final polish) | #119 | Removed stale Neon references left after the replatform: a misleading operator-facing error message pointing at the deleted `NEON_API_KEY`, several mislabeled comments, the pyproject description + dead alembic ruff-ignore, and a dead `neon_configured` workflow output. Accurate historical notes ("the Neon gate is gone — Supabase replaced it") intentionally kept | `pyproject.toml`, `app/config.py`, `app/api/health.py`, `app/scripts/metric.py`, `.github/workflows/deploy.yml`, `.github/workflows/preview-deploy.yml` | unchanged (behavior-preserving) |
+
+## 4. Challenges and Mitigations
+
+| Challenge | Root cause | Mitigation | Prevention |
+|---|---|---|---|
+| Seven "open" epics were actually done — risk of re-building already-shipped work | Child tickets get closed on merge, but nobody closes the parent epic; the board chronically lags the codebase | Audited each epic's acceptance criteria against the live code (parallel Explore agents) before treating any as work; closed all seven with evidence comments | Before starting an "open" epic, verify child-ticket status + grep for the acceptance features. Saved as memory `board-lags-codebase` |
+| #99 had a hard "do not pick up" gate the user wasn't aware of when they asked for it | Ticket's section B requires real prod users **and** provisioned `SUPABASE_ACCESS_TOKEN`/`SUPABASE_DB_PASSWORD` before changing preview DBs; its DoD makes the workflow fail-loud, which would break previews for all PRs | Surfaced the gate, explained the blast radius (would block the comprehension work too), deferred by user decision | Read section B / guardrails of a ticket *before* committing to it, not after |
+| Could not push the first PR — `403 Permission denied to croissantfella` | The environment's only credential was a limited `GITHUB_TOKEN` (`ghu_…`) integration token — can't push or fork | User was added as a repo admin mid-session; retry then succeeded | A `ghu_` integration token in `GITHUB_TOKEN` can't do write ops; needs a personal PAT or collaborator/admin access first |
+| #29 looked like an unaddressed month-old security failure | Auto-filed alert (2026-05-03) reported branch protection NOT enabled on main | Checked *current* state instead of trusting the stale report: an active ruleset was added the **same day** (~16h later) enforcing PR-only + no-force-push + no-deletion; weekly verification green for 3+ weeks. Closed with evidence | For auto-filed alerts, verify the live state before acting — they capture a point in time and may be self-resolved |
+| Neon cleanup was bigger than the "4 references" first estimated | Initial grep undercounted; ~13 references across 5 files, including an operator-facing error message and dead workflow code | Expanded the fix to all *active-code* stale refs; kept accurate historical notes; verified with a full repo-wide `neon` grep | After a vendor migration, run a repo-wide grep for the old vendor name as the cleanup's definition-of-done, not a spot check |
+
+## 5. Insights and Learnings
+
+### Technical insights
+
+- **Two of #79's DoD line-items were wrong, not unmet.** (1) "Remove `psycopg` from deps" — psycopg3 *must* stay: Supabase **is** Postgres, so SQLAlchemy still needs the driver (`app/config.py` rewrites the scheme to `postgresql+psycopg://`). The DoD conflated the vendor (Neon, gone) with the driver (still required). (2) "ADR-003 supersedes ADR-002" — the Supabase ADR is actually **ADR-006**; ADR-003 was already taken by pdfplumber. The supersession is documented; only the predicted number was wrong. A DoD written before implementation can encode false assumptions — verify against reality, don't just check the box.
+- **The comprehension feature survived the Alembic→Supabase migration cleanly** — the `comprehension_question_cache` table was correctly translated into `supabase/migrations/` with RLS (service-role only), and the global cross-user cache (no `owner_id`) is intact. The cost-containment behavior was implicitly tested but the headline "10 passages × 5 = 10 calls" number wasn't pinned until #118.
+- **Stale comments can be operational traps, not just cosmetic.** `app/config.py`'s DB-validator error told operators to check `NEON_API_KEY` — a var deleted in SUPA-4 — when a deploy came up without a database. That sends an incident-responder down a dead path. Worth fixing at higher priority than a typo.
+
+### Process insights
+
+- **Audit-before-build paid for itself immediately.** The very first epic checked (#6) was already done; assuming the board was accurate would have meant re-implementing shipped features. Parallel Explore agents (one per epic) made the five-epic audit fast.
+- **"Verify & close" is a real unit of work.** Closing an epic properly means re-deriving its acceptance criteria against the current code and leaving the evidence on the issue — not just flipping the state. Each close here carries a verification table a future reader can trust.
+- **Reviewing your own PR (solo mode) is disclosed but still weak.** #118's review was author == reviewer; flagged transparently, but the same limitation the prior journal noted (§5) applies — a true second reviewer would be stronger.
+
+### Domain insights
+
+- After this sweep, cubrox's product surface is essentially **feature-complete for the MVP epics**: identity, ingestion (paste + PDF), reading surface (prefs + bionic), comprehension questions, reading-event metric, and the a11y gate all verified shipped. The only tracked open work is #99 (a defensive CI refinement, deferred until real users exist).
+- A genuine gap surfaced: the a11y harness (#8) covers only the **reading surface**, not the **login/verify flow**, even though #3's acceptance asked for an audit of that flow. Candidate follow-up ticket.
+
+## 6. Tickets Created
+
+None. This session closed issues rather than opening them. One follow-up was
+*identified* but not filed: an automated a11y assertion for the login/verify
+flow (gap noted when closing #3) — left for the Product Owner / next grooming
+pass.
+
+## 7. Metrics
+
+- **PRs created**: 2 (#118, #119)
+- **PRs merged**: 1 (#118)
+- **PRs reviewed**: 1 (#118 — solo-mode, conflict disclosed)
+- **PRs in review at session end**: 1 (#119)
+- **Issues closed**: 8 — epics #3, #4, #5, #6, #7, #8, #79 + security alert #29
+- **Issues created**: 0
+- **Tests added**: 1 (the cost-acceptance regression guard; full suite 230 green)
+- **Board state**: **8 open → 1 open**. Remaining open: #99 (deferred by design).
+- **Memory written**: 1 file-based entity (`board-lags-codebase`) + its `MEMORY.md` index pointer
+
+## 8. Next Up
+
+In priority order:
+
+1. **Merge PR #119** (Neon cleanup) — final polish for the now-closed #79; awaiting human merge.
+2. **Login/verify a11y coverage** — file + implement the follow-up flagged on #3; the axe harness only covers the reading surface today. S effort.
+3. **#99 — Per-PR Supabase DATABASE_URL injection** — still the one tracked open item. Stays deferred until (a) `SUPABASE_ACCESS_TOKEN` + `SUPABASE_DB_PASSWORD` are provisioned in repo secrets and (b) real users exist on production. **Escalate to P1 the moment real users land.**
+4. **Comprehension Phase-2 candidates** (out-of-scope for the now-closed #6, but the natural product-direction work): interactive answering (questions are display-only today — the biggest gap vs. the PRD's "confirm understanding"), an LLM-as-judge / curated-passage quality gate (Risk #2), or question types beyond recall/summary.
+
+## Memory Validation
+
+This fork uses **file-based memory** (`~/.claude/projects/-workspaces-cubrox/memory/`),
+not the `CompletedTicket-N` Memory-MCP entity scheme the standard template
+assumes. Queried the Memory MCP this session to confirm:
+`search_nodes("CompletedTicket-118 …")` and a broader
+`search_nodes("CompletedTicket SUPA comprehension …")` both returned an
+**empty graph** — no `CompletedTicket` entities exist.
+
+→ Memory validation: 0/1 merged tickets (#118) have `CompletedTicket`
+entities — expected, because this fork tracks memory in files, not the MCP
+graph. Not a gap. Run `/validate-memory` only if you want to adopt the MCP
+entity scheme retroactively.
+
+## Memory Consolidation
+
+One memory was written live during the session:
+
+- `board-lags-codebase.md` (type: project) — the recurring "epics stay OPEN
+  after all children ship" pattern, with the audit-before-build heuristic.
+  Linked to `comprehension-feature-shipped`.
+
+→ No further memory entities proposed — the session's other insights (the
+two wrong #79 DoD assumptions, the stale-comment-as-trap lesson) are recorded
+in this journal, which is the appropriate substrate. Consider a `LessonLearned`
+for "DoD written pre-implementation can encode false assumptions — verify
+against code" if a future session hits the same pattern again.


### PR DESCRIPTION
## Context

Session journal for 2026-06-02 — a board-reconciliation session.

## Summary

Discovered the GitHub board had drifted out of sync with the codebase: seven epics were OPEN while every child ticket had already shipped. Audited each against the live code and closed them with evidence (#3, #4, #5, #6, #7, #8, #79), plus a stale security alert (#29). Also added a comprehension cost-acceptance regression test (#118, merged) and stripped residual Neon references (#119, in review).

**Board: 8 open issues → 1** (only the deferred #99 remains).

Journal covers: tickets delivered/in-review, challenges + mitigations, insights (incl. two incorrect #79 DoD assumptions and the "stale comment as operational trap" lesson), metrics, and next-up priorities.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)