### PR TITLE
ci: split typecheck job into json-validate + version-parity (closes #233)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,24 @@ jobs:
             !starters/**
           config: '.markdownlint.json'
 
-  typecheck:
-    name: typecheck
+  # Split from the former `typecheck` umbrella (upstream PR vibeacademy/gembaflow#428;
+  # local backport per fork ticket #233). The two checks below run different things and
+  # fail for different reasons, so they're now separate jobs whose failure messages
+  # match their purpose. Branch protection ruleset 15886599 should require both.
+  json-validate:
+    name: json-validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
       - name: Validate JSON files
         run: ./scripts/validation/validate-json.sh
+
+  version-parity:
+    name: version-parity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
 
       - name: Validate version parity
         run: ./scripts/validation/validate-version-parity.sh


### PR DESCRIPTION
## Summary

Splits the combined `typecheck` job in `.github/workflows/ci.yml` into two separate jobs (`json-validate` and `version-parity`) so each check has its own GitHub check-run name and failure messages match their cause.

This is a local backport of upstream `vibeacademy/gembaflow#428`. The structural change didn't propagate via `template-sync.sh` because `.github/workflows/` isn't in `syncDirectories`. Caught during #231 verification when the branch-protection portion of #230's DoD couldn't land (the ruleset was supposed to require `json-validate` + `version-parity` but those check names didn't exist locally).

Closes #233.

## What changed

- `.github/workflows/ci.yml` (12 insertions, 2 deletions): replace one `typecheck` job with two jobs that mirror upstream v1.5.0 structure. Preserves local `actions/checkout@v6` pin.

## What did NOT change

- `npm run typecheck` on ci.yml line 206 — that's a separate concept (TypeScript script inside the `node` job), not a check-run name.
- `scripts/verify-bot-permissions.sh` deprecation aliases map — currently empty; the historical `typecheck → version-parity` rename is already documented in comments.

## Post-merge follow-up (per ticket #233 happy path step 4)

After this PR merges, update ruleset `15886599` via:
```bash
gh api repos/cubrox/cubrox > /tmp/ruleset-before.json
jq '.rules += [{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":false,"required_status_checks":[{"context":"json-validate"},{"context":"version-parity"}]}}]' /tmp/ruleset-before.json > /tmp/ruleset-patched.json
gh api -X PUT repos/cubrox/cubrox/rulesets/15886599 --input /tmp/ruleset-patched.json
```

This brings `main` under branch protection that gates on the two new check names. I'll do this immediately after you merge.

## Test plan

- [x] Pre-push hook clean (ruff + 271 pytest green)
- [ ] CI on this PR runs the two new jobs (`json-validate`, `version-parity`) and both pass
- [ ] CI on this PR does NOT run the old `typecheck` job (i.e., it doesn't reappear)
- [ ] All other jobs unchanged in pass/fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)