### PR TITLE
test(a11y): axe-scan the live comprehension questions panel

### DIFF
--- a/app/api/test_seed.py
+++ b/app/api/test_seed.py
@@ -43,6 +43,7 @@ process via `playwright.config.ts > webServer.env`. Production Cloud
 Run revisions do not set this var; the seed router cannot be reached.
 """
 
+import hashlib
 import os
 import secrets
 import uuid
@@ -59,6 +60,8 @@ from app.integrations.supabase.auth import SUPABASE_COOKIE_NAME
 from app.integrations.supabase.client import anon_client, service_client
 from app.models.passage import Passage
 from app.models.preference import Preference
+from app.services.comprehension import cache as comprehension_cache
+from app.services.comprehension.prompts import PROMPT_VERSION
 
 _SEED_ENABLED = os.environ.get("CUBROX_TEST_SEED_ENABLED") == "true"
 _TEST_ENV = os.environ.get("ENVIRONMENT") == "test"
@@ -90,6 +93,30 @@ SEED_PASSAGE_TEXT = (
 )
 
 
+# Pre-baked comprehension questions for the `with_questions` path (A11Y-5
+# #126). Seeding these into the cache makes the questions panel a cache
+# HIT, so the reading view renders the real answer UI (labeled textareas +
+# <details> reveals) WITHOUT an Anthropic call — letting axe scan it in CI.
+# The shape matches PROMPT_VERSION 2: type + text + a source-grounded answer.
+SEED_QUESTIONS: list[dict[str, str]] = [
+    {
+        "type": "recall",
+        "text": "What does the first counsel tell the reader to possess?",
+        "answer": "A pure, kindly and radiant heart.",
+    },
+    {
+        "type": "recall",
+        "text": "What does the speaker call the best beloved of all things?",
+        "answer": "Justice.",
+    },
+    {
+        "type": "summary",
+        "text": "What two qualities does the passage urge the reader to value?",
+        "answer": "A pure heart and justice.",
+    },
+]
+
+
 # Per-variant overrides to the stored Preference values. `default` is
 # empty (no row created — the reading view falls back to the
 # DEFAULT_PREFERENCES path). The other three exercise one axis each so
@@ -107,6 +134,7 @@ def seed_passage_and_login(
     variant: Variant,
     session: SessionDep,
     settings: SettingsDep,
+    with_questions: bool = False,
 ) -> JSONResponse:
     """Seed a fresh Supabase user + passage + (optional) preference;
     return the Supabase access token as the `sb-access-token` cookie +
@@ -115,6 +143,10 @@ def seed_passage_and_login(
     Each invocation creates an independent throwaway user (UUID-suffixed
     email) so concurrent Playwright tests don't collide on the email
     unique constraint in Supabase Auth.
+
+    When `with_questions=true` (A11Y-5 #126), also seed the comprehension
+    cache for this passage so the questions panel renders its real answer
+    UI from a cache hit — no Anthropic call — and axe can scan it.
     """
     email = f"a11y-{uuid.uuid4()}@example.test"
     # Supabase requires a password on admin.create_user (even with
@@ -145,10 +177,10 @@ def seed_passage_and_login(
 
     passage = Passage(
         owner_id=user_id,
-        # Placeholder hash — the read path doesn't validate it; only
-        # the comprehension-cache uses text_hash, which the a11y tests
-        # don't exercise (the questions panel makes a network call we
-        # don't care about for visual a11y).
+        # Placeholder hash — the read path doesn't validate it. Note the
+        # comprehension route keys its cache on SHA-256(passage.text), not
+        # this column, so the `with_questions` seed below hashes the text
+        # directly rather than reusing this value.
         text_hash=b"\x00" * 32,
         text=SEED_PASSAGE_TEXT,
         source_type="paste",
@@ -164,6 +196,21 @@ def seed_passage_and_login(
                 values=prefs_overrides,
                 updated_at=datetime.now(UTC),
             )
+        )
+
+    if with_questions:
+        # Seed the comprehension cache with the EXACT key the questions
+        # route looks up (GET /passages/{id}/questions): hash of the
+        # passage text, question_type="recall", the configured model, and
+        # the current PROMPT_VERSION. The route then cache-hits instead of
+        # calling Anthropic.
+        comprehension_cache.put_cache(
+            passage_hash=hashlib.sha256(SEED_PASSAGE_TEXT.encode("utf-8")).digest(),
+            question_type="recall",
+            model_id=settings.anthropic_model,
+            prompt_version=PROMPT_VERSION,
+            questions=SEED_QUESTIONS,
+            session=session,
         )
 
     session.commit()

--- a/tests/a11y/comprehension_panel.spec.ts
+++ b/tests/a11y/comprehension_panel.spec.ts
@@ -1,0 +1,51 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import { seedAndLogin } from "./fixtures/seed";
+
+/**
+ * Comprehension questions-panel accessibility (A11Y-5 #126).
+ *
+ * COMP-4 (#124) added an interactive answer UI (labeled textareas +
+ * <details> reveals) to the questions panel, but the panel lazy-loads
+ * via an Anthropic call that CI can't make — so reading_surface.spec
+ * only ever sees the panel's "unavailable" state.
+ *
+ * Here we seed the comprehension cache (`withQuestions`) so the panel
+ * is a cache HIT and renders the real answer UI with no Anthropic call,
+ * then axe-scan it. Gate matches the rest of the harness: zero
+ * serious/critical under WCAG 2.0 A+AA.
+ */
+test("comprehension answer panel a11y", async ({ page, context, request }) => {
+  const { passageId } = await seedAndLogin(request, context, "default", {
+    withQuestions: true,
+  });
+
+  await page.goto(`/read/${passageId}`);
+  await expect(page.locator("#reading-surface")).toBeVisible();
+
+  // The panel lazy-loads (hx-trigger="load delay:200ms") then swaps in
+  // the questions fragment. Wait for the real answer UI before scanning.
+  await expect(page.getByText("Reveal answer").first()).toBeVisible();
+
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa"])
+    .analyze();
+
+  const blockers = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  if (blockers.length > 0) {
+    console.log("[a11y blockers — questions panel]", JSON.stringify(blockers, null, 2));
+  }
+  const nonBlocking = results.violations.filter(
+    (v) => v.impact !== "critical" && v.impact !== "serious",
+  );
+  if (nonBlocking.length > 0) {
+    console.log(
+      "[a11y non-blocking — questions panel]",
+      nonBlocking.map((v) => `${v.id} (${v.impact})`).join(", "),
+    );
+  }
+
+  expect(blockers, "axe found serious/critical violations on the questions panel").toHaveLength(0);
+});

--- a/tests/a11y/fixtures/seed.ts
+++ b/tests/a11y/fixtures/seed.ts
@@ -28,9 +28,13 @@ export async function seedAndLogin(
   request: APIRequestContext,
   context: BrowserContext,
   variant: Variant,
+  opts: { withQuestions?: boolean } = {},
 ): Promise<SeedResult> {
+  // `with_questions` (A11Y-5 #126) also seeds the comprehension cache so
+  // the questions panel renders its real answer UI from a cache hit.
+  const q = opts.withQuestions ? "&with_questions=true" : "";
   const response = await request.post(
-    `/test/seed-passage-and-login?variant=${variant}`,
+    `/test/seed-passage-and-login?variant=${variant}${q}`,
   );
   if (!response.ok()) {
     throw new Error(

--- a/tests/test_seed_route.py
+++ b/tests/test_seed_route.py
@@ -244,3 +244,56 @@ def test_seed_500s_when_supabase_sign_in_returns_no_session(
         "/test/seed-passage-and-login?variant=default", follow_redirects=False
     )
     assert response.status_code == 500
+
+
+def test_seed_with_questions_seeds_cache_the_route_will_hit(
+    seed_client: TestClient, session: Session, supabase_mock: MagicMock
+) -> None:
+    """A11Y-5 (#126): `with_questions=true` seeds the comprehension cache
+    with the EXACT key the questions route looks up. Proven end-to-end:
+    after the seed, `generate_questions` for the seed passage returns the
+    seeded set WITHOUT calling Anthropic — i.e. a cache hit, which is what
+    lets the a11y harness render the real answer UI without an API key."""
+    import app.api.test_seed as test_seed
+    from app.config import get_settings
+    from app.services.comprehension.generator import generate_questions
+
+    _wire_supabase_for_seed(supabase_mock)
+    response = seed_client.post("/test/seed-passage-and-login?variant=default&with_questions=true")
+    assert response.status_code == 200
+
+    client = MagicMock()
+    result = generate_questions(
+        passage_text=test_seed.SEED_PASSAGE_TEXT,
+        question_type="recall",
+        client=client,
+        model_id=get_settings().anthropic_model,
+        session=session,
+    )
+    assert client.messages.create.call_count == 0  # cache hit, no LLM call
+    assert result == test_seed.SEED_QUESTIONS
+
+
+def test_seed_without_questions_leaves_comprehension_cache_empty(
+    seed_client: TestClient, session: Session, supabase_mock: MagicMock
+) -> None:
+    """The default path must NOT seed the cache — existing reading-surface
+    a11y tests keep rendering the panel's "unavailable" state, unchanged."""
+    import hashlib
+
+    import app.api.test_seed as test_seed
+    from app.config import get_settings
+    from app.services.comprehension import cache
+    from app.services.comprehension.prompts import PROMPT_VERSION
+
+    _wire_supabase_for_seed(supabase_mock)
+    seed_client.post("/test/seed-passage-and-login?variant=default")
+
+    cached = cache.get_cached(
+        passage_hash=hashlib.sha256(test_seed.SEED_PASSAGE_TEXT.encode("utf-8")).digest(),
+        question_type="recall",
+        model_id=get_settings().anthropic_model,
+        prompt_version=PROMPT_VERSION,
+        session=session,
+    )
+    assert cached is None


### PR DESCRIPTION
## Context

Closes #126 (A11Y-5). Closes the one coverage caveat from #124: the CI a11y harness never scanned the new interactive answer UI, because the questions panel lazy-loads via an Anthropic call CI can't make (no `ANTHROPIC_API_KEY`) — so it only ever rendered the "unavailable" state.

## Approach

Seed the comprehension cache from the test-only seed route so the panel becomes a **cache hit** — rendering the real answer UI (labeled textareas + `<details>` reveals) with **no API call** — then axe-scan it.

The seed uses the **exact** key the questions route looks up: `SHA-256(passage.text)`, `question_type="recall"`, `settings.anthropic_model`, `PROMPT_VERSION`. It's **opt-in** (`with_questions`, default false), so the existing 4 reading-surface variant tests are completely unaffected.

## Changes

| File | Change |
|------|--------|
| `app/api/test_seed.py` | `with_questions` flag seeds a matching `comprehension_question_cache` row (test-only route; no production path changes) |
| `tests/a11y/fixtures/seed.ts` | `withQuestions` option on `seedAndLogin` |
| `tests/a11y/comprehension_panel.spec.ts` | New spec: seed → wait for the reveal UI → axe scan (zero serious/critical) |
| `tests/test_seed_route.py` | Prove the seeded key is a cache hit for the route (`generate_questions` returns it with no LLM call); default path leaves the cache empty |

## Verification

- **Full suite 235 green** (+2 seed-route tests); lint + format + mypy clean.
- The 2 new pytest tests prove the **core correctness risk locally without Docker**: the seeded cache key exactly matches the questions route's lookup (cache hit, no Anthropic call), and the default path doesn't seed.
- All 8 Playwright specs compile + the new test is discovered (`playwright test --list`).
- The answer UI markup was already axe-verified in #124; this wires it into CI. The **CI `a11y` job** runs the new spec end-to-end against the local Supabase stack.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)