### PR TITLE
feat(a11y): add login + verify flow accessibility coverage

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -135,7 +135,7 @@ def auth_callback(
         return HTMLResponse(
             content=(
                 "<!doctype html>"
-                '<html><head><meta charset="utf-8"><title>Signing in…</title></head>'
+                '<html lang="en"><head><meta charset="utf-8"><title>Signing in…</title></head>'
                 "<body>"
                 "<p>Signing in…</p>"
                 "<script>"

--- a/tests/a11y/login.spec.ts
+++ b/tests/a11y/login.spec.ts
@@ -1,0 +1,64 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Login + verify flow accessibility assertions (A11Y-4 #121).
+ *
+ * Epic #8 covered the reading surface; epic #3's acceptance also asked
+ * for an a11y audit of the login + verify flow, which had no automated
+ * coverage. Every page here is PUBLIC, so — unlike reading_surface.spec
+ * — these tests need no seed/login fixture.
+ *
+ * Surfaces:
+ *   - GET /              → landing page + magic-link sign-in form
+ *   - GET /auth/callback → Stage 1 hash-extractor bridge page. With no
+ *     token/hash its inline JS renders the terminal "link invalid or
+ *     expired" state, which is what a user sees on a bad link — so it's
+ *     the right state to audit.
+ *
+ * Gate (matches reading_surface.spec): ZERO `serious`/`critical`
+ * violations under WCAG 2.0 A+AA. Moderate/minor are logged, not failed.
+ */
+
+async function expectNoA11yBlockers(page: Page, label: string): Promise<void> {
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa"])
+    .analyze();
+
+  const blockers = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+
+  if (blockers.length > 0) {
+    console.log(`[a11y blockers — ${label}]`, JSON.stringify(blockers, null, 2));
+  }
+
+  const nonBlocking = results.violations.filter(
+    (v) => v.impact !== "critical" && v.impact !== "serious",
+  );
+  if (nonBlocking.length > 0) {
+    console.log(
+      `[a11y non-blocking — ${label}]`,
+      nonBlocking.map((v) => `${v.id} (${v.impact})`).join(", "),
+    );
+  }
+
+  expect(blockers, `axe found serious/critical violations on ${label}`).toHaveLength(0);
+}
+
+test("login page a11y: sign-in form", async ({ page }) => {
+  await page.goto("/");
+  // Anchor on the sign-in form so the scan runs against rendered markup.
+  await expect(page.locator("#signin-form")).toBeVisible();
+
+  await expectNoA11yBlockers(page, "GET /");
+});
+
+test("verify flow a11y: callback bridge (invalid-link state)", async ({ page }) => {
+  // No token + no hash → the bridge JS renders its terminal error state.
+  await page.goto("/auth/callback");
+  // Wait for the JS to swap in the "Try again" link before scanning.
+  await expect(page.getByRole("link", { name: /try again/i })).toBeVisible();
+
+  await expectNoA11yBlockers(page, "GET /auth/callback (invalid link)");
+});

--- a/tests/test_auth_callback.py
+++ b/tests/test_auth_callback.py
@@ -35,6 +35,10 @@ def test_stage1_no_params_renders_hash_extractor_html(
     # The JS bridge that converts hash → query params is the whole point.
     assert "window.location.hash" in body
     assert "/auth/callback" in body
+    # A11Y-4 (#121): the bridge is hand-built HTML (not via base.html),
+    # so it must declare its language itself — axe flags a missing
+    # `lang` as a serious WCAG 2.0 A (html-has-lang) violation.
+    assert '<html lang="en">' in body
 
 
 def test_stage2_valid_token_sets_cookie_and_redirects(


### PR DESCRIPTION
## Context

Closes #121. The axe gate from epic #8 covered only the reading surface, but epic #3's acceptance also asked for an a11y audit of the **login + verify flow** — which had no automated coverage.

## The real defect found while scoping

The `/auth/callback` Stage 1 hash-extractor bridge page is hand-built inline HTML (not rendered via `base.html`, which *does* set `lang`), and it omitted `lang` on `<html>`. axe flags `html-has-lang` as a **serious** WCAG 2.0 A violation. This is the page a user lands on after clicking a magic link, so it's squarely on the "verify" path.

## Changes

| File | Change |
|------|--------|
| `app/api/auth.py` | Add `lang="en"` to the callback bridge `<html>` |
| `tests/a11y/login.spec.ts` | New axe spec: `GET /` (sign-in form) + `GET /auth/callback` (invalid-link terminal state). Zero serious/critical under `wcag2a`+`wcag2aa`. Public pages → **no seed fixture** |
| `tests/test_auth_callback.py` | Assert the bridge declares `lang="en"` — pins the fix in the fast pytest suite |

## Verification

- **Ran the Playwright spec locally — both tests pass** (sign-in form + callback bridge).
- **Proved the test is meaningful**: reverted the `lang` fix → the callback test fails with exactly `html-has-lang` (impact: serious) → restored the fix → green.
- `tests/test_auth_callback.py` green (6 tests incl. the new assertion).
- No CI workflow change needed — the `a11y` job runs `npx playwright test`, which auto-discovers the new spec.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)