### PR TITLE
fix(reading): width in em not ch (consistent across computers)

### DIFF
--- a/app/services/reading/defaults.py
+++ b/app/services/reading/defaults.py
@@ -7,7 +7,8 @@ user before they've toggled anything. Per the architecture doc:
   - 18px base size
   - 1.6 line-height
   - white background, near-black foreground (high but not maximum contrast)
-  - 65ch max width (the classic readable measure)
+  - 33em max width (~65 characters; in `em` not `ch` so the column is the
+    same width across computers regardless of the rendered font)
   - bionic emphasis off (opt-in only; ships in READ-3 #17)
 
 The keys here are the canonical preference keys for the rest of the
@@ -25,8 +26,20 @@ DEFAULT_PREFERENCES: dict[str, Any] = {
     "line_height": "1.6",
     "bg": "#ffffff",
     "fg": "#1a1a1a",
-    "max_width": "65ch",
+    "max_width": "33em",
     "bionic_enabled": False,
+}
+
+
+# Map legacy `ch`-based max_width values (stored before the switch to `em`)
+# to their em equivalents, so existing users get the cross-machine-consistent
+# width without having to re-pick. Any other stale `ch` value falls back to
+# the default. See the width-unit fix.
+_LEGACY_CH_TO_EM: dict[str, str] = {
+    "55ch": "28em",
+    "65ch": "33em",
+    "75ch": "38em",
+    "85ch": "43em",
 }
 
 
@@ -36,9 +49,13 @@ def with_defaults(stored: dict[str, Any] | None) -> dict[str, Any]:
     Returns a new dict — never mutates either input. If `stored` is None
     or empty, the returned dict is exactly the defaults. If `stored`
     contains keys not in DEFAULT_PREFERENCES, they're carried through
-    (forward-compat for new keys added later).
+    (forward-compat for new keys added later). A legacy `ch` max_width is
+    normalized to its `em` equivalent on the way out.
     """
     merged = dict(DEFAULT_PREFERENCES)
     if stored:
         merged.update(stored)
+    width = merged.get("max_width")
+    if isinstance(width, str) and width.endswith("ch"):
+        merged["max_width"] = _LEGACY_CH_TO_EM.get(width, DEFAULT_PREFERENCES["max_width"])
     return merged

--- a/app/services/reading/options.py
+++ b/app/services/reading/options.py
@@ -27,7 +27,15 @@ PREFERENCE_OPTIONS: dict[str, list[Any]] = {
     "line_height": ["1.4", "1.5", "1.6", "1.8", "2.0"],
     "bg": ["#ffffff", "#f5e6d3", "#1a1a1a"],  # white, sepia, dark
     "fg": ["#1a1a1a", "#3d2914", "#e8e8e8"],  # near-black, brown, light
-    "max_width": ["55ch", "65ch", "75ch", "85ch"],
+    # In `em` (relative to --reader-size), NOT `ch`. `ch` is the width of the
+    # font's `0` glyph, so a `ch` measure renders a DIFFERENT pixel width on
+    # machines that fall back to a different font — the stacks above are system
+    # fonts, not bundled webfonts, so the rendered font (and thus `ch`) varied
+    # by computer. `em` depends only on --reader-size (a fixed px), so the
+    # column is consistent across computers AND still scales with the size
+    # preference. ~0.5em/char keeps these close to the old 55/65/75/85-char
+    # measures.
+    "max_width": ["28em", "33em", "38em", "43em"],
     "bionic_enabled": [True, False],
 }
 
@@ -53,10 +61,10 @@ PREFERENCE_LABELS: dict[tuple[str, Any], str] = {
     ("fg", "#e8e8e8"): "Light text",
     ("bionic_enabled", True): "On",
     ("bionic_enabled", False): "Off",
-    ("max_width", "55ch"): "Narrow",
-    ("max_width", "65ch"): "Standard",
-    ("max_width", "75ch"): "Wide",
-    ("max_width", "85ch"): "Extra wide",
+    ("max_width", "28em"): "Narrow",
+    ("max_width", "33em"): "Standard",
+    ("max_width", "38em"): "Wide",
+    ("max_width", "43em"): "Extra wide",
 }
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -28,7 +28,7 @@
    #reading-surface, so it uses the page's default colors (not the user's
    chosen reader bg/fg). */
 .reading-nav {
-  max-width: var(--reader-max-width, 65ch);
+  max-width: var(--reader-max-width, 33em);
   margin: 1rem auto 0;
 }
 
@@ -47,7 +47,7 @@
    <button> is one allow-listed option. aria-pressed reflects the
    current value at page load. */
 .reader-controls {
-  max-width: var(--reader-max-width, 65ch);
+  max-width: var(--reader-max-width, 33em);
   margin: 2rem auto;
 }
 

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -103,7 +103,7 @@ def test_third_toggle_updates_only_its_own_key(client: TestClient, session: Sess
     user = signed_in(session)
 
     client.post("/preferences/size", data={"value": "20px"})
-    client.post("/preferences/max_width", data={"value": "75ch"})
+    client.post("/preferences/max_width", data={"value": "38em"})
     # Now change size again — max_width should survive.
     client.post("/preferences/size", data={"value": "28px"})
 
@@ -111,7 +111,7 @@ def test_third_toggle_updates_only_its_own_key(client: TestClient, session: Sess
     pref = session.get(Preference, user.id)
     assert pref is not None
     assert pref.values["size"] == "28px"
-    assert pref.values["max_width"] == "75ch"
+    assert pref.values["max_width"] == "38em"
 
 
 # ---------------------------------------------------------------------------
@@ -267,7 +267,7 @@ def test_sidebar_renders_button_for_each_allow_listed_value(
 
     # Specific values from the allow-list show up.
     assert "14px" in body and "28px" in body  # size extremes
-    assert "55ch" in body and "85ch" in body  # max_width extremes
+    assert "28em" in body and "43em" in body  # max_width extremes
 
 
 def test_sidebar_buttons_target_the_style_block(client: TestClient, session: Session) -> None:

--- a/tests/test_reading_defaults.py
+++ b/tests/test_reading_defaults.py
@@ -1,0 +1,35 @@
+"""Tests for with_defaults — preference merge + legacy width normalization."""
+
+from app.services.reading.defaults import DEFAULT_PREFERENCES, with_defaults
+
+
+def test_none_returns_defaults() -> None:
+    assert with_defaults(None) == DEFAULT_PREFERENCES
+    assert with_defaults({}) == DEFAULT_PREFERENCES
+
+
+def test_default_max_width_is_em_not_ch() -> None:
+    # The width fix: defaults use em so the column is consistent across machines.
+    assert DEFAULT_PREFERENCES["max_width"].endswith("em")
+
+
+def test_stored_em_width_passes_through() -> None:
+    assert with_defaults({"max_width": "38em"})["max_width"] == "38em"
+
+
+def test_legacy_ch_width_is_normalized_to_em() -> None:
+    """A width stored before the em switch must render as its em equivalent,
+    so existing users get the cross-machine-consistent width without re-picking."""
+    for ch, em in (("55ch", "28em"), ("65ch", "33em"), ("75ch", "38em"), ("85ch", "43em")):
+        assert with_defaults({"max_width": ch})["max_width"] == em
+
+
+def test_unknown_legacy_ch_width_falls_back_to_default() -> None:
+    assert with_defaults({"max_width": "999ch"})["max_width"] == DEFAULT_PREFERENCES["max_width"]
+
+
+def test_other_keys_still_merge_over_defaults() -> None:
+    merged = with_defaults({"size": "24px", "max_width": "65ch"})
+    assert merged["size"] == "24px"
+    assert merged["max_width"] == "33em"  # legacy ch normalized
+    assert merged["font"] == DEFAULT_PREFERENCES["font"]  # untouched key

--- a/tests/test_reading_view.py
+++ b/tests/test_reading_view.py
@@ -143,7 +143,7 @@ def test_user_with_no_preference_row_gets_defaults_rendered(
     assert f"--reader-size: {DEFAULT_PREFERENCES['size']}" in body
     # Default line-height is "1.6".
     assert f"--reader-line-height: {DEFAULT_PREFERENCES['line_height']}" in body
-    # Default max-width is "65ch".
+    # Default max-width is "33em" (em, not ch — consistent across machines).
     assert f"--reader-max-width: {DEFAULT_PREFERENCES['max_width']}" in body
 
 
@@ -160,7 +160,7 @@ def test_user_with_preference_row_gets_their_values_rendered(
     session.add(
         Preference(
             owner_id=user.id,
-            values={"size": "24px", "max_width": "55ch"},
+            values={"size": "24px", "max_width": "28em"},
             updated_at=datetime.now(UTC),
         )
     )
@@ -171,7 +171,7 @@ def test_user_with_preference_row_gets_their_values_rendered(
 
     # Stored values take precedence.
     assert "--reader-size: 24px" in body
-    assert "--reader-max-width: 55ch" in body
+    assert "--reader-max-width: 28em" in body
     # Unset keys still come from defaults.
     assert f"--reader-line-height: {DEFAULT_PREFERENCES['line_height']}" in body
 


### PR DESCRIPTION
## Context

Closes #154. The reading-width preference rendered a **different column width on different computers at the same setting** — some narrower than others.

## Root cause

`max_width` used **`ch`** (`55ch`…`85ch`). `ch` is the width of the font's `0` glyph, so a `ch` measure resolves to a different pixel width depending on **which font renders**. The font options are **system-font stacks with no bundled webfonts** (`system-ui` = San Francisco on macOS / Segoe UI on Windows; the serif stack falls back differently), so the rendered font — and thus `ch` — varied by machine.

## Fix

Switch `max_width` to **`em`** (relative to `--reader-size`, a fixed px). Now the column is:
- **consistent across computers** — no dependency on the rendered font's glyph width, and
- still **scales with the size preference** (which `ch` did; `rem` would not).

`~0.5em/char` keeps the measures close to the old 55/65/75/85-char widths → **28 / 33 / 38 / 43em**. On the default macOS/Georgia/18px setup the column is ~unchanged (~594px); other machines now match it instead of being narrower/wider.

## Changes

- `options.py` / `defaults.py`: `ch` values + default → `em`; sidebar labels updated.
- `static/style.css`: `--reader-max-width` fallbacks `65ch` → `33em`.
- `with_defaults` **normalizes a legacy stored `ch` width → `em`** (`65ch`→`33em`, etc.), so existing users get the fix without re-picking their width.

## Verification

- Full suite **264 green** (+6): a new `with_defaults` normalization test (legacy ch→em, em pass-through, unknown-ch fallback) + updated reading/preference tests.
- lint + format + mypy clean. No a11y impact (width is a valid CSS length; the a11y job's default variant just renders `33em`).

## Note

`em` keeps the typographic "measure scales with font size" behavior. The remaining (pre-existing) nuance — the back-link/controls containers resolve `em` against their own 16px font, so they're ~11% narrower than the surface — is identical to the old `ch` behavior (same ratio), not a regression.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)