### PR TITLE
docs(journal): log 2026-06-04 comprehension-hardening session

### DIFF
--- a/reports/session-journals/2026-06-04.md
+++ b/reports/session-journals/2026-06-04.md
@@ -1,0 +1,99 @@
+# Session Journal — 2026-06-04
+
+*(Continuation of the multi-day feature-delivery session — see
+`2026-06-02.md` (board reconciliation) and `2026-06-03.md` (Neon cleanup,
+login a11y, interactive comprehension answering) for prior segments.)*
+
+## 1. Session Summary
+
+Worked down the "Next Up" list from the 2026-06-03 journal, focused on
+hardening and extending comprehension. Closed the a11y coverage gap that
+COMP-4 left open (the live questions panel is now axe-scanned in CI), then
+shipped the per-passage comprehension disable toggle — the PRD's stated
+Risk #2 mitigation for uneven question quality on sacred/poetic text. Both
+landed verified (full suites + green CI a11y job) and merged. Board stays
+at a single open issue (#99, deferred).
+
+## 2. Tickets Delivered
+
+| Ticket | PR | What changed | Files touched | Tests |
+|---|---|---|---|---|
+| #126 A11Y-5: axe-scan the live questions panel | #127 | Opt-in `with_questions` flag on the test-seed route seeds the comprehension cache, so the panel becomes a cache HIT and renders the real answer UI (no Anthropic call) for axe to scan in CI | `app/api/test_seed.py`, `tests/a11y/fixtures/seed.ts`, `tests/a11y/comprehension_panel.spec.ts`, `tests/test_seed_route.py` | +3 (2 pytest: seeded key = route lookup is a cache hit; default leaves cache empty — plus 1 Playwright spec) |
+| #128 COMP-5: disable comprehension per passage | #129 | `passage.comprehension_enabled` (model + additive migration); `POST /passages/{id}/comprehension` toggle; questions route skips the generator when off; reading view renders the toggle + conditional panel | `app/models/passage.py`, `supabase/migrations/20260604000000_…sql`, `app/api/reading.py`, `templates/fragments/comprehension.html` (new), `templates/pages/reading.html`, `templates/fragments/questions_panel.html` | +8 (flip/persist, ownership 404s, disabled-skips-generation, reading-view on/off) |
+
+## 3. Tickets In Review
+
+None — all PRs from this segment are merged.
+
+## 4. Challenges and Mitigations
+
+| Challenge | Root cause | Mitigation | Prevention |
+|---|---|---|---|
+| Couldn't run the seed-based a11y spec (#127) end-to-end locally | The seed route calls Supabase admin/sign-in; Docker/`supabase` isn't available in this Codespace | Proved the **core risk** locally without Docker: a pytest asserts the seeded cache key is a genuine cache hit for the questions route (`generate_questions` returns the seeded set with zero LLM calls). The full browser path was confirmed by the green CI a11y job | For seed-backed a11y work, pin the seed↔route contract in pytest and let the CI a11y job (which has the Supabase stack) own the end-to-end run |
+| The COMP-5 migration applies only in the CI/real Supabase stack, not testable locally without Docker | pytest builds its schema from the SQLModel models (`create_all`), not the SQL migrations | Added BOTH the SQLModel field (for pytest + the app) and the additive SQL migration (for the a11y CI job's local Supabase stack + real Supabase); the green CI a11y job confirmed the migration applied | When adding a column: model field for pytest, SQL migration for CI/prod — both are required, and the a11y job is the local-Supabase smoke test |
+| `ruff format --check` flagged a file on both PRs this segment | Same root cause as last segment — CI enforces format, the pre-push hook + `ruff check` don't | Caught it **locally before pushing both times** (per the `ruff-format-check-not-in-prepush` memory) → zero wasted CI cycles this segment, vs. one wasted re-push on #124 before the lesson existed | The memory is doing its job; keep running `ruff format --check` in the pre-ship checklist |
+
+## 5. Insights and Learnings
+
+### Technical insights
+
+- **Seeding a content-addressable cache is how you make a lazy LLM panel deterministically renderable in CI.** The questions panel can't call Anthropic in CI, so it always rendered "unavailable". Seeding `comprehension_question_cache` with the EXACT key the route looks up (`SHA-256(passage.text)`, `question_type`, `model_id`, `PROMPT_VERSION`) turns the panel into a cache hit — real UI, no API key. Reusable for any LLM-backed surface that needs CI a11y/visual coverage.
+- **Prove the seed↔route key match in pytest, not just by inspection.** The one real failure mode of cache-seeding is a key mismatch (different hash/model/version → silent miss). A pytest that seeds then asserts `generate_questions` is a cache hit (zero LLM calls) catches that locally, even when the full browser path needs infra you don't have.
+- **Additive column = model field + migration, and they serve different consumers.** pytest's in-memory DB comes from `SQLModel.metadata.create_all`, so the field alone makes pytest pass; the CI a11y job + real Supabase come from `supabase/migrations/*.sql`, so the migration is what keeps those green. Shipping only one would pass pytest but break the a11y job (or prod).
+- **Disable-when-off must short-circuit before the dependency-injected work, not just hide the UI.** The questions route returns the "disabled" fragment before calling the generator, and the reading view doesn't render the lazy-load placeholder at all when off — so a disabled passage costs zero LLM calls even if the endpoint is hit directly.
+
+### Process insights
+
+- **A prior-session memory measurably paid off.** The `ruff-format-check-not-in-prepush` lesson (written last segment after a wasted CI cycle on #124) meant I ran `ruff format --check` before pushing both PRs this segment and fixed locally — no CI failures. Concrete evidence that the file-memory loop closes.
+- **Tee-up-with-options remains the right move for product forks.** Comprehension Phase 3 had a genuine fork (per-passage disable vs. persist self-marks); presenting both with a grounded recommendation (disable = a *stated* PRD requirement) let the direction get picked in one step before any code.
+
+### Domain insights
+
+- Comprehension is now feature-complete for the MVP arc: generate → answer/self-check → (a11y-covered) → disable-per-passage. The remaining idea (persist self-marks / feed the 100k-line metric) is genuinely speculative — not a stated PRD requirement — so it belongs behind a design pass, not an immediate build.
+
+## 6. Tickets Created
+
+| Ticket | Filed during | Why |
+|---|---|---|
+| #126 — A11Y-5: axe-scan the live questions panel | Picking up Next-Up #1 from the 2026-06-03 journal | Close the coverage caveat #124 documented — the new answer UI wasn't scanned in CI |
+| #128 — COMP-5: disable comprehension per passage | Picking up Next-Up #2 (Phase 3) | Fulfills the PRD's Risk #2 mitigation ("ability to disable per passage"); chosen over persist-self-marks as the grounded, well-scoped option |
+
+## 7. Metrics
+
+- **PRs created**: 2 (#127, #129)
+- **PRs merged**: 2
+- **PRs reviewed**: 2 (#127, #129 — solo-mode, conflict disclosed)
+- **Issues created**: 2 (#126, #128)
+- **Issues closed**: 2 (#126, #128) by their merges
+- **Tests added**: 11 (A11Y-5: 2 pytest + 1 Playwright spec; COMP-5: 8 pytest). Full suite 243 green at segment end
+- **Board state**: **1 open issue** (#99, deferred). No open PRs
+- **Memories written this segment**: none new (the relevant lesson, `ruff-format-check-not-in-prepush`, was written in the 2026-06-03 segment and applied here)
+
+## 8. Next Up
+
+In priority order:
+
+1. **Comprehension Phase 3 — persist self-marks** (got-it/not-yet), optionally feeding the 100k-line reading metric. The remaining, more speculative Phase 3 item — NOT a stated PRD requirement, with open product questions (data model, privacy, metric semantics). Start with a short design pass / DoR ticket before building.
+2. **A "disable comprehension" default preference** (vs. per-passage) — minor follow-on if readers want it off globally; not yet requested.
+3. **#99 — per-PR Supabase DATABASE_URL injection** — still the only tracked open item. Deferred until `SUPABASE_ACCESS_TOKEN` + `SUPABASE_DB_PASSWORD` are provisioned AND real users exist on production; escalate to P1 when users land.
+
+## Memory Validation
+
+This fork uses **file-based memory** (`~/.claude/projects/-workspaces-cubrox/memory/`),
+not the `CompletedTicket-N` Memory-MCP entity scheme. Queried the Memory
+MCP this session (`search_nodes`) — the graph is **empty**, so no
+`CompletedTicket` entities exist for #126 or #128.
+
+→ Memory validation: 0/2 delivered tickets have `CompletedTicket` MCP
+entities — expected for this fork (file-based memory), not a gap.
+
+## Memory Consolidation
+
+No new file-memories written this segment. The existing `board-lags-codebase`,
+`dod-can-encode-false-assumptions`, and `ruff-format-check-not-in-prepush`
+all stayed relevant (the last one actively prevented wasted CI cycles here).
+
+→ No new entities proposed — the segment's insights (cache-seeding to make
+an LLM panel CI-renderable; model-field-plus-migration for additive columns)
+are captured in this journal. The cache-seeding technique is a candidate
+`PatternDiscovered` if the MCP scheme is ever adopted in this fork.


### PR DESCRIPTION
## Context

Session journal for 2026-06-04 — continuation of the multi-day feature-delivery session.

## Summary

Worked the "Next Up" list from the 2026-06-03 journal:
- **#127 (A11Y-5 / #126)** — the live comprehension questions panel is now axe-scanned in CI (seed the cache → panel becomes a cache hit → real answer UI rendered without an API key).
- **#129 (COMP-5 / #128)** — per-passage comprehension disable toggle, fulfilling the PRD's Risk #2 mitigation.

Captures delivered tickets, challenges (no local Docker for the seed/migration paths → proven via pytest + green CI a11y job; the `ruff format` lesson preventing wasted CI cycles), insights (cache-seeding to make an LLM panel CI-renderable; model-field-plus-migration for additive columns), metrics, and next-up. Board holds at **1 open issue** (#99, deferred).

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)