### PR TITLE
fix(comprehension): tolerate fenced/prose LLM output + degrade API errors

### DIFF
--- a/app/services/comprehension/generator.py
+++ b/app/services/comprehension/generator.py
@@ -20,16 +20,14 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from typing import TYPE_CHECKING, Annotated, Any, Literal
+from typing import Annotated, Any, Literal
 
+import anthropic
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 from sqlmodel import Session
 
 from app.services.comprehension import cache
 from app.services.comprehension.prompts import PROMPT_VERSION, SYSTEM_PROMPT
-
-if TYPE_CHECKING:
-    import anthropic
 
 logger = logging.getLogger(__name__)
 
@@ -152,18 +150,30 @@ def generate_questions(
         },
     )
 
-    response = client.messages.create(
-        model=model_id,
-        max_tokens=DEFAULT_MAX_TOKENS,
-        system=[
-            {
-                "type": "text",
-                "text": SYSTEM_PROMPT,
-                "cache_control": {"type": "ephemeral"},
-            }
-        ],
-        messages=[{"role": "user", "content": passage_text}],
-    )
+    try:
+        response = client.messages.create(
+            model=model_id,
+            max_tokens=DEFAULT_MAX_TOKENS,
+            system=[
+                {
+                    "type": "text",
+                    "text": SYSTEM_PROMPT,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[{"role": "user", "content": passage_text}],
+        )
+    except anthropic.AnthropicError as exc:
+        # Auth failure (missing/invalid key), bad model id, rate limit,
+        # overload, network — all degrade to the "unavailable" fragment
+        # rather than 500ing the reading view. Comprehension is a feature,
+        # not a hard dependency. Log the error TYPE (never the message —
+        # it can echo request content) so prod failures are diagnosable.
+        logger.warning(
+            "comprehension Anthropic call failed",
+            extra={"text_hash": text_hash.hex(), "error_type": type(exc).__name__},
+        )
+        raise GeneratorError("Anthropic API call failed") from exc
 
     questions = _parse_response(response, text_hash=text_hash)
 
@@ -180,6 +190,34 @@ def generate_questions(
     return questions
 
 
+def _extract_json_array(text: str) -> str:
+    """Pull the JSON array out of a model response that may be wrapped.
+
+    The prompt asks for a bare JSON array with no markdown or preamble,
+    but real models (Haiku especially) frequently fence the output in
+    ```json … ``` or add a sentence before/after. A bare `json.loads`
+    rejects those, which surfaced in prod as "comprehension unavailable"
+    on the first real (non-mocked, non-cached) generation. This strips a
+    surrounding code fence and, failing that, slices to the outermost
+    `[ … ]` so well-formed JSON wrapped in chatter still parses.
+    """
+    s = text.strip()
+
+    # Strip a leading ``` / ```json fence and its trailing ``` partner.
+    if s.startswith("```"):
+        s = s.split("\n", 1)[1] if "\n" in s else s[3:]
+        if s.rstrip().endswith("```"):
+            s = s.rstrip()[:-3]
+        s = s.strip()
+
+    # If prose still surrounds the array, slice to the outermost brackets.
+    start, end = s.find("["), s.rfind("]")
+    if start != -1 and end > start:
+        s = s[start : end + 1]
+
+    return s
+
+
 def _parse_response(response: Any, *, text_hash: bytes) -> list[dict[str, Any]]:
     """Extract + validate the JSON array from the LLM response.
 
@@ -193,7 +231,7 @@ def _parse_response(response: Any, *, text_hash: bytes) -> list[dict[str, Any]]:
         raise GeneratorError("Anthropic response had no text content block") from exc
 
     try:
-        parsed = json.loads(raw_text)
+        parsed = json.loads(_extract_json_array(raw_text))
     except json.JSONDecodeError as exc:
         logger.warning(
             "comprehension response was not valid JSON",

--- a/tests/test_comprehension_generator.py
+++ b/tests/test_comprehension_generator.py
@@ -21,6 +21,7 @@ import logging
 from typing import Any
 from unittest.mock import MagicMock
 
+import anthropic
 import pytest
 from sqlmodel import Session
 
@@ -414,6 +415,78 @@ def test_empty_content_blocks_raises_generator_error(session: Session) -> None:
             model_id=TEST_MODEL_ID,
             session=session,
         )
+
+
+# ---------------------------------------------------------------------------
+# Real-world model output — tolerant parsing + graceful API-failure
+# (regression for the prod "comprehension unavailable" on first real call)
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_fenced_json_response_parses(session: Session) -> None:
+    """Haiku frequently wraps the array in ```json … ``` despite the
+    'NO markdown' instruction. The parser must tolerate it."""
+    client = _make_mock_client(response_text=f"```json\n{VALID_LLM_OUTPUT}\n```")
+
+    result = generate_questions(
+        passage_text=TEST_PASSAGE,
+        question_type="recall",
+        client=client,
+        model_id=TEST_MODEL_ID,
+        session=session,
+    )
+    assert len(result) == 3
+    assert result[0]["text"] == "What is the first counsel?"
+
+
+def test_prose_wrapped_json_response_parses(session: Session) -> None:
+    """Preamble/trailing chatter around a well-formed array must still
+    parse — slice to the outermost brackets."""
+    wrapped = (
+        f"Sure! Here are three questions:\n{VALID_LLM_OUTPUT}\nLet me know if you'd like more."
+    )
+    client = _make_mock_client(response_text=wrapped)
+
+    result = generate_questions(
+        passage_text=TEST_PASSAGE,
+        question_type="recall",
+        client=client,
+        model_id=TEST_MODEL_ID,
+        session=session,
+    )
+    assert len(result) == 3
+
+
+def test_anthropic_api_error_degrades_to_generator_error(session: Session) -> None:
+    """An API-layer failure (bad key, bad model id, rate limit, overload,
+    network) must surface as GeneratorError so the route shows the
+    'unavailable' fragment instead of 500ing — comprehension is a feature,
+    not a hard dependency. The bug: the call was previously unwrapped, so
+    these propagated as a raw 500."""
+    client = MagicMock()
+    client.messages.create.side_effect = anthropic.AnthropicError("simulated API failure")
+
+    with pytest.raises(GeneratorError):
+        generate_questions(
+            passage_text=TEST_PASSAGE,
+            question_type="recall",
+            client=client,
+            model_id=TEST_MODEL_ID,
+            session=session,
+        )
+
+    # And nothing was cached (no poisoning on API failure).
+    text_hash = hashlib.sha256(TEST_PASSAGE.encode("utf-8")).digest()
+    assert (
+        cache.get_cached(
+            passage_hash=text_hash,
+            question_type="recall",
+            model_id=TEST_MODEL_ID,
+            prompt_version=PROMPT_VERSION,
+            session=session,
+        )
+        is None
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

Closes #137. Comprehension questions render **"temporarily unavailable"** in production. The real Anthropic path had **never been exercised** — unit tests inject clean JSON via a mock, and the a11y job uses cache *hits* — so the first real (non-mocked, non-cached) generation in prod hit two latent defects.

## Root cause

1. **Strict parser.** `_parse_response` did a bare `json.loads(raw_text)`. Real Haiku output frequently wraps the array in ` ```json … ``` ` fences or adds preamble/trailing prose despite the "NO markdown" instruction → `json.loads` fails → `GeneratorError` → the "unavailable" fragment.
2. **Unwrapped API call.** `client.messages.create` wasn't wrapped, so a genuine API failure (missing/invalid key, bad model id, rate limit, overload, network) would propagate as a raw **500** — violating the route's "comprehension never 500s, it's a feature not a hard dependency" contract.

## Fix

- `_extract_json_array()` strips a surrounding code fence and slices to the outermost `[ … ]`, so fenced / prose-wrapped but well-formed JSON parses.
- Wrapped the Anthropic call in `except anthropic.AnthropicError` → `GeneratorError` (graceful "unavailable") + a log line recording the error **type** (never the message — it can echo passage content).

## Tests

- Markdown-fenced and prose-wrapped responses now parse (`test_markdown_fenced_json_response_parses`, `test_prose_wrapped_json_response_parses`).
- An `anthropic.AnthropicError` degrades to `GeneratorError` (route shows "unavailable", not 500) and doesn't poison the cache (`test_anthropic_api_error_degrades_to_generator_error`).
- Full suite 246 green; lint + format + mypy clean.

## If "unavailable" persists after deploy

This doesn't change the prompt. If the real failure is the model omitting the required `answer` field (schema mismatch, not fencing), the existing `comprehension response did not match schema` log line will now surface it clearly and we iterate. The wrapped call + logging make the next failure self-diagnosing.

## Related (separate follow-up)

Today's earlier production paste-500 was prod **schema drift** (the `comprehension_enabled` migration never reached prod; fixed manually via SQL). The systemic gap — no migration step in `deploy.yml` — is worth its own ticket.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)