### PR TITLE
docs(journal): log 2026-06-11 — #99 preview-DB isolation, backlog cleared

### DIFF
--- a/reports/session-journals/2026-06-11.md
+++ b/reports/session-journals/2026-06-11.md
@@ -1,0 +1,81 @@
+# Session Journal — 2026-06-11
+
+*(Short session. Prior segment: `2026-06-10.md`.)*
+
+## 1. Session Summary
+
+Shipped **#99** — the last open ticket — isolating preview deploys from the
+production database. With it merged, the tracked backlog is **empty** (0 open
+issues, 0 open PRs). The interesting part was less the code than the
+investigation: confirming how Supabase auto-branching actually behaves, and
+validating a workflow-only feature on real preview branches before merge.
+
+## 2. Tickets Delivered
+
+| Ticket | PR | What changed | Tests |
+|---|---|---|---|
+| #99 — per-PR Supabase branch DATABASE_URL | #151 | `preview-deploy.yml` resolves each PR's Supabase preview branch by git ref (`branches list` → match `git_branch` → `branches get -o env` → `POSTGRES_URL`) and injects its DATABASE_URL, so a migration PR's preview hits an isolated branch DB instead of production. Non-migration PRs (no branch) keep the shared prod DB; any failure/timing race falls back to prod (never deploy-breaking). | validated in CI (workflow-only) |
+
+## 3. Tickets In Review
+
+None. (A throwaway validation PR, #152, was opened *with* a migration to exercise the isolated path, confirmed it, and was closed — not merged.)
+
+## 4. Challenges and Mitigations
+
+| Challenge | Root cause | Mitigation | Prevention |
+|---|---|---|---|
+| #99 assumes "every preview gets a branch", but most PRs don't | Supabase auto-branches **only on PRs that change `supabase/migrations/**`** (verified: #146 got a branch on a separate project ref; non-migration PRs show "Supabase Preview: skipping") | Scoped #99 to isolate migration PRs; non-migration PRs keep shared prod (schema-identical to prod). Fallback to prod on no-branch | A new infra feature should be checked against how the underlying service actually behaves, not the ticket's assumption |
+| Adding a migration to an already-open PR didn't create a branch | Supabase decides branching **at PR-open time** and doesn't re-evaluate when migrations are pushed later | Validated isolation with a *fresh* PR opened **with** a migration (#152) | To exercise Supabase branching, open the PR with the migration present |
+| Couldn't validate a workflow-only feature locally or in its own PR | A workflow-only PR (#99) takes the no-branch fallback in its own run; the isolated path needs a migration PR | Throwaway PR opened with a harmless `COMMENT ON TABLE` migration → branch created → isolated path ran → confirmed via the PR comment + a keys-only diagnostic; then closed | Self-diagnosing workflow steps (log branch found + field *names*) make this kind of validation cheap |
+
+## 5. Insights and Learnings
+
+### Technical insights
+
+- **`supabase branches get <name> -o env` returns the branch's full `POSTGRES_URL` directly** (confirmed: `branches-get keys: POSTGRES_URL POSTGRES_URL_NON_POOLING …`). No constructing a URL from a password — so #99 needed only `SUPABASE_ACCESS_TOKEN`, not `SUPABASE_DB_PASSWORD`. (The CLI help even notes main-branch URL fields are blank because prod creds aren't API-retrievable — i.e. preview-branch creds *are*.)
+- **Supabase auto-branching is migration-scoped and decided at PR-open.** Only PRs that change `supabase/migrations/**` get a branch, and the decision is made when the PR opens (not re-evaluated on later pushes). Both facts shaped #99's scope and its validation.
+- **Best-effort isolation + prod fallback is the right shape for a preview-DB feature**: it isolates the risky (migration) PRs while never breaking a preview deploy on a missing branch, missing token, or async-timing race.
+
+### Process insights
+
+- **Validate workflow-only changes on a real throwaway PR, not by hoping.** The isolated path could only be exercised by a migration PR; a 5-minute throwaway (opened with a harmless table-comment migration, then closed) confirmed it end-to-end and ruled out silent-no-op field-name bugs.
+- **Bake a safe diagnostic into uncertain steps.** Logging "branch found / not found" + the available env *key names* (never values) turned the first real run into a definitive answer about the JSON shape.
+
+### Domain insights
+
+- The backlog is empty. The product is feature-complete for the MVP, production-hardened (warm instance, monitor + write-path smoke, auto-applied migrations, isolated previews), and large documents + comprehension both work. What remains for an actual **M1 launch** is operator/business, not engineering: verify production magic-link email delivery and schedule the human WCAG audit (both tracked in `docs/LAUNCH-CHECKLIST.md`).
+
+## 6. Tickets Created
+
+None (#99 was filed long ago).
+
+## 7. Metrics
+
+- **PRs created / merged**: 1 (#151) merged; 1 throwaway (#152) opened + closed for validation
+- **Issues closed**: 1 (#99)
+- **Board state**: **0 open issues, 0 open PRs** — backlog clear
+- **Tests added**: none (workflow-only; validated via CI on real branches)
+- **Secrets**: `SUPABASE_ACCESS_TOKEN` provisioned this session enabled #99
+
+## 8. Next Up
+
+The tracked backlog is empty. Candidate directions, in rough priority:
+
+1. **M1 launch operator actions (not code)** — verify production magic-link **email delivery** to a real inbox; **schedule the human WCAG audit**. These are the real gates between "feature-complete" and "first users onboarded" (`docs/LAUNCH-CHECKLIST.md`).
+2. **a11y CI reliability** — `supabase start` intermittently flakes and red-X's unrelated PRs; a startup retry would cut the noise. Small, unblocked.
+3. **Comprehension whole-passage coverage** — COMP-6 truncates to the opening; sampling across the passage would make questions span the whole text. Enhancement.
+4. **New feature work** — driven by real Phase-1 user feedback once users land (per the roadmap, Phase 2 is feedback-driven).
+
+## Memory Validation
+
+File-based memory in use; no `CompletedTicket-N` MCP scheme. Not applicable.
+
+## Memory Consolidation
+
+Saved one reusable gotcha this session:
+- **supabase-branching-migration-only** — Supabase auto-branches only on
+  migration-changing PRs, and decides at PR-open time. Pairs with
+  `supabase-ci-session-pooler`.
+
+→ The validation technique (throwaway opened-with-migration PR + keys-only
+diagnostic) is captured in this journal.


### PR DESCRIPTION
## Context

Short session journal for 2026-06-11.

## Summary

Shipped **#99** — the last open ticket — isolating preview deploys from the production DB: `preview-deploy.yml` now injects each migration PR's Supabase preview-branch `DATABASE_URL` (non-migration PRs keep shared prod; any failure falls back to prod, never deploy-breaking). Validated both paths on real branches (a throwaway opened-with-migration PR confirmed "Database: isolated"). **The tracked backlog is now empty — 0 open issues, 0 open PRs.**

Captures the Supabase branching behavior learned (auto-branches only on migration PRs, decided at PR-open time; `branches get -o env` returns `POSTGRES_URL` directly), the validation method, and the remaining non-code M1 gates.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)