### PR TITLE
docs(journal): log 2026-06-12 reading-surface UX session

### DIFF
--- a/reports/session-journals/2026-06-12.md
+++ b/reports/session-journals/2026-06-12.md
@@ -1,0 +1,72 @@
+# Session Journal — 2026-06-12
+
+*(Short session. Prior segment: `2026-06-11.md`.)*
+
+## 1. Session Summary
+
+A reading-surface UX session, all from the user testing the live app. Fixed a
+real cross-machine bug — the reading width rendered differently on different
+computers at the same setting — then polished the preference controls: moved
+them to the top of the page and made them a collapsible grid instead of a tall
+column at the bottom. Board ends at **0 open issues / 0 open PRs**.
+
+## 2. Tickets Delivered
+
+| Ticket | PR | What changed | Tests |
+|---|---|---|---|
+| #154 BUG-6: width inconsistent across computers | #155 | `max_width` switched from `ch` to `em` (values + default + sidebar labels + CSS fallbacks). `ch` is the font's `0`-glyph width, so with system-font stacks (no bundled webfonts) it rendered a different pixel width per machine. `em` depends only on `--reader-size` (fixed px) → consistent across computers AND still scales with the size pref. `with_defaults` normalizes legacy stored `ch` widths → `em`. | +6 |
+| #156: preference controls at the bottom | #157 | Relocated the `.reader-controls` block to the top of the reading view (after the style block, before the passage) so settings are reachable without scrolling. Pure placement; toggles + aria-pressed sync unchanged. | (existing) |
+| (polish) collapsible + grid controls | #158 | Wrapped the controls in `<details open>` ("Reading preferences" summary) — shown by default, foldable — and laid the groups out in a responsive auto-fit grid (label over wrapping buttons) instead of one tall column; panel widened for multiple columns. | (existing) |
+
+## 3. Tickets In Review
+
+None — all merged.
+
+## 4. Challenges and Mitigations
+
+| Challenge | Root cause | Mitigation | Prevention |
+|---|---|---|---|
+| Same width setting rendered a different column width per computer | `max_width` used `ch` (the font's `0`-glyph width); the font options are system stacks with no bundled webfonts, so the *rendered* font — and thus `ch` — varied by machine (system-ui = SF on macOS / Segoe UI on Windows, serif fallbacks differ) | Switched to `em` (relative to the fixed-px `--reader-size`): machine-consistent AND still scales with the size pref (which `ch` did and `rem` wouldn't) | Avoid `ch` for layout dimensions unless the font is a guaranteed (bundled) webfont; prefer `em`/`rem` |
+| Existing users would keep the old `ch` width until re-picking | Stored prefs render verbatim; the bug-reporter likely had a stored `ch` value | `with_defaults` normalizes a legacy `ch` width → its `em` equivalent (with a default fallback), so the fix applies without a re-pick | When changing a stored-value's unit/format, normalize legacy values on read |
+| "Settings at top" risked burying the passage | Always-open controls above the text push the reading content down | Shipped the move (per the explicit request) and flagged the trade-off; the user then asked for the collapsible-grid follow-up, which keeps it compact | Surface UX trade-offs in the PR rather than silently choosing |
+
+## 5. Insights and Learnings
+
+### Technical insights
+
+- **`ch` is font-glyph-dependent and therefore machine-inconsistent without a bundled webfont.** It's the width of the rendered font's `0` glyph, so any column/measure sized in `ch` shifts when the browser falls back to a different font. For a per-user-font reading surface on system fonts, `em` (relative to the fixed-px size) is the right unit: consistent across machines, still scales with the size preference. `rem` would be consistent too but wouldn't scale with size.
+- **Normalize legacy stored values on read.** A tiny `ch`→`em` map in `with_defaults` made the unit change apply to existing users transparently — no data migration, no re-pick.
+- **Native `<details>`/`<summary>` is the cheap, accessible disclosure.** Collapsible preferences needed no custom JS or ARIA and stayed axe-clean.
+
+### Process insights
+
+- **The standalone-render axe scan keeps paying off.** Rendered the real reading view (with the new `<details>`/grid) and scanned it locally (0 violations) before pushing — caught nothing this time, but it's the cheap confidence that the restructure didn't regress the a11y gate.
+- **Ship the literal ask, flag the trade-off, let the user iterate.** "Move settings to top" → done + noted it pushes the text down → user asked for the collapsible-grid refinement. Two small PRs beat guessing the final shape up front.
+
+### Domain insights
+
+- The reading surface is now consistent and ergonomic across machines: same width everywhere, settings up top and out of the way. Combined with the prior arc (large-doc split, comprehension, isolated previews), the MVP reading experience is in good shape.
+
+## 6. Tickets Created
+
+| Ticket | Why |
+|---|---|
+| #154 BUG-6 | The cross-machine width bug |
+| #156 | Preference controls buried at the bottom |
+| (#158 shipped as a quick-fix polish, no separate ticket) | |
+
+## 7. Metrics
+
+- **PRs created / merged**: 3 (#155, #157, #158) — all merged
+- **Issues created / closed**: 2 created (#154, #156), 2 closed
+- **Tests added**: 6 (`with_defaults` normalization) + updated reading/preference assertions. Full suite 264 green
+- **Board state**: **0 open issues, 0 open PRs**
+
+## 8. Next Up
+
+Backlog is empty. Candidate directions:
+
+1. **M1 launch operator actions (not code)** — verify production magic-link email delivery; schedule the human WCAG audit (`docs/LAUNCH-CHECKLIST.md`). The real gates to "first users onboarded".
+2. **Reading polish (optional)** — align the back-link/controls containers precisely with the surface column (they resolve `em` against their own 16px font, ~11% narrower); offer a "collapsed by default" option if preferred.
+3. **a11y CI reliability** — retry on the intermittent `supabase start` flake.
+4. **Feature work** — driven by real Phase-1 user feedback once users land.


### PR DESCRIPTION
## Summary

Session journal for **2026-06-12** — a reading-surface UX session driven by live-app testing:

- **#155 (BUG-6 #154)** — reading width was inconsistent across computers at the same setting. Root cause: `max_width` used `ch` (the rendered font's `0`-glyph width), which varies on system-font stacks. Switched to `em` (consistent across machines, still scales with the size pref); `with_defaults` normalizes legacy stored `ch` widths → `em`.
- **#157 (#156)** — moved the preference controls to the top of the reading view so they're reachable without scrolling.
- **#158** — made the controls collapsible (`<details open>`) and laid them out in a responsive grid instead of one tall column.

Board ends at **0 open issues / 0 open PRs**.

## Test plan

- Docs-only change (adds `reports/session-journals/2026-06-12.md`); no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)