### PR TITLE
fix(ci): baseline migrations over the session pooler (IPv4)

### DIFF
--- a/.github/workflows/baseline-migrations.yml
+++ b/.github/workflows/baseline-migrations.yml
@@ -15,11 +15,16 @@ name: Baseline Production Migrations
 #
 # Safe to re-run: `migration repair` is idempotent.
 #
-# Operator note: PRODUCTION_DATABASE_URL must be a connection the Supabase
-# CLI can run DDL/admin over (the direct or session-pooler connection, not
-# the transaction pooler). If "Mark existing migrations as applied" fails
-# with a connection/pooler error, provide a direct-connection URL (see the
-# README that PR 2 adds) and re-run.
+# Operator note — the SUPABASE_DB_URL secret: this must be the SESSION
+# POOLER connection string, NOT the app's PRODUCTION_DATABASE_URL. The app
+# uses Supabase's direct host (db.<ref>.supabase.co), which resolves to
+# IPv6 only — Cloud Run can reach it but GitHub Actions runners are
+# IPv4-only, so the CLI gets "network is unreachable". The session pooler
+# (host aws-0-<region>.pooler.supabase.com, port 5432, user
+# postgres.<ref>) is IPv4 AND supports the session-level DDL these commands
+# need. Get it from the Supabase dashboard → Project Settings → Database →
+# Connection string → "Session pooler" (NOT "Transaction pooler"), and set
+# it as the SUPABASE_DB_URL GitHub Actions secret. PR 2's db push reuses it.
 
 on:
   workflow_dispatch:
@@ -49,8 +54,12 @@ jobs:
 
       - name: Check for DB secret
         run: |
-          if [ -z "${{ secrets.PRODUCTION_DATABASE_URL }}" ]; then
-            echo "PRODUCTION_DATABASE_URL is not set — cannot baseline the ledger."
+          if [ -z "${{ secrets.SUPABASE_DB_URL }}" ]; then
+            echo "SUPABASE_DB_URL is not set — cannot baseline the ledger."
+            echo "Set it to the SESSION POOLER connection string (IPv4): Supabase"
+            echo "dashboard → Project Settings → Database → Connection string →"
+            echo "Session pooler. The app's PRODUCTION_DATABASE_URL is the direct"
+            echo "(IPv6) host and is unreachable from GitHub Actions runners."
             exit 1
           fi
 
@@ -64,7 +73,7 @@ jobs:
 
       - name: Mark existing migrations as applied
         env:
-          DB_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+          DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
           set -euo pipefail
           # The URL carries the DB password — never let it surface in logs.
@@ -84,7 +93,7 @@ jobs:
 
       - name: Verify ledger
         env:
-          DB_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+          DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
           set -euo pipefail
           echo "::add-mask::$DB_URL"


### PR DESCRIPTION
## Context

The baseline workflow (#140) failed on first run:

```
failed to connect to host=db.gnswmcgaztcxslirulwm.supabase.co …
dial tcp [2600:1f18:…]:6543: connect: network is unreachable
```

`PRODUCTION_DATABASE_URL` uses Supabase's **direct** host (`db.<ref>.supabase.co`), which resolves to **IPv6 only**. Cloud Run can reach it (so the app works), but **GitHub Actions runners are IPv4-only** → "network is unreachable".

## Fix

Run the migration commands over the **session pooler** — an IPv4 host (`aws-0-<region>.pooler.supabase.com`, port 5432) that also supports the session-level DDL `migration repair` / `db push` need. The workflow now reads a dedicated **`SUPABASE_DB_URL`** secret instead of the app's runtime URL. Documented inline and in the missing-secret error. PR 2's `db push` will reuse the same secret.

## Operator action needed before re-running

1. Supabase dashboard → **Project Settings → Database → Connection string → "Session pooler"** (NOT "Transaction pooler", NOT "Direct connection").
2. Copy that string (it looks like `postgresql://postgres.gnswmcgaztcxslirulwm:[PASSWORD]@aws-0-<region>.pooler.supabase.com:5432/postgres`) and fill in the DB password.
3. Add it as a GitHub Actions secret named **`SUPABASE_DB_URL`** (repo → Settings → Secrets and variables → Actions → New repository secret).
4. Re-run **Baseline Production Migrations** (type `baseline`).

Refs #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)