### PR TITLE
feat(ingestion): auto-split large documents into navigable parts

### DIFF
--- a/app/api/passages.py
+++ b/app/api/passages.py
@@ -15,6 +15,7 @@ bytes — the cache is keyed on what the user reads, not how it arrived.
 """
 
 import hashlib
+import uuid
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
@@ -25,6 +26,7 @@ from app.db import get_session
 from app.integrations.supabase.auth import current_user
 from app.models.passage import Passage
 from app.services.ingestion.pdf import EmptyPdfTextError, PdfParseError, extract_text
+from app.services.ingestion.split import MAX_PARTS, split_into_parts
 from app.templates import templates
 
 router = APIRouter()
@@ -47,6 +49,56 @@ EMPTY_PDF_MESSAGE = (
 )
 
 
+def _persist_as_passages(
+    *,
+    session: Session,
+    owner_id: uuid.UUID,
+    text: str,
+    source_type: str,
+    source_filename: str | None,
+) -> Passage:
+    """Persist `text` as one passage, or — if it's over MAX_TEXT_LEN — as an
+    ordered set of linked parts (INGEST-3 #145). Returns the FIRST passage
+    (part 0), which the caller redirects to.
+
+    Text within the cap stays a standalone passage (document_id=None) exactly
+    as before. Over the cap, it's split into <= MAX_TEXT_LEN-render-safe parts
+    that share one document_id; the reading view links them with Prev/Next.
+    """
+    if len(text) <= MAX_TEXT_LEN:
+        parts = [text]
+    else:
+        parts = split_into_parts(text)
+
+    if len(parts) > MAX_PARTS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Document is too large to ingest, even split into parts (>{MAX_PARTS}).",
+        )
+
+    document_id = uuid.uuid4() if len(parts) > 1 else None
+    part_count = len(parts)
+    first: Passage | None = None
+    for index, part_text in enumerate(parts):
+        passage = Passage(
+            owner_id=owner_id,
+            text=part_text,
+            text_hash=hashlib.sha256(part_text.encode("utf-8")).digest(),
+            source_type=source_type,
+            source_filename=source_filename,
+            document_id=document_id,
+            part_index=index,
+            part_count=part_count,
+        )
+        session.add(passage)
+        if index == 0:
+            first = passage
+    session.commit()
+    assert first is not None  # parts is always non-empty
+    session.refresh(first)
+    return first
+
+
 @router.get("/passages/new", response_class=HTMLResponse)
 def new_passage_form(request: Request, user: CurrentUser) -> HTMLResponse:
     """Render the paste-text form."""
@@ -65,35 +117,25 @@ def create_passage(
 ) -> RedirectResponse:
     """Persist the pasted text and redirect to the reading view.
 
-    Validation rules (per ticket guardrails):
-      - 1 <= len(text) <= MAX_TEXT_LEN
-      - text_hash = SHA-256 of the EXACT submitted bytes (no strip,
+    Validation rules:
+      - text is non-empty
+      - over MAX_TEXT_LEN, the text is auto-split into linked parts
+        (INGEST-3 #145) rather than rejected
+      - each part's text_hash = SHA-256 of its EXACT bytes (no strip,
         no lowercase) so cross-user cache hits work
       - source_type='paste', source_filename=None
     """
     if len(text) == 0:
         raise HTTPException(status_code=422, detail="Text is required")
-    if len(text) > MAX_TEXT_LEN:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Passage exceeds {MAX_TEXT_LEN:,}-character limit",
-        )
 
-    text_hash = hashlib.sha256(text.encode("utf-8")).digest()
-    passage = Passage(
+    first = _persist_as_passages(
+        session=session,
         owner_id=user.id,
         text=text,
-        text_hash=text_hash,
         source_type="paste",
         source_filename=None,
     )
-    session.add(passage)
-    session.commit()
-    session.refresh(passage)
-
-    # /read/{id} ships in READ-1 (#15). Until then this redirect lands
-    # on a 404 — the URL shape is what matters for downstream wiring.
-    return RedirectResponse(url=f"/read/{passage.id}", status_code=303)
+    return RedirectResponse(url=f"/read/{first.id}", status_code=303)
 
 
 @router.post("/passages/pdf")
@@ -138,19 +180,13 @@ async def create_passage_from_pdf(
     except (PdfParseError, EmptyPdfTextError):
         raise HTTPException(status_code=422, detail=EMPTY_PDF_MESSAGE) from None
 
-    if len(text) > MAX_TEXT_LEN:
-        text = text[:MAX_TEXT_LEN]
-
-    text_hash = hashlib.sha256(text.encode("utf-8")).digest()
-    passage = Passage(
+    # Over the cap, auto-split into linked parts (INGEST-3 #145) instead of
+    # silently truncating to MAX_TEXT_LEN — a large PDF reads in full.
+    first = _persist_as_passages(
+        session=session,
         owner_id=user.id,
         text=text,
-        text_hash=text_hash,
         source_type="pdf",
         source_filename=file.filename,
     )
-    session.add(passage)
-    session.commit()
-    session.refresh(passage)
-
-    return RedirectResponse(url=f"/read/{passage.id}", status_code=303)
+    return RedirectResponse(url=f"/read/{first.id}", status_code=303)

--- a/app/api/reading.py
+++ b/app/api/reading.py
@@ -88,12 +88,32 @@ def read_passage(
     stored_pref = session.get(Preference, user.id)
     prefs = with_defaults(stored_pref.values if stored_pref else None)
 
+    # INGEST-3 (#145): if this passage is one part of an auto-split document,
+    # build Prev/Next links to its sibling parts so the reader can move
+    # through the whole document. Standalone passages get no nav.
+    nav: dict[str, Any] | None = None
+    if passage.document_id is not None and passage.part_count > 1:
+        siblings = session.exec(
+            select(Passage).where(
+                Passage.document_id == passage.document_id,  # type: ignore[arg-type]
+                Passage.owner_id == user.id,  # type: ignore[arg-type]
+            )
+        ).all()
+        by_index = {p.part_index: p.id for p in siblings}
+        nav = {
+            "part_index": passage.part_index,
+            "part_count": passage.part_count,
+            "prev_id": by_index.get(passage.part_index - 1),
+            "next_id": by_index.get(passage.part_index + 1),
+        }
+
     return templates.TemplateResponse(
         request=request,
         name="pages/reading.html",
         context={
             "passage": passage,
             "prefs": prefs,
+            "nav": nav,
             "preference_options": PREFERENCE_OPTIONS,
             "label_for": label_for,
             "label_for_key": label_for_key,

--- a/app/models/passage.py
+++ b/app/models/passage.py
@@ -35,4 +35,11 @@ class Passage(SQLModel, table=True):
     # can disable questions for a passage where the auto-generated ones are
     # unhelpful (PRD Risk #2 mitigation for sacred/poetic text).
     comprehension_enabled: bool = Field(default=True, nullable=False)
+    # INGEST-3 (#145): documents larger than MAX_TEXT_LEN are auto-split into
+    # ordered parts that share a `document_id`, so a big PDF reads as a
+    # navigable sequence instead of being truncated or rejected. A standalone
+    # passage has document_id=None, part_index=0, part_count=1.
+    document_id: uuid.UUID | None = Field(default=None, index=True)
+    part_index: int = Field(default=0, nullable=False)
+    part_count: int = Field(default=1, nullable=False)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/app/services/ingestion/split.py
+++ b/app/services/ingestion/split.py
@@ -1,0 +1,86 @@
+"""Split an over-long document into ordered parts at natural boundaries.
+
+INGEST-3 (#145): a paste or PDF whose text exceeds the per-passage cap is
+split into parts so a large document reads as a navigable sequence instead
+of being truncated (PDF) or rejected (paste). Splitting prefers paragraph
+boundaries (pdfplumber joins pages with blank lines), and hard-cuts a single
+paragraph that is itself larger than the target. It never drops or reorders
+text: ``"".join(split_into_parts(t)) == t`` for any input.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Target size per part. Comfortably under the 100k single-passage render cap
+# (each part renders within known-good limits) while keeping the number of
+# parts — and Prev/Next clicks — low for a smooth reading flow.
+PART_TARGET_CHARS = 80_000
+
+# Hard ceiling on parts, so an absurdly large upload can't create unbounded
+# rows. The ingestion caller rejects an upload that would exceed this.
+MAX_PARTS = 60
+
+# Split on runs of blank lines, KEEPING the delimiter (capturing group) so the
+# pieces concatenate back to the original exactly.
+_PARA_SPLIT = re.compile(r"(\n{2,})")
+
+
+def _boundary_chunks(text: str) -> list[str]:
+    """Break `text` into paragraph-sized chunks that concatenate to `text`.
+
+    Each chunk is a paragraph plus the blank-line delimiter that follows it,
+    so joining all chunks reproduces the input.
+    """
+    pieces = _PARA_SPLIT.split(text)  # [para, delim, para, delim, ..., para]
+    chunks: list[str] = []
+    for i in range(0, len(pieces), 2):
+        para = pieces[i]
+        delim = pieces[i + 1] if i + 1 < len(pieces) else ""
+        chunk = para + delim
+        if chunk:
+            chunks.append(chunk)
+    return chunks
+
+
+def split_into_parts(text: str, *, target: int = PART_TARGET_CHARS) -> list[str]:
+    """Split `text` into parts of at most `target` chars at paragraph
+    boundaries.
+
+    Guarantees:
+      - ``"".join(result) == text`` — no loss, no reordering, nothing added.
+      - every part is at most `target` chars (a single paragraph longer than
+        `target` is hard-cut to honor the bound).
+      - text at most `target` long returns ``[text]`` unchanged.
+    """
+    if len(text) <= target:
+        return [text]
+
+    parts: list[str] = []
+    current = ""
+
+    for chunk in _boundary_chunks(text):
+        if len(chunk) > target:
+            # A single paragraph bigger than target: flush what we have, then
+            # hard-cut it into target-sized slices, keeping the tail in
+            # `current` so the next chunk can pack onto it.
+            if current:
+                parts.append(current)
+                current = ""
+            for start in range(0, len(chunk), target):
+                current = chunk[start : start + target]
+                if len(current) == target:
+                    parts.append(current)
+                    current = ""
+            continue
+
+        if len(current) + len(chunk) > target:
+            if current:
+                parts.append(current)
+            current = chunk
+        else:
+            current += chunk
+
+    if current:
+        parts.append(current)
+    return parts

--- a/supabase/migrations/20260609170000_add_passage_document_parts.sql
+++ b/supabase/migrations/20260609170000_add_passage_document_parts.sql
@@ -1,0 +1,16 @@
+-- INGEST-3 (#145): auto-split large documents into navigable parts.
+--
+-- Additive columns. A standalone passage keeps document_id=NULL,
+-- part_index=0, part_count=1 (unchanged behavior). A document split into N
+-- parts shares one document_id with part_index 0..N-1 and part_count=N.
+-- The index serves the reading view's sibling lookup
+-- (WHERE document_id = ? ORDER BY part_index).
+--
+-- IF NOT EXISTS keeps this idempotent across re-applies / per-PR branches.
+ALTER TABLE public.passage
+    ADD COLUMN IF NOT EXISTS document_id uuid,
+    ADD COLUMN IF NOT EXISTS part_index integer NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS part_count integer NOT NULL DEFAULT 1;
+
+CREATE INDEX IF NOT EXISTS ix_passage_document_id_part_index
+    ON public.passage (document_id, part_index);

--- a/templates/fragments/part_nav.html
+++ b/templates/fragments/part_nav.html
@@ -1,0 +1,13 @@
+{% if nav %}
+  <nav class="part-nav" aria-label="Document parts">
+    <p class="part-position">Part {{ nav.part_index + 1 }} of {{ nav.part_count }}</p>
+    <div class="part-links">
+      {% if nav.prev_id %}
+        <a href="/read/{{ nav.prev_id }}" rel="prev"><span aria-hidden="true">&larr;</span> Previous part</a>
+      {% endif %}
+      {% if nav.next_id %}
+        <a href="/read/{{ nav.next_id }}" rel="next">Next part <span aria-hidden="true">&rarr;</span></a>
+      {% endif %}
+    </div>
+  </nav>
+{% endif %}

--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -9,6 +9,8 @@
 
   {% include "fragments/reader_style.html" %}
 
+  {% include "fragments/part_nav.html" %}
+
   {% include "fragments/reading_surface.html" %}
 
   {% include "fragments/comprehension.html" %}

--- a/tests/test_ingestion_split.py
+++ b/tests/test_ingestion_split.py
@@ -1,0 +1,59 @@
+"""Tests for the document-splitting service (INGEST-3 #145).
+
+The load-bearing invariant: splitting never loses, reorders, or adds text —
+joining the parts reproduces the input exactly — and every part respects the
+size bound.
+"""
+
+from app.services.ingestion.split import (
+    MAX_PARTS,
+    PART_TARGET_CHARS,
+    split_into_parts,
+)
+
+
+def _assert_lossless(text: str, target: int) -> list[str]:
+    parts = split_into_parts(text, target=target)
+    assert "".join(parts) == text, "splitting must not lose or reorder text"
+    assert all(len(p) <= target for p in parts), "every part must respect the target bound"
+    return parts
+
+
+def test_short_text_returns_single_part_unchanged() -> None:
+    assert split_into_parts("hello world", target=80_000) == ["hello world"]
+
+
+def test_text_at_target_is_not_split() -> None:
+    text = "a" * 80_000
+    assert split_into_parts(text, target=80_000) == [text]
+
+
+def test_packs_paragraphs_to_boundaries_without_splitting_them() -> None:
+    # Six ~30k paragraphs → packs two per ~80k part (a third would overflow).
+    para = "A" * 30_000 + "\n\n"
+    parts = _assert_lossless(para * 6, 80_000)
+    assert len(parts) == 3
+    # Each part is whole paragraphs (ends on the blank-line delimiter).
+    assert all(p.endswith("\n\n") for p in parts)
+
+
+def test_single_paragraph_larger_than_target_is_hard_cut() -> None:
+    parts = _assert_lossless("X" * 250_000, 80_000)
+    assert [len(p) for p in parts] == [80_000, 80_000, 80_000, 10_000]
+
+
+def test_mixed_giant_then_small_paragraphs() -> None:
+    text = "X" * 200_000 + "\n\n" + "Y" * 10_000 + "\n\n" + "Z" * 10_000
+    parts = _assert_lossless(text, 80_000)
+    assert len(parts) >= 3
+
+
+def test_exact_multiple_of_target() -> None:
+    parts = _assert_lossless("Q" * 160_000, 80_000)
+    assert [len(p) for p in parts] == [80_000, 80_000]
+
+
+def test_max_parts_is_a_sane_ceiling() -> None:
+    # Sanity on the exported constants the ingestion caller enforces.
+    assert PART_TARGET_CHARS > 0
+    assert MAX_PARTS >= 2

--- a/tests/test_passages_paste.py
+++ b/tests/test_passages_paste.py
@@ -95,11 +95,46 @@ def test_text_at_limit_succeeds(client: TestClient, session: Session) -> None:
     assert response.status_code == 303
 
 
-def test_text_over_limit_returns_422(client: TestClient, session: Session) -> None:
-    signed_in(session)
-    text = "a" * 100_001
+def test_text_over_limit_auto_splits_into_linked_parts(
+    client: TestClient, session: Session
+) -> None:
+    """INGEST-3 (#145): over-cap text is auto-split into linked parts instead
+    of rejected. Redirects to part 0; the parts share a document_id, are
+    ordered, and concatenate back to the original (no loss)."""
+    user = signed_in(session)
+    text = "a" * 100_001  # just over MAX_TEXT_LEN → 2 parts at the 80k target
     response = client.post("/passages", data={"text": text}, follow_redirects=False)
-    assert response.status_code == 422
+    assert response.status_code == 303
+
+    rows = session.exec(
+        select(Passage).where(Passage.owner_id == user.id).order_by(Passage.part_index)  # type: ignore[arg-type]
+    ).all()
+    assert len(rows) == 2
+    assert {r.part_index for r in rows} == {0, 1}
+    assert all(r.part_count == 2 for r in rows)
+    # All parts belong to the same (non-null) document.
+    doc_ids = {r.document_id for r in rows}
+    assert len(doc_ids) == 1 and None not in doc_ids
+    # No text lost or reordered.
+    assert "".join(r.text for r in rows) == text
+    # Redirect lands on part 0.
+    assert response.headers["location"] == f"/read/{rows[0].id}"
+
+
+def test_text_at_limit_stays_a_single_standalone_passage(
+    client: TestClient, session: Session
+) -> None:
+    """At/under the cap, behavior is unchanged: one standalone passage with
+    document_id=None and part_count=1 (no nav)."""
+    user = signed_in(session)
+    text = "a" * 100_000
+    client.post("/passages", data={"text": text}, follow_redirects=False)
+
+    rows = session.exec(select(Passage).where(Passage.owner_id == user.id)).all()  # type: ignore[arg-type]
+    assert len(rows) == 1
+    assert rows[0].document_id is None
+    assert rows[0].part_count == 1
+    assert rows[0].part_index == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_passages_pdf.py
+++ b/tests/test_passages_pdf.py
@@ -16,6 +16,7 @@ import subprocess
 import uuid
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
@@ -195,3 +196,27 @@ def test_no_pymupdf_or_fitz_import_in_app() -> None:
     )
     # grep returns 1 when no matches are found — that's what we want.
     assert result.returncode == 1, f"Forbidden PyMuPDF import detected:\n{result.stdout}"
+
+
+def test_over_cap_pdf_auto_splits_instead_of_truncating(
+    client: TestClient, session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """INGEST-3 (#145): a large PDF is split into linked parts (no content
+    lost) — replacing the old silent truncation to MAX_TEXT_LEN."""
+    signed_in(session)
+    big_text = "p" * 250_000  # ~3 parts at the 80k target
+    monkeypatch.setattr("app.api.passages.extract_text", lambda _b: big_text)
+
+    response = client.post(
+        "/passages/pdf",
+        files={"file": ("big.pdf", io.BytesIO(b"%PDF-1.4 dummy"), "application/pdf")},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+
+    rows = session.exec(select(Passage).order_by(Passage.part_index)).all()
+    assert len(rows) >= 2
+    assert all(r.source_type == "pdf" and r.source_filename == "big.pdf" for r in rows)
+    assert {r.part_count for r in rows} == {len(rows)}
+    # Nothing truncated — the parts reproduce the full extracted text.
+    assert "".join(r.text for r in rows) == big_text

--- a/tests/test_reading_view.py
+++ b/tests/test_reading_view.py
@@ -252,3 +252,80 @@ def test_invalid_uuid_returns_422(client: TestClient, session: Session) -> None:
     signed_in(session)
     response = client.get("/read/not-a-uuid")
     assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Multi-part document navigation (INGEST-3 #145)
+# ---------------------------------------------------------------------------
+
+
+def _make_document(session: Session, owner_id: uuid.UUID, n_parts: int) -> list[Passage]:
+    """Create `n_parts` linked passages sharing one document_id."""
+    document_id = uuid.uuid4()
+    parts: list[Passage] = []
+    for i in range(n_parts):
+        text = f"Part {i} body text."
+        p = Passage(
+            owner_id=owner_id,
+            text=text,
+            text_hash=hashlib.sha256(text.encode("utf-8")).digest(),
+            source_type="pdf",
+            source_filename="big.pdf",
+            document_id=document_id,
+            part_index=i,
+            part_count=n_parts,
+        )
+        session.add(p)
+        parts.append(p)
+    session.commit()
+    for p in parts:
+        session.refresh(p)
+    return parts
+
+
+def test_middle_part_shows_position_and_both_nav_links(
+    client: TestClient, session: Session
+) -> None:
+    user = signed_in(session)
+    parts = _make_document(session, user.id, 3)
+
+    body = client.get(f"/read/{parts[1].id}").text
+
+    assert 'aria-label="Document parts"' in body
+    assert "Part 2 of 3" in body
+    assert f"/read/{parts[0].id}" in body  # Previous
+    assert f"/read/{parts[2].id}" in body  # Next
+
+
+def test_first_part_has_next_but_no_previous(client: TestClient, session: Session) -> None:
+    user = signed_in(session)
+    parts = _make_document(session, user.id, 3)
+
+    body = client.get(f"/read/{parts[0].id}").text
+
+    assert "Part 1 of 3" in body
+    assert "Next part" in body
+    assert f"/read/{parts[1].id}" in body
+    assert "Previous part" not in body
+
+
+def test_last_part_has_previous_but_no_next(client: TestClient, session: Session) -> None:
+    user = signed_in(session)
+    parts = _make_document(session, user.id, 3)
+
+    body = client.get(f"/read/{parts[2].id}").text
+
+    assert "Part 3 of 3" in body
+    assert "Previous part" in body
+    assert f"/read/{parts[1].id}" in body
+    assert "Next part" not in body
+
+
+def test_standalone_passage_has_no_part_nav(client: TestClient, session: Session) -> None:
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+
+    body = client.get(f"/read/{passage.id}").text
+
+    assert 'aria-label="Document parts"' not in body
+    assert "Part 1 of 1" not in body


### PR DESCRIPTION
## Context

Closes #145 (INGEST-3). Large documents had to be broken up by the reader: a text-heavy **PDF over `MAX_TEXT_LEN` (100k chars) was silently truncated** to the first 100k (content lost), and an over-cap **paste was rejected with 422**. This auto-splits over-cap uploads into ordered, navigable parts — the whole document reads in full, no manual splitting.

## How it works

- **Model + migration**: `passage` gains `document_id` / `part_index` / `part_count` (additive; auto-applies to prod via the OPS-3 pipeline). A standalone passage keeps `document_id=NULL`, `part_count=1` — **unchanged behavior**.
- **Split service** (`app/services/ingestion/split.py`): `split_into_parts()` packs paragraphs (blank-line boundaries — how pdfplumber joins pages) into ~80k parts (under the 100k render cap), hard-cuts a single giant paragraph, and is **lossless** (`"".join(parts) == text`). A `MAX_PARTS` ceiling keeps an absurd upload from creating unbounded rows (still 422 past it).
- **Ingestion**: paste + PDF share `_persist_as_passages()` — at/under the cap → one passage (as before); over the cap → split into linked parts, redirect to part 0.
- **Reading view**: shows "Part N of M" + accessible **Prev/Next** (plain `<a rel=prev/next>` in a labeled `<nav>`) for multi-part documents only.

## Out of scope (noted in the ticket)

Comprehension on a large part is unchanged — a part over the 16k comprehension cap still shows the "too long" questions message. Reading the whole document is the goal here; per-part comprehension chunking is a possible future improvement.

## Verification

- Full suite **259 green** (+13): split invariants (boundaries / no loss / giant-paragraph cut / exact multiples), paste + PDF create linked parts with **no truncation**, reading-view nav renders for parts and is omitted for standalone, ownership still enforced.
- lint + format + mypy clean.
- **Part-nav verified axe-clean** locally (0 serious/critical) — the CI a11y job seeds a standalone passage so it doesn't exercise the nav.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)