### PR TITLE
ci(ops): pass --yes to supabase db push (never block on the prompt)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,9 @@ jobs:
           set -euo pipefail
           # URL carries the DB password — keep it out of the logs.
           echo "::add-mask::$DB_URL"
-          supabase db push --db-url "$DB_URL"
+          # --yes auto-answers the interactive "push these migrations?"
+          # prompt so the step can never hang on stdin in CI.
+          supabase db push --yes --db-url "$DB_URL"
 
       - name: Build and push container
         if: steps.check_secrets.outputs.skip != 'true'


### PR DESCRIPTION
## Context

When the OPS-3 migration step applied its first *real* migration (#146), it printed:
```
Do you want to push these migrations to the remote database? [Y/n]
```
It auto-confirmed and succeeded (the CLI proceeds non-interactively in CI), but relying on that is fragile.

## Fix

Add `--yes` to `supabase db push` — a global CLI flag ("answer yes to all prompts"), confirmed present in the pinned 2.105.0 via `db push --help`. This guarantees the deploy's migration step can never hang waiting on stdin, on any future CLI version.

One-line hardening; workflow-only. Quick-fix (no behavior change beyond removing the prompt dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)