### PR TITLE
test(ops): add a DB write-path check (paste→read) to the synthetic monitor

### DIFF
--- a/scripts/smoke_auth.py
+++ b/scripts/smoke_auth.py
@@ -24,6 +24,12 @@ that hits the *real* deployed URL with a *real* Supabase session can.
    - `GET /passages/new` (cookie attached) → expect 200 + the authed page.
    - `GET /passages/new` again → still 200, proving the session persists across
      reloads.
+   - `POST /passages` (paste text) → expect a 303 to `/read/<id>`, then
+     `GET /read/<id>` → 200 with the pasted text rendered. This is the WRITE
+     path (OPS-4 #143): it INSERTs a row and reads it back, catching the
+     "green CI, broken prod" failures that auth-only probing misses (BUG-4,
+     the paste-500). The passage is owned by the throwaway user, so it is
+     removed by the same cleanup (FK `ON DELETE CASCADE`).
    - `GET /logout` → expect a 303 to `/` that clears the cookie.
    - `GET /passages/new` (cookie now gone) → expect a 303 back to `/`, proving
      the session is actually gone.
@@ -155,7 +161,7 @@ def sign_in(anon: Client, email: str, password: str) -> tuple[str, str]:
 
 
 def run_flow(base_url: str, access_token: str, refresh_token: str) -> None:
-    """Drive the live app through callback → authed page → reload → logout.
+    """Drive the live app through callback → authed page → reload → paste → read → logout.
 
     Raises SmokeFailure on the first deviation from the expected contract.
     """
@@ -197,6 +203,41 @@ def run_flow(base_url: str, access_token: str, refresh_token: str) -> None:
             raise SmokeFailure(
                 f"session did not persist across reload: {AUTHED_ENTRY_PATH} returned "
                 f"{reload_resp.status_code}, expected 200"
+            )
+
+        # Write path (OPS-4 #143). Both 2026-06 prod incidents — BUG-4 and the
+        # paste-500 (a migration column that never reached prod) — were "green
+        # CI, broken prod" precisely because nothing exercised a real DB write.
+        # Auth alone never touches the `passage` table; this does.
+        _step("POST /passages — paste a passage (write path), expect 303 to /read/<id>")
+        marker = "smokewrite" + uuid.uuid4().hex[:12]
+        passage_text = (
+            f"{marker} — synthetic write-path check from scripts/smoke_auth.py. "
+            "Created and removed with the throwaway user (passage.owner_id "
+            "cascades on user delete)."
+        )
+        paste = client.post(f"{base}/passages", data={"text": passage_text})
+        if paste.status_code != 303:
+            raise SmokeFailure(
+                f"POST /passages returned {paste.status_code}, expected 303 "
+                "(the BUG-4 / paste-500 class of failure — a broken DB write path)"
+            )
+        read_path = paste.headers.get("location", "")
+        if not read_path.startswith("/read/"):
+            raise SmokeFailure(f"POST /passages redirected to {read_path!r}, expected /read/<id>")
+
+        # A plain HTTP client doesn't run HTMX, so the reading view's lazy-loaded
+        # questions panel never fires — no comprehension LLM spend from this probe.
+        _step("GET /read/<id> — expect 200 with the pasted text rendered")
+        reading = client.get(f"{base}{read_path}")
+        if reading.status_code != 200:
+            raise SmokeFailure(
+                f"{read_path} returned {reading.status_code} while authed, expected 200"
+            )
+        if marker not in reading.text:
+            raise SmokeFailure(
+                f"{read_path} did not render the pasted marker {marker!r} — the reading "
+                "view did not show the new passage"
             )
 
         _step("GET /logout — expect 303 to / and a cleared session cookie")
@@ -268,7 +309,10 @@ def main() -> int:
             except Exception as exc:  # noqa: BLE001 — cleanup must never mask the real result
                 print(f"WARN: failed to delete throwaway user {user_id}: {exc}", flush=True)
 
-    print("PASS: magic-link session → authed page → reload → logout all verified", flush=True)
+    print(
+        "PASS: session → authed page → reload → paste → read → logout all verified",
+        flush=True,
+    )
     return 0
 
 


### PR DESCRIPTION
## Context

Closes #143 (OPS-4). The **detection** complement to OPS-3 (#139, which *prevents* migration drift). Both 2026-06 production incidents — BUG-4 and the paste-500 — were **"green CI, broken prod"** because nothing exercised a real database **write**: the synthetic monitor only did auth (never touching the `passage` table), and CI runs against an ephemeral local DB.

## What this adds

Extends `scripts/smoke_auth.py`'s authed flow with a write path, between the reload and logout steps:

```
POST /passages (paste) → 303 to /read/<id> → GET /read/<id> → 200 with the pasted text rendered
```

It **INSERTs a row and reads it back**, so a broken write path (schema drift, a migration that didn't land) fails the monitor instead of going unnoticed.

## Why it's clean

- **Cleanup is free** — the passage is owned by the throwaway user, so the existing user-delete in `finally` removes it via FK `ON DELETE CASCADE`. No extra teardown, no leaked rows.
- **No comprehension LLM spend** — a plain `httpx` client doesn't run HTMX, so the reading view's lazy-loaded questions panel never fires (guardrail honored).
- **No workflow change** — `synthetic-monitor.yml` already runs this script hourly, and failures now open the deduped `[ALERT]` issue (OPS-1 #131). So this is automatically wired to run on schedule with alerting.

## Verification

- `ruff` (check + format) + `mypy` clean; full suite 246 green (the script isn't unit-tested — it drives a live deploy — so the real validation is the next scheduled monitor run against prod).
- The new steps reuse the existing harness (same session, same cleanup) rather than a parallel implementation.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)