### PR TITLE
feat(reading): move preference controls to the top of the reading view

### DIFF
--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -9,6 +9,28 @@
 
   {% include "fragments/reader_style.html" %}
 
+  {# Reading preferences live at the top so they're reachable without
+     scrolling past the passage. #}
+  <aside class="reader-controls" aria-labelledby="reading-preferences-heading">
+    <h2 id="reading-preferences-heading">Reading preferences</h2>
+
+    {% for key, options in preference_options.items() %}
+      <fieldset class="reader-control-group" data-pref-key="{{ key }}">
+        <legend>{{ label_for_key(key) }}</legend>
+        {% for opt in options %}
+          <button
+            type="button"
+            hx-post="/preferences/{{ key }}"
+            hx-vals='{"value": "{{ value_for_form(opt) }}", "passage_id": "{{ passage.id }}"}'
+            hx-target="#reading-surface-style"
+            hx-swap="outerHTML"
+            aria-pressed="{{ 'true' if prefs[key] == opt else 'false' }}"
+          >{{ label_for(key, opt) }}</button>
+        {% endfor %}
+      </fieldset>
+    {% endfor %}
+  </aside>
+
   {% include "fragments/part_nav.html" %}
 
   {% include "fragments/reading_surface.html" %}
@@ -52,26 +74,6 @@
        hx-swap="none"
        aria-hidden="true"
        style="display:none"></div>
-
-  <aside class="reader-controls" aria-labelledby="reading-preferences-heading">
-    <h2 id="reading-preferences-heading">Reading preferences</h2>
-
-    {% for key, options in preference_options.items() %}
-      <fieldset class="reader-control-group" data-pref-key="{{ key }}">
-        <legend>{{ label_for_key(key) }}</legend>
-        {% for opt in options %}
-          <button
-            type="button"
-            hx-post="/preferences/{{ key }}"
-            hx-vals='{"value": "{{ value_for_form(opt) }}", "passage_id": "{{ passage.id }}"}'
-            hx-target="#reading-surface-style"
-            hx-swap="outerHTML"
-            aria-pressed="{{ 'true' if prefs[key] == opt else 'false' }}"
-          >{{ label_for(key, opt) }}</button>
-        {% endfor %}
-      </fieldset>
-    {% endfor %}
-  </aside>
 
   <script>
     // Reflect the just-clicked preference button as `aria-pressed=true`


### PR DESCRIPTION
## Context

Closes #156. The format settings (font, size, line-height, colors, width, bionic) rendered as an `<aside>` at the **bottom** of the reading view, so the reader had to scroll past the whole passage to reach them.

## Change

Relocated the `.reader-controls` block to the **top** of `reading.html` — right after the style block, before the passage. New order: back-link → style → **settings** → part-nav → passage → comprehension.

- The aria-pressed sync `<script>` is document-delegated, so it works unchanged regardless of position.
- The preference buttons still target `#reading-surface-style`, which is emitted above them, so toggles still swap the style block correctly.
- Pure placement change — no behavior change.

## Verification

- Full suite **264 green** (the reading-view + preferences tests render the page and assert on the controls/buttons — all pass with the new placement); lint clean.
- No a11y impact (same elements, just reordered; the controls' `<h2>` was already on the page).

## Heads-up / possible follow-up

This places the always-open controls **above** the passage, which pushes the reading text down a bit. If that feels heavy, I can make it a collapsed `<details>` "Reading preferences" panel at the top — reachable without scrolling, but keeps the passage prominent. Say the word and I'll switch it.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)