### PR TITLE
feat(reading): collapsible + grid-arranged preference controls

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -47,24 +47,48 @@
    <button> is one allow-listed option. aria-pressed reflects the
    current value at page load. */
 .reader-controls {
-  max-width: var(--reader-max-width, 33em);
+  /* Wider than the reading column so the preference groups can lay out as a
+     grid instead of one tall stack. Capped and centered. */
+  max-width: min(56rem, 100%);
   margin: 2rem auto;
 }
 
+.reader-controls-panel > summary {
+  font-size: 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-bottom: 0.75rem;
+}
+
+/* Arrange the preference groups in a responsive grid (auto-fit columns) so
+   they don't stack into one tall column. */
+.reader-control-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 1rem 1.5rem;
+}
+
 .reader-control-group {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: center;
-  margin-bottom: 1rem;
+  /* Each group is a grid cell: label on its own line, option buttons
+     wrapping below. min-width:0 lets a cell shrink instead of overflowing. */
   border: none;
   padding: 0;
+  margin: 0;
+  min-width: 0;
 }
 
 .reader-control-group legend {
-  margin: 0 0.75rem 0 0;
+  display: block;
+  width: 100%;
+  margin: 0 0 0.4rem 0;
+  padding: 0;
   font-weight: 600;
-  flex-basis: 8rem;
+}
+
+.reader-control-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
 }
 
 .reader-control-group button {

--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -9,26 +9,32 @@
 
   {% include "fragments/reader_style.html" %}
 
-  {# Reading preferences live at the top so they're reachable without
-     scrolling past the passage. #}
+  {# Reading preferences at the top: collapsible (open by default) so they're
+     reachable without scrolling but can be folded away, and laid out as a grid
+     so the groups don't stack into one tall column. #}
   <aside class="reader-controls" aria-labelledby="reading-preferences-heading">
-    <h2 id="reading-preferences-heading">Reading preferences</h2>
-
-    {% for key, options in preference_options.items() %}
-      <fieldset class="reader-control-group" data-pref-key="{{ key }}">
-        <legend>{{ label_for_key(key) }}</legend>
-        {% for opt in options %}
-          <button
-            type="button"
-            hx-post="/preferences/{{ key }}"
-            hx-vals='{"value": "{{ value_for_form(opt) }}", "passage_id": "{{ passage.id }}"}'
-            hx-target="#reading-surface-style"
-            hx-swap="outerHTML"
-            aria-pressed="{{ 'true' if prefs[key] == opt else 'false' }}"
-          >{{ label_for(key, opt) }}</button>
+    <details class="reader-controls-panel" open>
+      <summary id="reading-preferences-heading">Reading preferences</summary>
+      <div class="reader-control-grid">
+        {% for key, options in preference_options.items() %}
+          <fieldset class="reader-control-group" data-pref-key="{{ key }}">
+            <legend>{{ label_for_key(key) }}</legend>
+            <div class="reader-control-options">
+              {% for opt in options %}
+                <button
+                  type="button"
+                  hx-post="/preferences/{{ key }}"
+                  hx-vals='{"value": "{{ value_for_form(opt) }}", "passage_id": "{{ passage.id }}"}'
+                  hx-target="#reading-surface-style"
+                  hx-swap="outerHTML"
+                  aria-pressed="{{ 'true' if prefs[key] == opt else 'false' }}"
+                >{{ label_for(key, opt) }}</button>
+              {% endfor %}
+            </div>
+          </fieldset>
         {% endfor %}
-      </fieldset>
-    {% endfor %}
+      </div>
+    </details>
   </aside>
 
   {% include "fragments/part_nav.html" %}


### PR DESCRIPTION
## Context

Polish on the top-of-page reading preferences (follow-up to #157):
1. Make them **collapsible** — but **open by default** (no extra click to use them).
2. Lay the settings out in a **grid** instead of one tall column.

## Changes

- **`reading.html`**: wrapped the controls in `<details open>` with a `<summary id="reading-preferences-heading">Reading preferences</summary>`; the groups now live in a `.reader-control-grid`, and each group's option buttons are wrapped in `.reader-control-options` (label on its own line, buttons below).
- **`style.css`**: the panel is widened (`min(56rem, 100%)`) so the grid (`repeat(auto-fit, minmax(14rem, 1fr))`) gets multiple columns; summary styled as a clickable heading.

## Verification

- Full suite **264 green** (the reading/preferences tests render the page and assert on the buttons/hx-attrs — all pass through the restructure); lint clean.
- **Axe-clean** — rendered the real reading view locally and scanned: **0 serious/critical, 0 non-blocking**. Native `<details>`/`<summary>` is accessible; buttons still target `#reading-surface-style`; the aria-pressed sync script is document-delegated and unchanged.
- The CI `a11y` job (which renders the reading surface) also exercises the new controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)