### PR TITLE
ci(ops): one-time production migration-ledger baseline workflow (OPS-3, 1/2)

### DIFF
--- a/.github/workflows/baseline-migrations.yml
+++ b/.github/workflows/baseline-migrations.yml
@@ -1,0 +1,92 @@
+name: Baseline Production Migrations
+
+# ONE-TIME, manually triggered (workflow_dispatch).
+#
+# Production was never managed by the Supabase CLI — it has no
+# `supabase_migrations.schema_migrations` ledger (verified for OPS-3 #139),
+# so its schema has been maintained by hand (which is how BUG-4 and the
+# 2026-06-08 paste-500 happened). This registers the existing
+# supabase/migrations/*.sql as ALREADY-APPLIED, WITHOUT running them
+# (`migration repair --status applied` records the version; it does not
+# execute the SQL). After this runs once and "Verify ledger" shows every
+# migration as Applied on the remote, the `supabase db push` step that
+# deploy.yml adds (PR 2) is safe — push will see them as applied and only
+# run FUTURE migrations.
+#
+# Safe to re-run: `migration repair` is idempotent.
+#
+# Operator note: PRODUCTION_DATABASE_URL must be a connection the Supabase
+# CLI can run DDL/admin over (the direct or session-pooler connection, not
+# the transaction pooler). If "Mark existing migrations as applied" fails
+# with a connection/pooler error, provide a direct-connection URL (see the
+# README that PR 2 adds) and re-run.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "baseline" to confirm registering prod migrations as applied'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  baseline:
+    name: Baseline production migration ledger
+    runs-on: ubuntu-latest
+    # Don't run on the upstream template repo — only on configured forks.
+    if: github.repository != 'vibeacademy/agile-flow-gcp'
+    steps:
+      - name: Guard on confirmation
+        if: inputs.confirm != 'baseline'
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          echo "Confirmation was '${CONFIRM}', expected 'baseline' — aborting."
+          exit 1
+
+      - name: Check for DB secret
+        run: |
+          if [ -z "${{ secrets.PRODUCTION_DATABASE_URL }}" ]; then
+            echo "PRODUCTION_DATABASE_URL is not set — cannot baseline the ledger."
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Supabase CLI (pinned)
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.105.0
+
+      - name: Mark existing migrations as applied
+        env:
+          DB_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          # The URL carries the DB password — never let it surface in logs.
+          echo "::add-mask::$DB_URL"
+
+          # Repair (record as applied) every local migration version. The
+          # version is the leading timestamp of each filename. `repair`
+          # creates the supabase_migrations ledger if it doesn't exist and
+          # does NOT execute the migration SQL.
+          shopt -s nullglob
+          for f in supabase/migrations/*.sql; do
+            base="$(basename "$f")"
+            version="${base%%_*}"
+            echo "→ marking $version ($base) as applied"
+            supabase migration repair --status applied "$version" --db-url "$DB_URL"
+          done
+
+      - name: Verify ledger
+        env:
+          DB_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          echo "::add-mask::$DB_URL"
+          echo "Remote migration ledger after baseline (every local migration should show Applied):"
+          supabase migration list --db-url "$DB_URL"


### PR DESCRIPTION
## Context

OPS-3 (#139), **PR 1 of 2**. Closes the gap that caused BUG-4 and the 2026-06-08 paste-500: nothing applies migrations to production.

**Why a baseline is needed first:** diagnosis showed production has **no `supabase_migrations` ledger** — it was never CLI-managed (its schema has been maintained by hand). So `supabase db push` can't just be added to the deploy: with no recorded history it would try to re-run `initial_schema`'s `CREATE TABLE` and fail. The existing migrations must first be registered as **already-applied**.

## What this PR adds

A **dormant, manually-triggered** (`workflow_dispatch`) workflow that:
- Runs `supabase migration repair --status applied <version>` for each `supabase/migrations/*.sql` — this **records** the version in the ledger **without executing** the SQL (creates the ledger if absent).
- Runs `supabase migration list` to verify every migration shows Applied.
- Pinned CLI `2.105.0` (CI currently uses `latest` — the anti-pattern the ticket flags); DB URL masked; guarded by a typed `baseline` confirmation input; idempotent (safe to re-run).

**Merging this changes nothing at deploy time** — it only runs when you dispatch it.

## How to use (after merge)

1. Actions → **Baseline Production Migrations** → Run workflow → type `baseline` → Run.
2. Check the **Verify ledger** step output: every migration (`20260524015233` … `20260604000000`) should show **Applied** on the remote.
3. Once confirmed, **PR 2** adds `supabase db push` to `deploy.yml` so future migrations auto-apply.

### If the baseline step fails on connection/pooler
`PRODUCTION_DATABASE_URL` must be a connection the CLI can run admin/DDL over (direct or session pooler, not the transaction pooler). If it errors there, we provide a direct-connection URL and re-run — that's exactly why this is staged separately from the deploy path.

Refs #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)