### PR TITLE
docs(journal): log 2026-06-05 launch-readiness session

### DIFF
--- a/reports/session-journals/2026-06-05.md
+++ b/reports/session-journals/2026-06-05.md
@@ -1,0 +1,111 @@
+# Session Journal — 2026-06-05
+
+*(Continuation of the multi-day session — prior segments:
+`2026-06-02.md` board reconciliation, `2026-06-03.md` + `2026-06-04.md`
+comprehension feature delivery & hardening.)*
+
+## 1. Session Summary
+
+Pivoted from feature-building to **launch readiness**, since the P0 build is
+complete. An M1 readiness assessment surfaced a **live production incident**
+— the synthetic auth monitor had just failed on a cold-start timeout — which
+was diagnosed and fixed (a warm production instance), alongside wiring real
+alerting onto that monitor. Then wrote the go-live runbook and reconciled the
+roadmap doc to reflect shipped reality. Net: the M1 picture (board, code, ops,
+docs) is now consistent and accurate, and the top production-reliability risk
+is closed. Board holds at 1 open issue (#99, deferred).
+
+## 2. Tickets Delivered
+
+| Ticket | PR | What changed | Files touched | Tests |
+|---|---|---|---|---|
+| #131 OPS-1: harden production auth reliability | #132 | Production Cloud Run `--min-instances 0 → 1` (warm instance — kills cold-start auth timeouts); synthetic monitor opens a **deduped** `[ALERT]` issue on failure | `.github/workflows/deploy.yml`, `.github/workflows/synthetic-monitor.yml` | none (workflow-only; verified via actionlint + live prod probe post-deploy) |
+| #133 OPS-2: M1 launch checklist / go-live runbook | #134 | `docs/LAUNCH-CHECKLIST.md` — M1 criteria + status, pre-launch gates, first-user onboarding, GO/NO-GO sign-off, incident/rollback runbook; linked from CLAUDE.md | `docs/LAUNCH-CHECKLIST.md` (new), `CLAUDE.md` | n/a (docs) |
+| (quick-fix) Roadmap P0 status reconciliation | #135 | Roadmap Phase 1 features Backlog → Shipped; M1 criteria ticked/annotated honestly; status note added | `docs/PRODUCT-ROADMAP.md` | n/a (docs) |
+
+## 3. Tickets In Review
+
+None — all PRs merged.
+
+## 4. Challenges and Mitigations
+
+| Challenge | Root cause | Mitigation | Prevention |
+|---|---|---|---|
+| **Live production incident found mid-assessment**: synthetic auth monitor failed 2026-06-05 15:23 | Production ran `--min-instances=0`; an idle service cold-started and the `/auth/callback` Supabase round-trip exceeded the probe's 30s read timeout | Probed live prod directly (`/api/health` 83ms, `/api/health/db` 161ms — healthy now, so a transient cold start, not an outage); shipped `--min-instances=1`, deployed, re-probed healthy | A readiness assessment should *probe live state*, not trust the monitor's last-known result. Cold-start + min-instances=0 is a real first-user auth risk |
+| Sub-agent's readiness report listed stale "blockers" (#80/#81/#97 open, "4 a11y tests skipped") | The Explore agent read May's journal "Next Up" as current state — the same board-/journal-lags-reality trap, applied to an AI report | Fact-checked every disputed claim against ground truth: `gh issue view` (all CLOSED), grep for skipped tests (none) — corrected before synthesizing | Treat sub-agent findings as leads, not facts; verify ticket/test claims against the live repo. `[[board-lags-codebase]]` applies to generated reports too |
+| Roadmap doc described Phase 1 as unstarted (all P0 = "Backlog") | Docs lag reality on this project, repeatedly (board, then roadmap) | Reconciled to Shipped + annotated M1 criteria honestly | After major delivery, sweep the *narrative* docs (roadmap, status) the same way we reconcile the board |
+
+## 5. Insights and Learnings
+
+### Technical insights
+
+- **`--min-instances=0` is a launch-readiness trap for an auth-gated app.** Scale-to-zero means the first request after idle eats a cold start (container init + the Supabase `get_user` round-trip on the callback), which timed out the synthetic monitor and would hit a real first user. `--min-instances=1` (production only; previews stay 0) trades ~one always-on instance's cost for reliable sign-in. Direct evidence: the 15:23 timeout vs. the sub-100ms warm probes after the fix deployed.
+- **Deduped alerting for a *scheduled* monitor.** A naive "open an issue on failure" step run hourly would file 24 issues/day during an outage. The pattern: search open issues by label + a body marker; comment on the existing one if present, else create. Open-on-failure, (suggested follow-up) close-on-recovery.
+- **A readiness assessment is a live-probe exercise, not a paperwork exercise.** The most valuable output today wasn't the checklist — it was curling production and catching a real cold-start incident the monitor had flagged 90 minutes earlier.
+
+### Process insights
+
+- **Verify AI-generated assessments against ground truth.** A thorough Explore report confidently listed closed tickets as open blockers because it trusted a stale journal section. The `board-lags-codebase` lesson generalizes: any narrative source (journal, roadmap, sub-agent) can lag the code — check `gh`/grep before acting.
+- **Know when the repo work is done.** After OPS-1/2 + the roadmap, the honest read is that remaining M1 work is operator/business (verify prod email, schedule human WCAG audit), not code. Stating that plainly is more useful than inventing more code to write.
+
+### Domain insights
+
+- The product is **feature-complete and live**; M1 is gated on operator pre-flight, not engineering. The launch checklist makes that explicit and ownable.
+- Two genuine non-code gates remain for M1: (1) the **human WCAG audit** (automated axe ≠ the human audit the roadmap requires), and (2) **real magic-link email delivery** — which the synthetic monitor does NOT exercise (it uses a password-grant shortcut), so it must be hand-verified before onboarding.
+
+## 6. Tickets Created
+
+| Ticket | Why |
+|---|---|
+| #131 — OPS-1: harden production auth reliability | Fix the cold-start auth timeout found in the assessment + add monitor alerting |
+| #133 — OPS-2: M1 launch checklist | Write the missing go-live runbook (assessment finding) |
+
+*(The roadmap reconciliation, #135, was a docs quick-fix — no ticket.)*
+
+## 7. Metrics
+
+- **PRs created**: 3 (#132, #134, #135)
+- **PRs merged**: 3
+- **PRs reviewed**: 2 (#132, #134 — solo-mode disclosed; #135 was a docs quick-fix)
+- **Issues created**: 2 (#131, #133)
+- **Issues closed**: 2 (#131, #133)
+- **Tests added**: 0 — this segment was ops + docs; no app-code change (OPS-1 was workflow-only, verified via actionlint + live prod probe)
+- **Production change**: `--min-instances 0 → 1` deployed and verified (post-deploy probes healthy)
+- **Board state**: **1 open issue** (#99, deferred). No open PRs
+- **Memories written**: none new (existing lessons stayed relevant)
+
+## 8. Next Up
+
+In priority order:
+
+1. **Operator / business actions (NOT code) — the real M1 gates**:
+   - Verify production **magic-link email delivery** to a real inbox (the synthetic monitor skips this).
+   - **Schedule the human WCAG audit** (a stated M1 success criterion).
+   - Both are tracked in `docs/LAUNCH-CHECKLIST.md` §2.B / §2.D.
+2. **Optional repo follow-ons**:
+   - Auto-close the `[ALERT]` synthetic-monitor issue on the next *successful* probe (completes the OPS-1 loop; flagged as a non-blocking suggestion on #132).
+   - Resolve the production URL dynamically (`gcloud run services describe`) instead of the hardcoded hostname in the runbook/monitor.
+   - Comprehension Phase 3 — persist self-marks (speculative; roadmap says Phase 2 is feedback-driven, so defer until real users exist).
+3. **#99** — per-PR Supabase DATABASE_URL injection; deferred until `SUPABASE_ACCESS_TOKEN` + `SUPABASE_DB_PASSWORD` are provisioned AND real users exist; escalate to P1 at first prod users.
+
+## Memory Validation
+
+This fork uses **file-based memory** (`~/.claude/projects/-workspaces-cubrox/memory/`),
+not the `CompletedTicket-N` Memory-MCP entity scheme. The graph (when the
+MCP is connected) has been empty all session.
+
+→ Memory validation: 0/2 delivered tickets have `CompletedTicket` MCP
+entities — expected for this fork (file-based memory), not a gap.
+
+## Memory Consolidation
+
+No new file-memories written this segment. The existing `board-lags-codebase`,
+`dod-can-encode-false-assumptions`, and `ruff-format-check-not-in-prepush`
+all stayed relevant — notably `board-lags-codebase`, which generalized to
+"verify AI-generated assessments against ground truth" when a sub-agent's
+report cited closed tickets as open blockers.
+
+→ No new entities proposed — the segment's insights (min-instances=0 as an
+auth-reliability trap; deduped scheduled-monitor alerting; assess-by-live-probe)
+are captured in this journal. The "verify sub-agent claims vs. ground truth"
+note is a candidate addition to `board-lags-codebase` if that pattern recurs.


### PR DESCRIPTION
## Context

Session journal for 2026-06-05 — the launch-readiness segment.

## Summary

Pivoted from feature work to M1 launch readiness:
- **M1 readiness assessment** — found the product feature-complete and live, and caught a **live production incident** (synthetic auth monitor failed on a cold-start timeout).
- **OPS-1 (#132)** — warm production instance (`--min-instances=1`, deployed + verified) + deduped `[ALERT]` issue on monitor failure.
- **OPS-2 (#134)** — the M1 go-live runbook (`docs/LAUNCH-CHECKLIST.md`).
- **#135** — reconciled the roadmap doc (P0 features Backlog → Shipped).

Captures delivered tickets, challenges (the live cold-start incident; a sub-agent report citing closed tickets as open blockers — the board-lags trap applied to AI output), insights (min-instances=0 as an auth-reliability trap; deduped scheduled-monitor alerting; assess-by-live-probe), metrics, and next-up. Board holds at **1 open issue** (#99, deferred); remaining M1 work is operator/business (verify prod email, schedule human WCAG audit).

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)