### PR TITLE
feat(comprehension): per-passage disable toggle

### DIFF
--- a/app/api/reading.py
+++ b/app/api/reading.py
@@ -193,6 +193,17 @@ def passage_questions(
     if passage is None:
         raise HTTPException(status_code=404, detail="Passage not found")
 
+    # COMP-5 (#128): comprehension off for this passage → never call the
+    # generator. The reading view doesn't render the lazy-load placeholder
+    # when disabled, so this is defense-in-depth (and keeps a direct hit
+    # from spending an LLM call on a disabled passage).
+    if not passage.comprehension_enabled:
+        return templates.TemplateResponse(
+            request=request,
+            name="fragments/questions_panel.html",
+            context={"questions": None, "error": "disabled"},
+        )
+
     questions: list[dict] | None = None
     error: str | None = None
 
@@ -222,6 +233,39 @@ def passage_questions(
         request=request,
         name="fragments/questions_panel.html",
         context={"questions": questions, "error": error},
+    )
+
+
+@router.post("/passages/{passage_id}/comprehension", response_class=HTMLResponse)
+def toggle_comprehension(
+    request: Request,
+    passage_id: uuid.UUID,
+    user: CurrentUser,
+    session: SessionDep,
+    enabled: Annotated[bool, Form()],
+) -> HTMLResponse:
+    """Enable/disable comprehension questions for one passage (COMP-5 #128).
+
+    Flips `passage.comprehension_enabled` and returns the `#comprehension`
+    fragment reflecting the new state; HTMX swaps it via `outerHTML`.
+    Ownership-checked exactly like GET /read — cross-user / nonexistent
+    passages 404 with an identical body.
+    """
+    passage = session.exec(
+        select(Passage).where(Passage.id == passage_id, Passage.owner_id == user.id)  # type: ignore[arg-type]
+    ).first()
+    if passage is None:
+        raise HTTPException(status_code=404, detail="Passage not found")
+
+    passage.comprehension_enabled = enabled
+    session.add(passage)
+    session.commit()
+    session.refresh(passage)
+
+    return templates.TemplateResponse(
+        request=request,
+        name="fragments/comprehension.html",
+        context={"passage": passage},
     )
 
 

--- a/app/models/passage.py
+++ b/app/models/passage.py
@@ -31,4 +31,8 @@ class Passage(SQLModel, table=True):
     text_hash: bytes
     source_type: str
     source_filename: str | None = Field(default=None)
+    # COMP-5 (#128): per-passage comprehension toggle. Default on; a reader
+    # can disable questions for a passage where the auto-generated ones are
+    # unhelpful (PRD Risk #2 mitigation for sacred/poetic text).
+    comprehension_enabled: bool = Field(default=True, nullable=False)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/supabase/migrations/20260604000000_add_passage_comprehension_enabled.sql
+++ b/supabase/migrations/20260604000000_add_passage_comprehension_enabled.sql
@@ -1,0 +1,11 @@
+-- COMP-5 (#128): per-passage comprehension toggle.
+--
+-- Additive column, default true, so every existing passage keeps its
+-- questions on. The reading view + POST /passages/{id}/comprehension flip
+-- this; the questions route skips generation when it's false. Mirrors the
+-- SQLModel field on app/models/passage.py.
+--
+-- IF NOT EXISTS keeps the migration idempotent across re-applies and
+-- per-PR Supabase branches.
+ALTER TABLE public.passage
+    ADD COLUMN IF NOT EXISTS comprehension_enabled boolean NOT NULL DEFAULT true;

--- a/templates/fragments/comprehension.html
+++ b/templates/fragments/comprehension.html
@@ -1,0 +1,25 @@
+<div id="comprehension">
+  {% if passage.comprehension_enabled %}
+    <button type="button"
+            class="comprehension-toggle"
+            hx-post="/passages/{{ passage.id }}/comprehension"
+            hx-vals='{"enabled": "false"}'
+            hx-target="#comprehension"
+            hx-swap="outerHTML">Hide questions for this passage</button>
+    {# Lazy-loaded panel — fires ~200ms after this fragment renders,
+       whether on first page load or after re-enabling via the toggle. #}
+    <div id="questions-panel"
+         hx-get="/passages/{{ passage.id }}/questions"
+         hx-trigger="load delay:200ms"
+         hx-swap="outerHTML"
+         aria-live="polite"></div>
+  {% else %}
+    <button type="button"
+            class="comprehension-toggle"
+            hx-post="/passages/{{ passage.id }}/comprehension"
+            hx-vals='{"enabled": "true"}'
+            hx-target="#comprehension"
+            hx-swap="outerHTML">Show comprehension questions</button>
+    <p>Comprehension questions are off for this passage.</p>
+  {% endif %}
+</div>

--- a/templates/fragments/questions_panel.html
+++ b/templates/fragments/questions_panel.html
@@ -24,5 +24,7 @@
   {% elif error == "unavailable" %}
     <p>Comprehension questions are temporarily unavailable.
        The rest of your reading still works as normal.</p>
+  {% elif error == "disabled" %}
+    <p>Comprehension questions are off for this passage.</p>
   {% endif %}
 </section>

--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -11,11 +11,7 @@
 
   {% include "fragments/reading_surface.html" %}
 
-  <div id="questions-panel"
-       hx-get="/passages/{{ passage.id }}/questions"
-       hx-trigger="load delay:200ms"
-       hx-swap="outerHTML"
-       aria-live="polite"></div>
+  {% include "fragments/comprehension.html" %}
 
   {#
     METRIC-2: emit one reading_event on unload. The inline <script>

--- a/tests/test_comprehension_toggle.py
+++ b/tests/test_comprehension_toggle.py
@@ -1,0 +1,154 @@
+"""Tests for the per-passage comprehension toggle (COMP-5 #128).
+
+Covers:
+  - POST /passages/{id}/comprehension flips `comprehension_enabled` and
+    persists it, returning the #comprehension fragment for the new state
+  - Ownership: cross-user / nonexistent passages 404 (no existence leak)
+  - The questions route returns a "disabled" fragment AND skips the
+    generator when comprehension is off for the passage
+  - The reading view renders the right toggle state for on vs. off
+"""
+
+import hashlib
+import uuid
+from collections.abc import Generator
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.main import app
+from app.models.passage import Passage
+from app.services.comprehension.client import get_anthropic_client
+from tests.conftest import make_user, signed_in
+
+
+@pytest.fixture(autouse=True)
+def _stub_anthropic_client() -> Generator[None, None, None]:
+    """Override the Anthropic client dep so no test here builds a real
+    client (the toggle/guard paths must never reach the API anyway)."""
+    app.dependency_overrides[get_anthropic_client] = lambda: MagicMock()
+    yield
+    app.dependency_overrides.pop(get_anthropic_client, None)
+
+
+def _make_passage(session: Session, owner_id: uuid.UUID, *, enabled: bool = True) -> Passage:
+    text = "A passage of text."
+    p = Passage(
+        owner_id=owner_id,
+        text=text,
+        text_hash=hashlib.sha256(text.encode("utf-8")).digest(),
+        source_type="paste",
+        source_filename=None,
+        comprehension_enabled=enabled,
+    )
+    session.add(p)
+    session.commit()
+    session.refresh(p)
+    return p
+
+
+def test_default_passage_has_comprehension_enabled(session: Session) -> None:
+    """The column defaults to on — existing reading behaviour is unchanged."""
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+    assert passage.comprehension_enabled is True
+
+
+def test_toggle_off_persists_and_returns_disabled_fragment(
+    client: TestClient, session: Session
+) -> None:
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+
+    response = client.post(f"/passages/{passage.id}/comprehension", data={"enabled": "false"})
+
+    assert response.status_code == 200
+    body = response.text
+    assert "Comprehension questions are off for this passage." in body
+    assert "Show comprehension questions" in body
+    # Fragment, not a full page.
+    assert "<html" not in body.lower()
+
+    session.refresh(passage)
+    assert passage.comprehension_enabled is False
+
+
+def test_toggle_on_persists_and_returns_panel_placeholder(
+    client: TestClient, session: Session
+) -> None:
+    user = signed_in(session)
+    passage = _make_passage(session, user.id, enabled=False)
+
+    response = client.post(f"/passages/{passage.id}/comprehension", data={"enabled": "true"})
+
+    assert response.status_code == 200
+    body = response.text
+    assert "Hide questions for this passage" in body
+    # Re-enabling brings back the lazy-load placeholder.
+    assert f"/passages/{passage.id}/questions" in body
+
+    session.refresh(passage)
+    assert passage.comprehension_enabled is True
+
+
+def test_toggle_other_users_passage_returns_404(client: TestClient, session: Session) -> None:
+    owner = make_user(session, email="owner@example.com")
+    passage = _make_passage(session, owner.id)
+    signed_in(session, email="intruder@example.com")
+
+    response = client.post(f"/passages/{passage.id}/comprehension", data={"enabled": "false"})
+    assert response.status_code == 404
+
+    # The flag must be untouched.
+    session.refresh(passage)
+    assert passage.comprehension_enabled is True
+
+
+def test_toggle_nonexistent_passage_returns_404(client: TestClient, session: Session) -> None:
+    signed_in(session)
+    response = client.post(f"/passages/{uuid.uuid4()}/comprehension", data={"enabled": "false"})
+    assert response.status_code == 404
+
+
+def test_questions_route_skips_generator_when_disabled(
+    client: TestClient, session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When comprehension is off, the questions route returns the disabled
+    fragment and never calls the generator (no LLM cost for a disabled
+    passage)."""
+    user = signed_in(session)
+    passage = _make_passage(session, user.id, enabled=False)
+
+    def _boom(**_: object) -> list[dict]:
+        raise AssertionError("generate_questions must not run when disabled")
+
+    monkeypatch.setattr("app.api.reading.generate_questions", _boom)
+
+    response = client.get(f"/passages/{passage.id}/questions")
+
+    assert response.status_code == 200
+    assert "Comprehension questions are off for this passage." in response.text
+
+
+def test_reading_view_shows_toggle_enabled_by_default(client: TestClient, session: Session) -> None:
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+
+    body = client.get(f"/read/{passage.id}").text
+
+    assert "Hide questions for this passage" in body
+    assert f'hx-get="/passages/{passage.id}/questions"' in body
+
+
+def test_reading_view_shows_off_state_when_disabled(client: TestClient, session: Session) -> None:
+    user = signed_in(session)
+    passage = _make_passage(session, user.id, enabled=False)
+
+    body = client.get(f"/read/{passage.id}").text
+
+    assert "Show comprehension questions" in body
+    assert "Comprehension questions are off for this passage." in body
+    # The lazy-load placeholder must NOT be present when disabled.
+    assert f'hx-get="/passages/{passage.id}/questions"' not in body


### PR DESCRIPTION
## Context

Closes #128 (COMP-5). Comprehension questions always loaded. The PRD's **Risk #2 mitigation** explicitly calls for the *"ability to disable per passage"* — auto-generated questions can be uneven on sacred/poetic text, and a reader had no way to turn them off for a passage.

## Changes

| File | Change |
|------|--------|
| `app/models/passage.py` + new migration | `comprehension_enabled` column, additive, **default true** (existing passages keep questions on) |
| `app/api/reading.py` | `POST /passages/{id}/comprehension` toggles the flag (ownership-checked, 404 on cross-user/nonexistent); questions route returns a "disabled" fragment and **skips the generator** when off |
| `templates/fragments/comprehension.html` (new) + `reading.html` | reading view renders the toggle + conditional panel; on → "Hide questions…" + lazy-load placeholder, off → "Show comprehension questions" + off message |
| `templates/fragments/questions_panel.html` | `disabled` branch (defense-in-depth for a direct hit) |

## Design notes

- **No LLM cost when off** — the questions route returns before calling `generate_questions`; the reading view doesn't even render the lazy-load placeholder when disabled.
- **Mirrors existing patterns** — the toggle is the same HTMX fragment-swap shape as the preference toggles; ownership check matches `GET /read`.
- **Additive migration only** — `ADD COLUMN IF NOT EXISTS … DEFAULT true`, idempotent across re-applies / per-PR Supabase branches.

## Verification

- **Full suite 243 green** (+8 toggle tests: flip/persist, ownership 404s, disabled-skips-generation, reading-view on/off states); lint + format + mypy clean; all 8 a11y specs compile.
- The toggle is a plain `<button>` with clear text — a11y-clean; the reading-surface + comprehension-panel a11y specs (which now render the toggle) exercise it in CI.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)