### PR TITLE
ci(ops): apply DB migrations to production on deploy (OPS-3, 2/2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,10 +78,44 @@ jobs:
         if: steps.check_secrets.outputs.skip != 'true'
         run: gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev --quiet
 
-      # Schema migrations now run via the Supabase GitHub App
-      # auto-branching integration (per SUPA-1 / #80). No
-      # workflow-driven migration step needed; the alembic chain was
-      # deleted in SUPA-2b / #87.
+      # ── Apply DB migrations to production (OPS-3 #139) ────────────────
+      #
+      # Until now nothing applied supabase/migrations/*.sql to prod — it was
+      # hand-maintained, which is how BUG-4 and the paste-500 (a column that
+      # never landed) happened. Production's migration ledger was baselined
+      # once via baseline-migrations.yml, so `supabase db push` now sees the
+      # existing migrations as applied and runs only NEW ones.
+      #
+      # Run BEFORE build/deploy so a failed migration fails the deploy
+      # instead of shipping code against an old schema. Over the SESSION
+      # POOLER (IPv4) — the direct host is IPv6-only and unreachable from
+      # Actions runners (see SUPABASE_DB_URL in baseline-migrations.yml).
+      - name: Check for migration DB secret
+        if: steps.check_secrets.outputs.skip != 'true'
+        id: check_migrate
+        run: |
+          if [ -z "${{ secrets.SUPABASE_DB_URL }}" ]; then
+            echo "migrate=false" >> "$GITHUB_OUTPUT"
+            echo "SUPABASE_DB_URL not set — skipping migrations. Set the session-pooler URL to enable auto-apply."
+          else
+            echo "migrate=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Supabase CLI (pinned)
+        if: steps.check_migrate.outputs.migrate == 'true'
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.105.0
+
+      - name: Apply database migrations
+        if: steps.check_migrate.outputs.migrate == 'true'
+        env:
+          DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          set -euo pipefail
+          # URL carries the DB password — keep it out of the logs.
+          echo "::add-mask::$DB_URL"
+          supabase db push --db-url "$DB_URL"
 
       - name: Build and push container
         if: steps.check_secrets.outputs.skip != 'true'


### PR DESCRIPTION
## Context

**Closes #139 (OPS-3), PR 2 of 2.** This is the fix that stops production schema drift — the root cause of BUG-4 and the 2026-06-08 paste-500 (a column that never reached prod).

PR 1 added the baseline workflow; you ran it and the ledger now shows all 4 migrations Applied on the remote. So `supabase db push` is now safe — it sees the existing migrations as applied and runs only **new** ones.

## What this adds to `deploy.yml`

A migration step that runs **before** build/deploy:
```
Configure Docker → [Check secret → Install CLI → Apply migrations] → Build → Deploy → Route traffic
```
- `supabase db push` over the **session pooler** (`SUPABASE_DB_URL`, IPv4 — the direct host is IPv6-only and unreachable from runners).
- **Fails the deploy before shipping** if a migration fails — so we never again serve new code against an old schema (the paste-500 failure mode).
- Gated on `SUPABASE_DB_URL` presence (forks without it skip migrations rather than break); pinned CLI `2.105.0`; URL masked.
- Removes the now-false "no workflow-driven migration step needed" comment.

## Effect

From now on, merging a migration to `main` applies it to production automatically on deploy. No more manual SQL, no more drift. On a deploy with no new migrations, `db push` is a fast no-op.

## Verify-after-merge

This merge itself triggers a deploy → the new step runs `db push` against prod. Since the ledger is current, it should report **no pending migrations** (no-op) and the deploy proceeds normally. Worth a glance at the deploy run's "Apply database migrations" step to confirm.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)