### PR TITLE
feat(comprehension): truncate long passages instead of rejecting them

### DIFF
--- a/app/api/reading.py
+++ b/app/api/reading.py
@@ -35,7 +35,6 @@ from app.models.reading_event import ReadingEvent
 from app.services.comprehension.client import get_anthropic_client
 from app.services.comprehension.generator import (
     GeneratorError,
-    PassageTooLongError,
     generate_questions,
 )
 from app.services.reading.defaults import with_defaults
@@ -200,7 +199,7 @@ def passage_questions(
 
     Three response shapes (all 200, all HTML fragments):
       - Success → questions list inside <section aria-label="...">
-      - PassageTooLongError → friendly "split it" message
+      - disabled (comprehension off for this passage) → off message
       - GeneratorError → "temporarily unavailable" message (logged WARN)
 
     Owner check mirrors GET /read: cross-user passage and nonexistent
@@ -235,10 +234,6 @@ def passage_questions(
             model_id=settings.anthropic_model,
             session=session,
         )
-    except PassageTooLongError:
-        # User-recoverable: tell them to split. NOT logged at WARN
-        # because it's expected behaviour on long passages.
-        error = "too_long"
     except GeneratorError:
         # System-side: log so we can investigate, surface a friendly
         # message to the user. NEVER 500 because comprehension is a

--- a/app/services/comprehension/generator.py
+++ b/app/services/comprehension/generator.py
@@ -31,30 +31,27 @@ from app.services.comprehension.prompts import PROMPT_VERSION, SYSTEM_PROMPT
 
 logger = logging.getLogger(__name__)
 
-# Max chars sent to the LLM. ~4 chars per token is a conservative estimate
-# for Claude on English text, so 16_000 chars ≈ 4_000 input tokens. The
-# passage-ingestion route already caps at 100_000 chars per the INGEST-1
-# guardrails, so passages between these two limits are the over-budget
-# ones we reject here.
+# Max chars sent to the LLM per generation. ~4 chars per token, so 16_000
+# chars ≈ 4_000 input tokens — the cost bound. A passage longer than this is
+# TRUNCATED to this many chars (at a word boundary) for question generation
+# rather than rejected: comprehension questions about the opening of a long
+# passage beat no questions at all (and INGEST-3 already splits big documents
+# into parts). Cost stays bounded because we never send more than this.
 MAX_INPUT_CHARS = 16_000
 
 DEFAULT_MAX_TOKENS = 1024
 
 
-class PassageTooLongError(Exception):
-    """The passage exceeds the LLM input-cap. Caller surfaces a UX hint.
-
-    Distinct from GeneratorError because this is a recoverable, user-
-    actionable condition (split the passage), not a system failure.
-    """
-
-    def __init__(self, char_count: int, max_chars: int = MAX_INPUT_CHARS) -> None:
-        super().__init__(
-            f"Passage is {char_count:,} chars; max for comprehension questions "
-            f"is {max_chars:,}. Try splitting it."
-        )
-        self.char_count = char_count
-        self.max_chars = max_chars
+def _truncate_for_llm(text: str) -> str:
+    """Cap `text` at MAX_INPUT_CHARS for question generation, trimming back to
+    the last word boundary so we don't cut a word in half."""
+    if len(text) <= MAX_INPUT_CHARS:
+        return text
+    cut = text[:MAX_INPUT_CHARS]
+    space = cut.rfind(" ")
+    # Only honor the boundary if it doesn't lop off most of the budget (a
+    # passage with no spaces in the first 16k just gets a hard cut).
+    return cut[:space] if space > MAX_INPUT_CHARS // 2 else cut
 
 
 class GeneratorError(Exception):
@@ -97,9 +94,10 @@ def generate_questions(
     """Return cached or freshly-generated comprehension questions.
 
     Order of operations (the cost-containment contract):
-      1. SHA-256 the passage text.
+      1. SHA-256 the passage text (the cache key is the FULL text).
       2. Look up the cache. On hit, return immediately. No LLM call.
-      3. On miss, length-check. Over MAX_INPUT_CHARS → PassageTooLongError.
+      3. On miss, truncate the input to MAX_INPUT_CHARS (bounds token cost;
+         a long passage still gets questions about its opening).
       4. Call Anthropic with the system prompt under cache_control
          ephemeral. Parse + validate the JSON response.
       5. Persist to cache. Return.
@@ -128,16 +126,10 @@ def generate_questions(
         )
         return cached
 
-    if len(passage_text) > MAX_INPUT_CHARS:
-        logger.info(
-            "comprehension passage too long",
-            extra={
-                "text_hash": text_hash.hex(),
-                "char_count": len(passage_text),
-                "max_chars": MAX_INPUT_CHARS,
-            },
-        )
-        raise PassageTooLongError(char_count=len(passage_text))
+    # Long passages are truncated (not rejected) so they still get questions
+    # while keeping the per-call token cost bounded. The cache key is the FULL
+    # passage hash, so the same passage always yields the same questions.
+    llm_input = _truncate_for_llm(passage_text)
 
     logger.info(
         "comprehension cache miss → calling Anthropic",
@@ -147,6 +139,8 @@ def generate_questions(
             "model_id": model_id,
             "prompt_version": PROMPT_VERSION,
             "char_count": len(passage_text),
+            "input_chars": len(llm_input),
+            "truncated": len(llm_input) < len(passage_text),
         },
     )
 
@@ -161,7 +155,7 @@ def generate_questions(
                     "cache_control": {"type": "ephemeral"},
                 }
             ],
-            messages=[{"role": "user", "content": passage_text}],
+            messages=[{"role": "user", "content": llm_input}],
         )
     except anthropic.AnthropicError as exc:
         # Auth failure (missing/invalid key), bad model id, rate limit,

--- a/templates/fragments/questions_panel.html
+++ b/templates/fragments/questions_panel.html
@@ -18,9 +18,6 @@
         </li>
       {% endfor %}
     </ol>
-  {% elif error == "too_long" %}
-    <p>This passage is too long for comprehension questions right now.
-       Try splitting it into shorter sections.</p>
   {% elif error == "unavailable" %}
     <p>Comprehension questions are temporarily unavailable.
        The rest of your reading still works as normal.</p>

--- a/tests/test_comprehension_generator.py
+++ b/tests/test_comprehension_generator.py
@@ -4,7 +4,7 @@ Covers the Definition of Done from issue #19 (COMP-2):
   - Cache hit returns immediately without invoking the Anthropic client
   - Cache miss calls Anthropic exactly once, persists to cache, returns parsed list
   - Second call with the same text after a miss is a cache hit
-  - Passage exceeding 16,000 chars raises PassageTooLongError BEFORE the LLM call
+  - Passage exceeding 16,000 chars is truncated for the LLM call (not rejected)
   - The call to messages.create uses cache_control={'type': 'ephemeral'} on the system message
   - The call uses model=settings.anthropic_model
   - Malformed JSON response raises GeneratorError
@@ -29,7 +29,6 @@ from app.services.comprehension import cache, generator
 from app.services.comprehension.generator import (
     MAX_INPUT_CHARS,
     GeneratorError,
-    PassageTooLongError,
     generate_questions,
 )
 from app.services.comprehension.prompts import PROMPT_VERSION
@@ -198,28 +197,31 @@ def test_passage_at_input_cap_succeeds(session: Session) -> None:
     assert len(result) == 3
 
 
-def test_passage_over_input_cap_raises_and_does_not_call_anthropic(
-    session: Session,
-) -> None:
-    """The cost-prevention property: a too-long passage raises BEFORE the
-    LLM is invoked, AND BEFORE writing anything to the cache. Pinned by
-    asserting both side effects didn't happen."""
+def test_passage_over_input_cap_truncates_and_still_generates(session: Session) -> None:
+    """A passage longer than MAX_INPUT_CHARS is TRUNCATED for the LLM call
+    (token cost stays bounded) and still produces questions — it is no longer
+    rejected. The cache key remains the FULL passage text."""
     client = _make_mock_client()
-    passage = "a" * (MAX_INPUT_CHARS + 1)
+    passage = "word " * 5000  # ~25k chars, well over the 16k cap
 
-    with pytest.raises(PassageTooLongError) as exc_info:
-        generate_questions(
-            passage_text=passage,
-            question_type="recall",
-            client=client,
-            model_id=TEST_MODEL_ID,
-            session=session,
-        )
+    result = generate_questions(
+        passage_text=passage,
+        question_type="recall",
+        client=client,
+        model_id=TEST_MODEL_ID,
+        session=session,
+    )
 
-    assert client.messages.create.call_count == 0
-    assert exc_info.value.char_count == MAX_INPUT_CHARS + 1
+    # Generated (not rejected), exactly one call.
+    assert client.messages.create.call_count == 1
+    assert len(result) == 3
 
-    # No cache row was written.
+    # The content sent to the LLM was capped at MAX_INPUT_CHARS (truncated).
+    sent = client.messages.create.call_args.kwargs["messages"][0]["content"]
+    assert len(sent) <= MAX_INPUT_CHARS
+    assert len(sent) < len(passage)
+
+    # Cached under the FULL passage hash so re-reads are free.
     text_hash = hashlib.sha256(passage.encode("utf-8")).digest()
     assert (
         cache.get_cached(
@@ -229,7 +231,7 @@ def test_passage_over_input_cap_raises_and_does_not_call_anthropic(
             prompt_version=PROMPT_VERSION,
             session=session,
         )
-        is None
+        == result
     )
 
 
@@ -516,23 +518,24 @@ def test_passage_text_never_appears_in_logs(
     assert sensitive_phrase not in caplog.text
 
 
-def test_passage_too_long_log_does_not_include_passage(
+def test_truncated_long_passage_log_does_not_include_passage(
     session: Session, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """The 'too long' log line records char count but never the text."""
+    """The cache-miss/truncation log line records char counts but never the
+    passage text — even now that a long passage is truncated and generated
+    rather than rejected."""
     client = _make_mock_client()
     sensitive_marker = "THIS_IS_THE_SECRET_MARKER"
-    passage = sensitive_marker + ("a" * (MAX_INPUT_CHARS + 1))
+    passage = sensitive_marker + (" a" * 12_000)  # well over the cap
 
     with caplog.at_level(logging.DEBUG):
-        with pytest.raises(PassageTooLongError):
-            generate_questions(
-                passage_text=passage,
-                question_type="recall",
-                client=client,
-                model_id=TEST_MODEL_ID,
-                session=session,
-            )
+        generate_questions(
+            passage_text=passage,
+            question_type="recall",
+            client=client,
+            model_id=TEST_MODEL_ID,
+            session=session,
+        )
 
     assert sensitive_marker not in caplog.text
 

--- a/tests/test_questions_route.py
+++ b/tests/test_questions_route.py
@@ -8,7 +8,7 @@ Covers the Definition of Done from issue #20 (COMP-3):
   - Nonexistent passage → 404
   - Both 404 paths return identical body (no existence leak)
   - Route invokes generator.generate_questions with question_type="recall"
-  - PassageTooLongError → 200 with the "too long" fragment
+  - GeneratorError → 200 with the "temporarily unavailable" fragment
   - GeneratorError → 200 with the "unavailable" fragment + WARN log
   - Unauthenticated request → 200 + HX-Redirect: /login (per AUTH-3)
   - The Anthropic client is never the real client in tests
@@ -224,33 +224,8 @@ def test_other_user_and_nonexistent_have_identical_response_shape(
 
 
 # ---------------------------------------------------------------------------
-# Error states — too long + unavailable
+# Error states — unavailable
 # ---------------------------------------------------------------------------
-
-
-def test_passage_too_long_returns_200_with_friendly_fragment(
-    client: TestClient,
-    session: Session,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A PassageTooLongError from the generator must render as a friendly
-    200 fragment, NOT a 4xx/5xx. Comprehension is a feature, not a hard
-    dependency on every passage."""
-    user = signed_in(session)
-    passage = _make_passage(session, user.id)
-
-    def fake_generate(**_: Any) -> list[dict]:
-        raise generator.PassageTooLongError(char_count=20_000)
-
-    monkeypatch.setattr("app.api.reading.generate_questions", fake_generate)
-
-    response = client.get(f"/passages/{passage.id}/questions")
-    assert response.status_code == 200
-    body = response.text
-    assert "too long" in body.lower()
-    # Still wrapped in the comprehension-check section so the rest of
-    # the page's structure / a11y is consistent.
-    assert '<section aria-label="Comprehension check"' in body
 
 
 def test_generator_error_returns_200_with_unavailable_fragment(


### PR DESCRIPTION
## Context

Closes #148 (COMP-6). A passage over `MAX_INPUT_CHARS` (16k) got **no** comprehension questions — the generator raised `PassageTooLongError` and the panel showed "too long, split it." This is newly important: **INGEST-3 (#145) ships large documents as ~80k-char parts, every one of which exceeds 16k**, so comprehension would never work on a large or split document.

## Fix

Over-cap passages are now **truncated to `MAX_INPUT_CHARS`** (at a word boundary) for question generation instead of rejected:
- **Cost stays bounded** — we never send more than the cap to the LLM.
- The reader gets questions about the **opening** of a long passage instead of nothing.
- The **cache key is still the full passage hash**, so re-reads stay free and deterministic.

Removed the now-dead path entirely: `PassageTooLongError`, the route's `too_long` branch, and the template's "too long" fragment. Truncation is logged with char counts only — never the passage text (PII discipline preserved).

## Out of scope

Whole-passage coverage via sampling (questions spanning the entire passage) — a future enhancement; truncation-to-opening is the bounded-cost fix here.

## Verification

- Full suite **258 green**: over-cap passage truncates + generates (asserts the LLM input ≤ cap and is actually shorter than the passage), caches under the full hash; the truncation log omits the passage text; existing cache/cost/parse tests unchanged.
- lint + format + mypy clean.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)