### PR TITLE
feat(comprehension): interactive answering via self-assessment

### DIFF
--- a/app/services/comprehension/generator.py
+++ b/app/services/comprehension/generator.py
@@ -73,10 +73,16 @@ class _Question(BaseModel):
     The Literal on `type` is the structural enforcement of the prompt's
     'recall' or 'summary' allow-list. If the LLM emits any other type,
     Pydantic raises ValidationError and we surface GeneratorError.
+
+    `answer` (COMP-4 / #123) is the source-grounded model answer the
+    reader self-assesses against — required and non-empty, so a v2
+    response missing it is rejected as a malformed (poison-cache)
+    response rather than cached without an answer.
     """
 
     type: Annotated[Literal["recall", "summary"], Field()]
     text: Annotated[str, Field(min_length=1, max_length=500)]
+    answer: Annotated[str, Field(min_length=1, max_length=500)]
 
 
 _QUESTIONS_ADAPTER: TypeAdapter[list[_Question]] = TypeAdapter(list[_Question])

--- a/app/services/comprehension/prompts.py
+++ b/app/services/comprehension/prompts.py
@@ -17,7 +17,9 @@ prompt is shared, the user message varies per passage.
 
 from typing import Final
 
-PROMPT_VERSION: Final[int] = 1
+# v2 (COMP-4 / #123): each question now carries a source-grounded
+# `answer` so the reader can self-assess. Output-schema change → bump.
+PROMPT_VERSION: Final[int] = 2
 
 SYSTEM_PROMPT: Final[str] = (
     "You generate reading-comprehension questions for a passage of text."
@@ -32,18 +34,28 @@ SYSTEM_PROMPT: Final[str] = (
     "  - Each question has a 'type' of either 'recall' or 'summary'\n"
     "    - 'recall' tests memory of a specific detail or fact in the passage\n"
     "    - 'summary' tests understanding of an overall theme or argument\n"
-    "  - Output ONLY a JSON array of objects with keys 'type' and 'text'\n"
+    "  - Each question has an 'answer': a correct, concise model answer the"
+    " reader can check their own answer against\n"
+    "    - The answer MUST be grounded in the passage — drawn from what the"
+    " text actually says, never outside knowledge or invention\n"
+    "    - Keep it to one or two short sentences, under 40 words\n"
+    "  - Output ONLY a JSON array of objects with keys 'type', 'text', and"
+    " 'answer'\n"
     "  - NO preamble, NO markdown, NO commentary — only the JSON array\n"
     "\n"
     "The reader may be neurodivergent or otherwise prefer plain, direct"
     " language. Avoid abstract framings, double negatives, and questions"
     " that require interpretation of literary devices unless the passage"
-    " itself uses them.\n"
+    " itself uses them. The same plain-language guidance applies to the"
+    " answers.\n"
     "\n"
     "Example output for a hypothetical passage:\n"
     "[\n"
-    '  {"type": "recall", "text": "Who did the speaker address in the opening line?"},\n'
-    '  {"type": "recall", "text": "What did the protagonist do when they saw the storm?"},\n'
-    '  {"type": "summary", "text": "In one sentence, what is the speaker urging?"}\n'
+    '  {"type": "recall", "text": "Who did the speaker address in the opening'
+    ' line?", "answer": "The speaker addressed the Son of Spirit."},\n'
+    '  {"type": "recall", "text": "What did the protagonist do when they saw'
+    ' the storm?", "answer": "They turned back and sought shelter."},\n'
+    '  {"type": "summary", "text": "In one sentence, what is the speaker'
+    ' urging?", "answer": "To keep a pure, kindly heart above all else."}\n'
     "]\n"
 )

--- a/templates/fragments/questions_panel.html
+++ b/templates/fragments/questions_panel.html
@@ -1,9 +1,21 @@
 <section aria-label="Comprehension check" id="questions-panel">
   {% if questions %}
     <h2>Check your understanding</h2>
+    <p>Answer each in your own words, then reveal the answer to check yourself.</p>
     <ol>
       {% for q in questions %}
-        <li>{{ q.text }}</li>
+        <li>
+          {# The question doubles as the textarea's accessible name. #}
+          <label for="answer-{{ loop.index }}">{{ q.text }}</label>
+          <textarea id="answer-{{ loop.index }}" name="answer-{{ loop.index }}"
+                    rows="2" placeholder="Write your answer (optional)"></textarea>
+          {# Native <details> reveal — accessible, no JS, no server round-trip.
+             The model answer is source-grounded; the reader self-assesses. #}
+          <details>
+            <summary>Reveal answer</summary>
+            <p>{{ q.answer }}</p>
+          </details>
+        </li>
       {% endfor %}
     </ol>
   {% elif error == "too_long" %}

--- a/tests/test_comprehension_generator.py
+++ b/tests/test_comprehension_generator.py
@@ -37,9 +37,12 @@ TEST_MODEL_ID = "claude-haiku-4-5"
 TEST_PASSAGE = "O Son of Spirit! My first counsel is this: possess a pure, kindly heart."
 
 VALID_LLM_OUTPUT = (
-    '[{"type":"recall","text":"What is the first counsel?"},'
-    '{"type":"recall","text":"What attribute should the heart have?"},'
-    '{"type":"summary","text":"What virtue is the passage urging?"}]'
+    '[{"type":"recall","text":"What is the first counsel?",'
+    '"answer":"To possess a pure, kindly heart."},'
+    '{"type":"recall","text":"What attribute should the heart have?",'
+    '"answer":"It should be pure and kindly."},'
+    '{"type":"summary","text":"What virtue is the passage urging?",'
+    '"answer":"Purity and kindliness of heart."}]'
 )
 
 
@@ -66,7 +69,9 @@ def test_cache_hit_returns_immediately_without_calling_anthropic(session: Sessio
     before the Anthropic SDK is touched. Verify by pre-populating the
     cache and asserting the mock client's create() is never called."""
     text_hash = hashlib.sha256(TEST_PASSAGE.encode("utf-8")).digest()
-    cached_questions = [{"type": "recall", "text": "cached question?"}]
+    cached_questions = [
+        {"type": "recall", "text": "cached question?", "answer": "cached answer."}
+    ]
 
     cache.put_cache(
         passage_hash=text_hash,
@@ -105,7 +110,11 @@ def test_cache_miss_calls_anthropic_once_and_persists(session: Session) -> None:
 
     assert client.messages.create.call_count == 1
     assert len(result) == 3
-    assert result[0] == {"type": "recall", "text": "What is the first counsel?"}
+    assert result[0] == {
+        "type": "recall",
+        "text": "What is the first counsel?",
+        "answer": "To possess a pure, kindly heart.",
+    }
 
     # And the cache now has it.
     text_hash = hashlib.sha256(TEST_PASSAGE.encode("utf-8")).digest()
@@ -318,6 +327,51 @@ def test_schema_mismatched_response_raises_generator_error(session: Session) -> 
         )
 
 
+def test_response_missing_answer_field_raises_generator_error(session: Session) -> None:
+    """COMP-4 (#123): a v2 response must carry an `answer` per question.
+    A question with valid type+text but no answer is malformed — reject
+    it as GeneratorError rather than cache a question with no answer to
+    reveal."""
+    bad_payload = '[{"type":"recall","text":"What is the first counsel?"}]'
+    client = _make_mock_client(response_text=bad_payload)
+
+    with pytest.raises(GeneratorError):
+        generate_questions(
+            passage_text=TEST_PASSAGE,
+            question_type="recall",
+            client=client,
+            model_id=TEST_MODEL_ID,
+            session=session,
+        )
+
+
+def test_answer_is_parsed_and_cached(session: Session) -> None:
+    """COMP-4 (#123): the source-grounded answer rides the existing cache
+    alongside the question — no separate storage, no extra LLM call on
+    re-read."""
+    client = _make_mock_client()
+
+    result = generate_questions(
+        passage_text=TEST_PASSAGE,
+        question_type="recall",
+        client=client,
+        model_id=TEST_MODEL_ID,
+        session=session,
+    )
+    assert all(q["answer"] for q in result)
+
+    text_hash = hashlib.sha256(TEST_PASSAGE.encode("utf-8")).digest()
+    cached = cache.get_cached(
+        passage_hash=text_hash,
+        question_type="recall",
+        model_id=TEST_MODEL_ID,
+        prompt_version=PROMPT_VERSION,
+        session=session,
+    )
+    assert cached is not None
+    assert cached[0]["answer"] == "To possess a pure, kindly heart."
+
+
 def test_malformed_response_does_not_poison_cache(session: Session) -> None:
     """A failed call must NOT write the bad output to the cache. Otherwise
     every retry would serve the broken result without re-calling the LLM."""
@@ -471,6 +525,7 @@ def test_return_shape_is_list_of_plain_dicts(session: Session) -> None:
     assert isinstance(result, list)
     for q in result:
         assert isinstance(q, dict)
-        assert set(q.keys()) == {"type", "text"}
+        assert set(q.keys()) == {"type", "text", "answer"}
         assert isinstance(q["text"], str)
+        assert isinstance(q["answer"], str)
         assert q["type"] in ("recall", "summary")

--- a/tests/test_comprehension_generator.py
+++ b/tests/test_comprehension_generator.py
@@ -69,9 +69,7 @@ def test_cache_hit_returns_immediately_without_calling_anthropic(session: Sessio
     before the Anthropic SDK is touched. Verify by pre-populating the
     cache and asserting the mock client's create() is never called."""
     text_hash = hashlib.sha256(TEST_PASSAGE.encode("utf-8")).digest()
-    cached_questions = [
-        {"type": "recall", "text": "cached question?", "answer": "cached answer."}
-    ]
+    cached_questions = [{"type": "recall", "text": "cached question?", "answer": "cached answer."}]
 
     cache.put_cache(
         passage_hash=text_hash,

--- a/tests/test_questions_route.py
+++ b/tests/test_questions_route.py
@@ -77,9 +77,9 @@ def test_owner_gets_questions_fragment(
     monkeypatch.setattr(
         "app.api.reading.generate_questions",
         lambda **_: [
-            {"type": "recall", "text": "What is the first word?"},
-            {"type": "recall", "text": "What is the last word?"},
-            {"type": "summary", "text": "What is the passage about?"},
+            {"type": "recall", "text": "What is the first word?", "answer": "O."},
+            {"type": "recall", "text": "What is the last word?", "answer": "Heart."},
+            {"type": "summary", "text": "What is the passage about?", "answer": "Purity."},
         ],
     )
 
@@ -91,6 +91,35 @@ def test_owner_gets_questions_fragment(
     assert "<ol>" in body
     assert body.count("<li>") == 3
     assert "What is the first word?" in body
+
+
+def test_questions_fragment_renders_interactive_answer_ui(
+    client: TestClient,
+    session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """COMP-4 (#123): each question renders an accessible self-assessment
+    UI — a labeled answer textarea + a <details> reveal containing the
+    source-grounded model answer."""
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+
+    monkeypatch.setattr(
+        "app.api.reading.generate_questions",
+        lambda **_: [
+            {"type": "recall", "text": "Who is addressed?", "answer": "The Son of Spirit."},
+        ],
+    )
+
+    body = client.get(f"/passages/{passage.id}/questions").text
+
+    # Labeled, accessible answer input (label `for` matches textarea `id`).
+    assert '<label for="answer-1">Who is addressed?</label>' in body
+    assert 'id="answer-1"' in body and "<textarea" in body
+    # Native reveal carrying the source-grounded answer.
+    assert "<details>" in body
+    assert "<summary>Reveal answer</summary>" in body
+    assert "The Son of Spirit." in body
 
 
 def test_response_is_a_fragment_not_a_full_page(


### PR DESCRIPTION
## Context

Closes #123 (COMP-4). Comprehension questions were **display-only** — the reading view showed 3 open-ended questions with no way to answer or check them. The PRD frames comprehension as checks to *"confirm the reader understood a passage."* This adds the answer + self-check loop.

## Approach (chosen over LLM-judge / MCQ)

**Self-assessment against a source-grounded model answer.** The generator now emits a short, passage-grounded `answer` per question; the reader writes their own answer, reveals the model answer, and self-assesses.

Crucially, the answer is generated in the **same Anthropic call** as the question and rides the **existing cache** — so:
- **No new API call**, no per-answer LLM cost.
- The epic #6 cost invariant ("10 distinct passages × 5 re-reads = exactly 10 calls") is **unchanged** — its regression test still passes.
- Honors epic #6's decision to keep LLM-as-judge **out of scope** (Risk #2: judging sacred/poetic text quality).

## Changes

| File | Change |
|------|--------|
| `app/services/comprehension/prompts.py` | Emit a source-grounded `answer` per question (≤40 words, plain language); **bump `PROMPT_VERSION` 1→2** (output-schema change re-generates the cache cleanly — no DB migration, it's a JSON column) |
| `app/services/comprehension/generator.py` | `_Question` validates a required, non-empty `answer`; a v2 response missing it is rejected as `GeneratorError` (poison-cache protection) |
| `templates/fragments/questions_panel.html` | Each question renders a labeled answer `<textarea>` (ephemeral — not persisted) + a native `<details>` reveal with the model answer. No JS, no server round-trip |
| `tests/` | Answer parsed + cached; missing-answer rejected; fragment renders labeled textarea + reveal |

## Verification

- **Full suite: 233 green** (+3 new tests); lint + mypy clean.
- **Cost invariant intact** — the epic #6 cost-acceptance test passes unchanged; no new Anthropic call introduced.
- **Accessibility: actually axe-scanned.** Rendered the real fragment and ran `@axe-core/playwright` (wcag2a+wcag2aa) → **0 serious/critical, 0 non-blocking**. The markup uses only native-accessible primitives (`<label for>`/`<textarea>`, `<details>`/`<summary>`); a route test pins the label↔textarea association.

### Note on CI a11y coverage
The existing `reading_surface.spec.ts` doesn't exercise the questions panel in CI (Anthropic isn't called there, so the panel renders its "unavailable" state). The new UI is covered by the route/template test + the local axe scan above. Giving the harness true coverage of the panel would mean seeding `comprehension_question_cache` in the test-seed route — a clean follow-up if desired.

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)