### PR TITLE
ci(ops): warm production instance + alert on synthetic-monitor failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,12 +117,19 @@ jobs:
           # provisioner) that gcloud pinned 100% to. Symptom of getting
           # this wrong: green CI, service URL serves "Hello from Cloud
           # Run!" forever. See #61 / #76.
+          #
+          # --min-instances=1 (OPS-1 #131): keep ONE warm instance in
+          # production so an idle service doesn't cold-start on the first
+          # request. Cold starts were timing out the auth callback (the
+          # 2026-06-05 synthetic-monitor failure) and blow the <100ms
+          # latency NFR. The trade-off is ~one always-on instance's cost;
+          # acceptable for launch reliability. Previews stay at 0.
           flags: |
             --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }}
             --port=8080
             --memory=512Mi
             --cpu=1
-            --min-instances=0
+            --min-instances=1
             --max-instances=10
             --allow-unauthenticated
           # DATABASE_URL is set as a plain env var (not a Secret Manager

--- a/.github/workflows/synthetic-monitor.yml
+++ b/.github/workflows/synthetic-monitor.yml
@@ -30,6 +30,8 @@ on:
 permissions:
   contents: read
   id-token: write
+  # OPS-1 (#131): open/update an alert issue when the probe fails.
+  issues: write
 
 jobs:
   monitor:
@@ -138,3 +140,65 @@ jobs:
       - name: Run synthetic auth monitor
         if: steps.check_secrets.outputs.skip != 'true'
         run: uv run python scripts/smoke_auth.py
+
+      # OPS-1 (#131): on failure, open an alert issue — or comment on the
+      # existing open one — so a real production auth outage is visible
+      # instead of just a red ✗ nobody watches. Deduped because this runs
+      # hourly: a sustained outage must not file a new issue every run.
+      - name: Open or update alert issue on failure
+        if: failure() && steps.check_secrets.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- synthetic-auth-monitor-alert -->';
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const stamp = new Date().toISOString();
+
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'incident,synthetic-monitor',
+            });
+            const existing = open.data.find((i) => i.body && i.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Probe failed again — ${runUrl} (${stamp})`,
+              });
+              console.log(`Commented on existing alert issue #${existing.number}`);
+              return;
+            }
+
+            const body = [
+              marker,
+              '## Synthetic auth monitor failed',
+              '',
+              'The scheduled production sign-in probe failed. It drives the live',
+              'Cloud Run deploy through magic-link callback → authed page → reload',
+              '→ logout (`scripts/smoke_auth.py`).',
+              '',
+              `- **Run:** ${runUrl}`,
+              `- **First failed:** ${stamp}`,
+              '',
+              'A failure means production auth may be degraded. A single failure',
+              'can also be a transient cold-start timeout — check the run log',
+              '(`--min-instances=1` should have eliminated those; recurring',
+              'failures are a real signal).',
+              '',
+              '_Auto-filed by `synthetic-monitor.yml`. Subsequent failures comment',
+              'here rather than opening duplicates. Close this once the probe is',
+              'green again._',
+            ].join('\n');
+
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[ALERT] Synthetic auth monitor failed - ${stamp.split('T')[0]}`,
+              labels: ['incident', 'synthetic-monitor'],
+              body,
+            });
+            console.log(`Created alert issue #${issue.data.number}`);


### PR DESCRIPTION
## Context

Refs #131 (OPS-1). Two production-reliability fixes surfaced by the 2026-06-05 M1 launch-readiness assessment. The product is feature-complete and live; these harden the first-user auth experience and outage detection.

## 1. Warm production instance (`deploy.yml`)

`--min-instances=0` → `--min-instances=1`. The service scaled to zero and cold-started, and the **2026-06-05 15:23 synthetic-monitor failure was a ~30s read timeout on `/auth/callback`** caused by a cold start. A warm instance eliminates cold-start auth timeouts (and the <100ms-NFR miss) for the first user after idle. Previews stay at `0` (cost).

## 2. Alert on monitor failure (`synthetic-monitor.yml`)

Today, a probe failure is just a red ✗ in Actions — nobody is notified. Now it opens an `[ALERT]` issue (mirroring the repo's existing `verify-agent-restrictions` pattern), **deduped**: because the monitor runs hourly, a sustained outage comments on the one open alert issue instead of filing a new one each run. Adds `issues: write`.

## Verification

- Both workflow files parse (YAML valid); `actions/github-script@v7` is already used in the repo (`preview-deploy.yml`, `verify-agent-restrictions.yml`); **actionlint runs in CI** as the final gate.
- No app/test changes — workflow-only.
- The `--min-instances=1` change takes effect on the next production deploy (this merge), so the next synthetic-monitor run should be warm.

## Assessment context (not in this PR)

The readiness assessment also flagged operator/business actions out of scope here: verify production magic-link **email delivery** to a real address, and **schedule the human WCAG audit** (a stated M1 success criterion). Sentry stays deferred per ADR-004. Happy to write an M1 launch-checklist doc as a follow-up.

Refs #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)