### PR TITLE
docs(journal): log 2026-06-03 feature-delivery session

### DIFF
--- a/reports/session-journals/2026-06-03.md
+++ b/reports/session-journals/2026-06-03.md
@@ -1,0 +1,106 @@
+# Session Journal — 2026-06-03
+
+*(Continuation of the 2026-06-02 board-reconciliation session — see
+`2026-06-02.md` for the epic-closure work that preceded this.)*
+
+## 1. Session Summary
+
+Having reconciled the board the day before (8 open issues → closed 7
+epics + a stale security alert), this segment turned the freshly-clean
+board into **feature delivery**: shipped login/verify accessibility
+coverage (which surfaced and fixed a real WCAG `lang` defect) and
+interactive comprehension answering (the "confirm understanding" loop
+the PRD always implied), plus finished the residual Neon-reference
+cleanup. Every change was verified with full test suites and **real axe
+scans**, reviewed, and merged. Board ended at a single open issue (#99,
+deferred by design).
+
+## 2. Tickets Delivered
+
+| Ticket | PR | What changed | Files touched | Tests |
+|---|---|---|---|---|
+| (chore) Strip stale Neon references | #119 | Removed ~13 stale Neon refs left after the Supabase replatform — incl. an operator-facing error message pointing at the deleted `NEON_API_KEY` and a dead `neon_configured` workflow output; kept accurate historical notes | `app/config.py`, `app/api/health.py`, `app/scripts/metric.py`, `pyproject.toml`, `.github/workflows/{deploy,preview-deploy}.yml` | none (behavior-preserving) |
+| #121 A11Y-4: login + verify a11y coverage | #122 | Added axe coverage for the login flow; fixed `/auth/callback` Stage 1 bridge missing `lang="en"` (axe `html-has-lang`, serious) | `app/api/auth.py`, `tests/a11y/login.spec.ts`, `tests/test_auth_callback.py` | +3 (2 Playwright: sign-in form + callback bridge; 1 pytest: `lang` assertion) |
+| #123 COMP-4: interactive comprehension answering | #124 | Questions gained a source-grounded model `answer` (same LLM call, same cache); reading view renders a labeled answer textarea + native `<details>` reveal for self-assessment | `app/services/comprehension/{prompts,generator}.py`, `templates/fragments/questions_panel.html`, `tests/test_comprehension_generator.py`, `tests/test_questions_route.py` | +3 (answer parsed+cached; missing-answer rejected; interactive-UI markup) |
+| (docs) 2026-06-02 board-reconciliation journal | #120 | The prior session's journal | `reports/session-journals/2026-06-02.md` | n/a |
+
+## 3. Tickets In Review
+
+None — all PRs from this session are merged.
+
+## 4. Challenges and Mitigations
+
+| Challenge | Root cause | Mitigation | Prevention |
+|---|---|---|---|
+| Playwright browser wouldn't launch locally (`libglib-2.0.so.0`, then `libasound.so.2` missing) | The Codespace lacks the OS libraries Chromium needs; `playwright install-deps` couldn't run (sudo had no `node` on PATH) | Installed the libs directly via `apt-get` — note `libasound2` is renamed `libasound2t64` on this Ubuntu (24.04), which aborted the batch install until isolated | To run the a11y harness locally on this image: `sudo apt-get install -y libglib2.0-0 libnss3 libnspr4 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libxkbcommon0 libatspi2.0-0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2t64` |
+| CI `python` job failed on PR #124 after a green local run + green pre-push | CI runs `ruff format --check`; the pre-push hook and `ruff check` (lint) do NOT — format is a separate ruff mode | Ran `ruff format`, re-pushed (one wasted CI cycle) | Run `uv run ruff format --check` (or just `ruff format .`) locally before pushing Python. Saved as memory `ruff-format-check-not-in-prepush` |
+| Neon cleanup was ~13 references across 5 files, not the "4" first estimated | Initial grep undercounted; some refs were stale operator guidance, others were accurate history | Expanded to all active-code stale refs (incl. the misleading `NEON_API_KEY` error message); deliberately kept accurate "we removed Neon here" historical notes; verified with a repo-wide grep | After a vendor migration, a repo-wide grep for the old vendor name is the cleanup's real definition-of-done, not a spot check |
+| The CI a11y harness doesn't exercise the live comprehension questions panel | The panel lazy-loads via an Anthropic call; CI has no `ANTHROPIC_API_KEY`, so the panel renders its "unavailable" state and axe never sees the answer UI | Verified the new UI a different way: rendered the real Jinja fragment to a standalone HTML doc and ran `@axe-core/playwright` against it (0 serious/critical) + a route test pinning the label↔textarea association | True harness coverage would need seeding `comprehension_question_cache` in the test-seed route — filed as a noted follow-up |
+
+## 5. Insights and Learnings
+
+### Technical insights
+
+- **Self-assessment beats LLM-judge for comprehension** here. The model answer is a deterministic function of (passage, question), so it rides the *existing* cache — generated in the same Anthropic call as the question, zero marginal cost on re-reads. This preserved epic #6's cost invariant (the "10 passages × 5 = 10 calls" test passed unchanged after the schema change) and honored its explicit "LLM-as-judge out of scope" decision (Risk #2: judging sacred/poetic text quality). An LLM grader would have broken all three.
+- **`PROMPT_VERSION` is the cache-migration lever.** Changing the generator's output schema (`{type,text}` → `{type,text,answer}`) needed no DB migration — the cache `questions` column is JSON, and bumping `PROMPT_VERSION` (part of the cache key) cleanly re-generates every entry. Required-field validation on the new `answer` means a stale/partial response is rejected as poison-cache rather than silently stored.
+- **Lightweight a11y verification without the full harness**: render a Jinja fragment to a standalone HTML doc (via the app's `templates` env), then axe-scan it with a tiny `@axe-core/playwright` script (`browser.newContext()` → `page.goto(file://…)`). Reusable whenever a fragment can't easily be reached as a live page in CI. (Gotcha: `AxeBuilder` rejects a page from `browser.newPage()` — it needs an explicit `newContext()`.)
+- **Accessible answer UI from native primitives only**: the question text *is* the `<label for>` (so the textarea's accessible name is the question), and reveal is a native `<details>`/`<summary>` — no JS, no ARIA, no server round-trip, and axe-clean by construction.
+- **`ruff check` ≠ `ruff format --check`** — lint rules vs. the autoformatter are separate modes; CI enforces both, the pre-push hook only the former.
+
+### Process insights
+
+- **Verify-don't-assume paid off twice**: the negative test on #122 (revert the `lang` fix → confirm the test fails with exactly `html-has-lang`) proved the test wasn't vacuous; the standalone axe scan on #124 turned "should be accessible" into "is accessible (0 violations)."
+- **Tee-up-then-build worked well for the feature with product ambiguity.** Interactive answering had a real fork (self-assess vs. LLM-judge vs. MCQ); writing the DoR ticket (#123) with the options + a recommendation, confirming the direction, *then* implementing kept the build unambiguous. Contrast with the a11y work (#121), which had an obvious approach and went straight to a ticket + code.
+
+### Domain insights
+
+- Comprehension is now an actual feedback loop, not just generated prompts — read → answer in your own words → reveal source-grounded answer → self-check. This is the first time the product delivers the PRD's "confirm understanding," and it does so within the cost envelope.
+- The login/verify flow's bridge page (`/auth/callback` Stage 1) is hand-built inline HTML that bypasses `base.html`, so it doesn't inherit the base template's a11y baseline (`lang`, landmarks). Any future hand-built HTML response carries the same risk.
+
+## 6. Tickets Created
+
+| Ticket | Filed during | Why |
+|---|---|---|
+| #121 — A11Y-4: login + verify a11y coverage | Scoping the "what's next" after board reconciliation | Epic #3's acceptance wanted a login-flow a11y audit; the harness only covered the reading surface, and scoping found a real `lang` defect |
+| #123 — COMP-4: interactive comprehension answering | Teeing up comprehension Phase 2 | Questions were display-only; filed a DoR ticket with the self-assessment approach recommended (over LLM-judge/MCQ) before implementing |
+
+## 7. Metrics
+
+- **PRs created**: 4 (#119, #120, #122, #124)
+- **PRs merged**: 4
+- **PRs reviewed**: 3 (#119, #122, #124 — solo-mode, conflict disclosed on each; #120 was a docs journal, no review)
+- **Issues created**: 2 (#121, #123)
+- **Issues closed**: 2 by this segment's merges (#121, #123) — plus the 7 epics + 1 alert closed in the 2026-06-02 segment
+- **Tests added**: 6 (2 Playwright login specs + 1 pytest `lang` assertion + 3 comprehension generator/route tests); full suite 233 green at session end
+- **Board state**: **1 open issue** (#99, deferred). No open PRs.
+- **Memories written this segment**: `ruff-format-check-not-in-prepush` (plus `board-lags-codebase` and `dod-can-encode-false-assumptions` earlier in the 06-02 segment)
+
+## 8. Next Up
+
+In priority order:
+
+1. **Seed `comprehension_question_cache` in the test-seed route** so the CI a11y harness actually scans the live questions panel (the new answer UI). Closes the one coverage caveat from #124. S effort.
+2. **Comprehension Phase 3** — persist self-marks and/or tie them into the reading-event metric; or a "disable comprehension per passage" toggle (the Risk #2 mitigation the PRD calls for). Each is its own ticket.
+3. **#99 — per-PR Supabase DATABASE_URL injection** — still the only tracked open item. Stays deferred until `SUPABASE_ACCESS_TOKEN` + `SUPABASE_DB_PASSWORD` are provisioned AND real users exist on production; escalate to P1 when users land.
+
+## Memory Validation
+
+This fork uses **file-based memory** (`~/.claude/projects/-workspaces-cubrox/memory/`),
+not the `CompletedTicket-N` Memory-MCP entity scheme. Queried the Memory
+MCP this session (`search_nodes`) — the graph is **empty**, so no
+`CompletedTicket` entities exist for #121 or #123.
+
+→ Memory validation: 0/2 delivered tickets have `CompletedTicket` MCP
+entities — expected for this fork (file-based memory), not a gap.
+
+## Memory Consolidation
+
+Written live this session: `ruff-format-check-not-in-prepush` (the CI
+format-check gotcha). The 2026-06-02 segment wrote `board-lags-codebase`
+and `dod-can-encode-false-assumptions`.
+
+→ No further entities proposed — the remaining insights (self-assess vs.
+LLM-judge rationale, the standalone-fragment axe-scan technique, the
+Playwright-system-deps recipe) are captured in this journal, which is
+the appropriate substrate. The fragment-axe-scan technique is a candidate
+`PatternDiscovered` if the MCP scheme is ever adopted here.


### PR DESCRIPTION
## Context

Session journal for 2026-06-03 — continuation of the 2026-06-02 board-reconciliation session.

## Summary

Turned the freshly-reconciled board into feature delivery:
- **#119** — stripped residual stale Neon references (incl. a misleading operator error message).
- **#122 (A11Y-4 / #121)** — login + verify a11y coverage; fixed a real `html-has-lang` (serious) WCAG defect on the `/auth/callback` bridge page.
- **#124 (COMP-4 / #123)** — interactive comprehension answering (self-assess vs. source-grounded model answers), at zero added LLM cost.

Captures delivered tickets, challenges (Playwright system-deps, the `ruff format --check` CI gap, the comprehension-panel a11y coverage limitation), insights, metrics, and next-up. Board ended at **1 open issue** (#99, deferred).

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)