### PR TITLE
chore(config): align bot.reviewer=tck517 (closes #234)

### DIFF
--- a/.gembaflow-config.json
+++ b/.gembaflow-config.json
@@ -7,6 +7,6 @@
   },
   "bot": {
     "worker": "tck517",
-    "reviewer": "cubrox"
+    "reviewer": "tck517"
   }
 }


### PR DESCRIPTION
## Summary

One-line config fix: `.gembaflow-config.json` `bot.reviewer` changes from `cubrox` → `tck517` to match `bot.worker` (which was already `tck517` from #229's mid-session adjustment).

## Why

`tck517` has authenticated gh access on `cubrox/cubrox`; the `cubrox` account does not. Leaving `bot.reviewer=cubrox` would substitute the broken handle into any future `.claude/commands/*.md` that references `{{bot.reviewer}}` (e.g., a `pr-reviewer` agent invocation pattern).

No current command references `{{bot.reviewer}}`, so this is a latent fix — `substitute-config-placeholders.sh --check` is a no-op post-change.

Closes #234.

## Test plan

- [x] `jq '.bot' .gembaflow-config.json` shows both `worker` and `reviewer` = `tck517`
- [x] `bash scripts/substitute-config-placeholders.sh --check` exits 0
- [x] Pre-push hook clean (ruff + 271 pytest green)
- [ ] CI green on all checks (preview-deploy may still fail due to pre-existing WIF gap — see #200 / E3-T1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)