### PR TITLE
docs(237): switch production refs to new masterkey GCP project (also lands v4.1 plan)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,18 +161,19 @@ Every agent output MUST follow these patterns. Full spec: `docs/AGENT-OUTPUT-STA
 ### Project Information
 
 - **License**: BSL 1.1 (converts to Apache 2.0 after 3 years per release)
-- **Project Name**: Cubrox
-- **Repository**: https://github.com/vibeacademy/cubrox
-- **Project Board**: https://github.com/orgs/vibeacademy/projects/29
+- **Project Name**: Cubrox (rename to Masterkey in flight — see plan v4.1)
+- **Repository**: https://github.com/cubrox/cubrox
+- **Project Board**: https://github.com/users/cubrox/projects/2
 - **Tech Stack**: FastAPI + Jinja2 + HTMX on Python 3.12
 - **Database layer**: SQLModel + Supabase CLI migrations (`supabase/migrations/*.sql`)
-- **Platform**: Google Cloud Platform (Cloud Run)
+- **Platform**: Google Cloud Platform (Cloud Run) — GCP project `master-key-501023`
+- **Production URL**: https://masterkey-7dit3lvmhq-uc.a.run.app
 - **Database**: Supabase Postgres (Pro plan, branching enabled; project ref `gnswmcgaztcxslirulwm`)
 - **Auth**: Supabase Auth (GoTrue magic-link via `supabase-py`; JWT in HttpOnly cookie)
-- **Container Registry**: Artifact Registry
-- **Secrets**: Google Secret Manager
+- **Container Registry**: Artifact Registry (repo `masterkey` in `us-central1`)
+- **Secrets**: Google Secret Manager (project `master-key-501023`)
 - **Package manager**: uv
-- **Organization**: vibeacademy
+- **Organization**: cubrox (GitHub user account owning the repo + project board)
 - **LLM**: Anthropic Claude API (`claude-haiku-4-5` for comprehension questions, with prompt caching + Postgres result cache)
 - **PDF**: pdfplumber, in-process, ≤25 MB
 - **Observability**: Google Cloud Logging + Error Reporting

--- a/docs/LAUNCH-CHECKLIST.md
+++ b/docs/LAUNCH-CHECKLIST.md
@@ -7,9 +7,11 @@ pre-flight before each cohort expansion, not just the first launch.
 
 Project facts referenced below:
 
-- Production URL (current Cloud Run revision): `https://agile-flow-app-heo5ry7rua-uc.a.run.app`
-- Supabase project ref: `gnswmcgaztcxslirulwm`
-- Repo: https://github.com/vibeacademy/cubrox · Board: https://github.com/orgs/vibeacademy/projects/29
+- Production URL (current Cloud Run revision): `https://masterkey-7dit3lvmhq-uc.a.run.app`
+  - Legacy URL `https://agile-flow-app-heo5ry7rua-uc.a.run.app` is orphaned (previous GCP project inaccessible per 2026-06-30 pivot; runtime may still serve stale content but is not managed). See #237.
+- Supabase project ref: `gnswmcgaztcxslirulwm` (unchanged)
+- GCP project: `master-key-501023`
+- Repo: https://github.com/cubrox/cubrox · Board: https://github.com/users/cubrox/projects/2
 
 ---
 

--- a/reports/refactor/01-architecture-plan.md
+++ b/reports/refactor/01-architecture-plan.md
@@ -1,13 +1,62 @@
 # Refactor Plan: `cubrox` -> `masterkey`
 
 **Author:** System Architect persona
-**Date:** 2026-06-29
-**Status:** REVISED (v3) — added Phase -1 (framework alignment) per user request 2026-06-29
+**Date:** 2026-06-29 (v4 revision 2026-06-30)
+**Status:** REVISED (v4) — GCP pivot per operator decision 2026-06-30; v3 in-place-rename assumptions invalidated
 **Scope locked by:** product owner (see task brief)
 
 ---
 
 ## Changelog
+
+### v4.1 — 2026-06-30 — DevOps revision pass (addresses BC1/BC2/BC3 from `reports/refactor/02c-devops-signoff-v4.md`)
+
+DevOps returned **NEEDS_REVISION** on v4 with three blockers, all order-of-operations / executability issues (the v4 architecture itself is sound). This revision addresses each in place:
+
+- **BC1 resolved.** §6 reconciliation rows for #200 and #237 made explicit about the WIF dual-write contract. #200 is **REWORK, not CLOSE** — it executes the `cubrox/masterkey` binding as the dual-write step in the NEW project. #237's row gains a "**#237 body MUST include**" callout listing the corrected text the issue body needs to have (operator/orchestrator must edit #237 to match; this plan tells them what to write). Cross-referenced in §3 Phase 2 step 16's preamble.
+- **BC2 resolved.** Phase 2 / §6 #237 callout now specifies the full 5-env-var (actually 6 if including `GITHUB_REPOSITORY` for Step 7's secret push) invocation contract for `provision-gcp-project.sh`. Confirmed by reading `scripts/provision-gcp-project.sh` lines 402-478: `WIF_OWNER` is sourced from `GITHUB_OWNER` (or legacy `GITHUB_USERNAME`), NOT from `GITHUB_REPO`. `WIF_REPO_NAME` is the bare repo name within the owner. Defaults `ARTIFACT_REPO=agile-flow` (line 60) and `CLOUD_RUN_SERVICE=agile-flow-app` (line 800) WILL fire if not overridden. Required invocation documented in #237's body spec.
+- **BC3 resolved.** Phase 2 step 16's WIF verification mechanism changed from `rollback-production.yml workflow_dispatch` (which mutates traffic — `gcloud run services update-traffic` is not zero-side-effect) to `synthetic-monitor.yml workflow_dispatch` (which auths via WIF and probes the service URL with no traffic-shift). `synthetic-monitor.yml`'s `workflow_dispatch` trigger continues to work even when its `schedule:` block is commented out per Phase 1 step 13. R3 mitigation text updated to match.
+
+**Five new risks added to §4 from DevOps's review:** R21 (AR repo `agile-flow` default), R22 (placeholder Cloud Run service has no env vars; R13 still applies on first real deploy), R23 (API-enable list mismatch between #237 body and the script), R24 (Supabase webhooks unaffected — informational, no action), R25 (legacy GCP project may still be accruing charges despite IAM loss; operator should escalate via billing org).
+
+**Not changed:** every v4 piece DevOps accepted (Phase -1 status, Phase 1 unchanged, Phase 4 collapse to 3 steps, Phase 5 reduction, R19/R20 framing, dependency graph) is preserved unmodified.
+
+### v4 — 2026-06-30 — GCP pivot: legacy production project inaccessible; provision new GCP project as `masterkey` from day 1
+
+**What happened.** The operator lost access to the production GCP project that hosted the `agile-flow-app` Cloud Run service, deployer SA, WIF binding, Artifact Registry repo, and Secret Manager entries. The fork's existing production runtime (`agile-flow-app-heo5ry7rua-uc.a.run.app`) is orphaned — still serving from a no-longer-managed runtime, but we cannot touch it, snapshot it, rename it, or delete it. Operator's locked decisions, captured in #237's body:
+
+1. **Provision a fresh new GCP project as `masterkey` from day 1.** Skip the legacy `agile-flow-app` naming entirely. The Cloud Run service is `masterkey`, the AR repo is `masterkey`, and the GitHub repo `vars` (`CLOUD_RUN_SERVICE=masterkey`, `ARTIFACT_REPO=masterkey`) are set as part of provisioning — not in a separate flip step.
+2. **Supabase project `gnswmcgaztcxslirulwm` is unchanged.** Still accessible, still the data plane. No data migration.
+3. **Close #189 (WIF binding verification) as not-planned** — already done 2026-06-30 — and file #237 for the new-project provisioning. Both actions completed before this v4 revision.
+
+**What this invalidates from v3.** The v3 plan's core assumption ("rename Cloud Run service `agile-flow-app` → `masterkey` in place, keep GCP project ID") no longer holds:
+
+- **Phase 0 step 2 snapshots** of the old service / revisions / SA IAM / secrets list are unobtainable (no access to the old project). The four `snapshots/*.pre-rename.yaml` files are not gettable; Phase 0's `S2`-mandated artifacts collapse to the GitHub-only inventory work (#187).
+- **Phase 2 step 16 (WIF dual-write)** is moot — there's no old `cubrox/cubrox` binding to dual-write from. #237 provisions WIF cleanly in the new project, bound to `cubrox/cubrox` initially (since the repo isn't renamed yet). The remaining decision (folded into Phase 2 below): after `gh repo rename` (step 17 / E3-T2), either add a SECOND WIF binding for `cubrox/masterkey` then prune the old one, or re-run the provision script's WIF setup pointing at the renamed repo.
+- **Phase 3 (Cloud Run + AR preparation)** mostly collapses into #237. The "pre-create masterkey AR repo + Cloud Run service in the same project as the old one" sequence becomes "the new project IS the masterkey project, and its first deploy IS the masterkey service" — no pre-create-then-cutover dance needed. Phase 3 becomes a verification-only stage post-#237: confirm the new service is healthy, capture its URL, update Supabase Auth allowlist with the new URLs, and (if desired) run a dry-run preview-deploy.
+- **Phase 4 (Cutover)** is dramatically simplified. The v3 var-flip race window (B7) does not exist — there is no old GCP project to flip FROM. `vars.CLOUD_RUN_SERVICE=masterkey` and `vars.ARTIFACT_REPO=masterkey` are set as part of #237's GitHub-secrets / vars rotation; from that point onward, all CI deploys (preview AND production) land on the new `masterkey` service. The Phase 1 PR merge's `deploy.yml` run lands on `masterkey` directly — not on `agile-flow-app` first then re-deployed after a flip.
+- **Phase 5 cleanup** loses three of its most destructive steps: we cannot delete the old Cloud Run service (no access), cannot delete the old AR repo (no access), and cannot prune the old WIF binding in the old project (no access). The legacy production URL `agile-flow-app-heo5ry7rua-uc.a.run.app` continues to resolve from the orphaned runtime indefinitely — we have to enumerate external references and either redirect or replace them (new R20).
+
+**What survives unchanged from v3.**
+
+- **Phase -1 (framework alignment to gembaflow v1.5.0)** is DONE — closed via PR #232 (2026-06-30) and follow-up PRs #235 (#234 closed) and #236 (#233 closed). The local fork is at v1.5.0 with `.gembaflow-*` dotfiles.
+- **Phase 1 (codebase rename PR)** is entirely unaffected by the GCP pivot. The 8 sub-tickets (#192-#199) cover identifier renames in `app/`, `tests/`, `templates/`, `ci.yml`, the two `.gembaflow-overrides`-listed scripts, agent persona files, `supabase/config.toml`, and the synthetic-monitor schedule disable. The preview-deploy concern from v3 Phase 1 step 15 (preview goes to the old service) is resolved differently: once #237 lands, the preview-deploy lands on `masterkey` from the start.
+- **Repo rename (#201 / E3-T2)** is unchanged — still `gh repo rename masterkey`, still triggers cascade local-remote updates, still needs Supabase GitHub App allowlist verification (R10).
+- **Project board migration (#202 + #203)** — #202 (create new board) is partially done (board #2 created on the cubrox user account); ticket-content migration of 67 items (#203) is still valid work.
+- **Supabase GitHub App allowlist re-verification** (#209 / E4-T6) still valid post-repo-rename.
+- **Memory MCP audit (#222), ADR-007 (#223), Cloud Logging filter updates (#221)** — all still valid, mostly cosmetic post-pivot.
+- **Synthetic monitor disable/restore (#199 / #215)** still valid — the cron risk during cutover is the same shape regardless of GCP project identity.
+
+**Risk register changes.**
+
+- **R3 (WIF binding correctness)** — RESOLVED. #237 provisions WIF cleanly in the new project from day 1; the dual-write dance is replaced by a single binding that will need adjustment after the repo rename (handled by re-running `scripts/provision-gcp-project.sh` against the new repo name, OR by an explicit add-binding then remove-binding pair).
+- **R19 (NEW)** — GCP billing on the new project. Operator's billing org may have quota or cost surprises (default Cloud Run service quotas vs. project, AR storage cost, Cloud Logging cost). Mitigation: enable billing alerts during #237.
+- **R20 (NEW)** — DNS / external links pointing at the legacy production URL `agile-flow-app-heo5ry7rua-uc.a.run.app`. Anything linking to it will 404 or serve a stale runtime once the new prod URL is live. Need to enumerate external references (`rg agile-flow-app-heo5ry7rua` across the repo + Slack history + any blog posts) and either redirect or accept-and-document.
+- All other risks (R1, R2, R4-R18) that don't depend on the old project survive unchanged.
+
+**Ticket renumbering.** None. v3's E-series IDs are preserved; v4 reuses them with explicit reconciliation actions documented in the new **§6 Backlog reconciliation post-pivot** table below. v3's "Phase 2 step 16" WIF dual-write is removed (now an explicit "DROP" row in §6 against #200); the Phase 4 var-flip steps (E5-T3, E5-T4) become trivial "verify vars already set" rather than actively flipping. Old step numbers 27-40 remain referenced in the §3 phase descriptions but are flagged "OBSOLETE" where the GCP pivot eliminates their substance.
+
+**One-paragraph net effect.** The pivot turns the most operationally fragile parts of v3 (the dual-state Cloud Run window, the var-flip race, the WIF dual-write timing, the destructive Phase 5 deletions) into "non-events" — they collapse into #237's clean from-scratch provisioning. The remaining work is mostly: do Phase 1 (codebase rename) as planned, rename the repo, migrate the board contents, and audit the new production URL. The trade-off is permanent loss of the legacy `agile-flow-app` runtime (we can't snapshot, can't roll back to it, can't gracefully redirect from it) — but since we'd lost ownership anyway, that trade was already made.
 
 ### v3 — 2026-06-29 — added Phase -1 (framework alignment) per user request 2026-06-29
 
@@ -43,12 +92,14 @@
 
 ## 1. Executive summary
 
-- **The rename is a codebase / infra identifier change, not a brand change.** The user-facing product is already "Master Key" in `templates/home.html`, `passages_new.html`, `reading.html`, and `tests/test_home.py`. The string "Cubrox" only appears in technical artifacts: repo slug, package metadata, env-var prefixes, browser globals, Supabase project-id (local), test-seed package name, and developer docs. No marketing copy or sign-in flow needs to change.
-- **Two distinct namespaces collapse into one after this work.** Today the repo is `cubrox/cubrox` on GitHub (confirmed via `git remote`), but the project board is still on the legacy `vibeacademy` org (`orgs/vibeacademy/projects/29`). After the rename, both will live under `cubrox/*` — repo at `cubrox/masterkey`, new board at `orgs/cubrox/projects/<new-id>` with all tickets migrated.
-- **The Cloud Run service is currently named `agile-flow-app`, not `cubrox`.** This is a holdover from the upstream framework defaults (`vars.CLOUD_RUN_SERVICE` was never overridden — `docs/LAUNCH-CHECKLIST.md` line 10 shows the live URL `agile-flow-app-heo5ry7rua-uc.a.run.app`). The rename is therefore *also* the moment we finally give this service a project-specific name. **This is a destructive Cloud Run service rename and the highest-risk part of the plan** (see Risk Register §4).
-- **Ephemeral preview deploys are the most fragile surface.** They depend on a per-service revision tag (`pr-N`) and a comment on the PR. The rename must hit Cloud Run service name + Artifact Registry repo + GitHub Actions `vars` atomically with the repo rename, or in-flight PRs will start failing.
-- **Framework artifacts (Agile Flow) stay named as-is.** `pyproject.toml`'s `name = "agile-flow-gcp"` is the framework template name, not the product. `template-sync.sh` and the upstream URL in `.agile-flow-version` (`vibeacademy/agile-flow`) point at the *upstream framework*, which is unrelated to this product rename. Touching them would break upstream sync. **However**, two `.agile-flow-overrides`-listed scripts (`provision-gcp-project.sh`, `diagnose-cloudrun.sh`) DO need edits — they hardcode `agile-flow-app` as the default service name (B4).
-- **WIF authentication is the highest-leverage "stuck in the middle" failure mode** (B2). The repo pin lives on the deployer SA's IAM policy as a `principalSet` member, not on the WIF provider's attribute condition. Phase 2 step 16 dual-writes the binding for the new repo name BEFORE the rename so no GCP-touching workflow ever sees an unauthorized request.
+**v4 update (2026-06-30):** the GCP pivot reshapes this summary. Bullets below are kept for v3 context; v4-specific framing is added inline as **v4 notes**.
+
+- **The rename is a codebase / infra identifier change, not a brand change.** The user-facing product is already "Master Key" in `templates/home.html`, `passages_new.html`, `reading.html`, and `tests/test_home.py`. The string "Cubrox" only appears in technical artifacts: repo slug, package metadata, env-var prefixes, browser globals, Supabase project-id (local), test-seed package name, and developer docs. No marketing copy or sign-in flow needs to change. **v4 unchanged.**
+- **Two distinct namespaces collapse into one after this work.** Today the repo is `cubrox/cubrox` on GitHub (confirmed via `git remote`), but the project board is still on the legacy `vibeacademy` org (`orgs/vibeacademy/projects/29`). After the rename, both will live under `cubrox/*` — repo at `cubrox/masterkey`, new board at `users/cubrox/projects/<new-id>` (note: cubrox is a user account, not an org — board #2 already created 2026-06-30). All tickets migrated via #203.
+- ~~**The Cloud Run service is currently named `agile-flow-app`, not `cubrox`.**~~ **v4 REPLACES:** The legacy Cloud Run service `agile-flow-app` lives in a GCP project the operator lost access to 2026-06-30. It is orphaned and outside our control. #237 provisions a brand-new GCP project, and the Cloud Run service in that project is named `masterkey` from day 1. **There is no destructive Cloud Run service rename in v4** — the new service simply doesn't exist until #237 creates it.
+- **Ephemeral preview deploys are the most fragile surface.** They depend on a per-service revision tag (`pr-N`) and a comment on the PR. **v4 update:** the atomic-flip-with-rename concern is dissolved — once #237 sets `vars.CLOUD_RUN_SERVICE=masterkey`, all preview deploys go to the new service from then onward, with no flip event to coordinate.
+- **Framework artifacts (Gemba Flow) stay named as-is.** `pyproject.toml`'s `name = "agile-flow-gcp"` is the framework template name, not the product. (Note: v3 said "Agile Flow"; Phase -1's framework upgrade made this "Gemba Flow" at the framework layer.) **However**, two `.gembaflow-overrides`-listed scripts (`provision-gcp-project.sh`, `diagnose-cloudrun.sh`) DO need edits — they hardcode `agile-flow-app` as the default service name (B4). v4 note: `provision-gcp-project.sh` was used to provision the new project via #237, so its rename matters going forward for any future operator re-running it.
+- **WIF authentication is no longer the highest-leverage "stuck in the middle" failure mode in v4.** The fresh provisioning in #237 establishes a known-good baseline; Phase 2 step 16's dual-write (now executed against the new project, not the legacy one) handles the residual repo-rename risk. **The new highest-leverage risk in v4 is R19 (GCP billing surprises) and R20 (orphaned legacy URL still serving from the inaccessible project).**
 
 ---
 
@@ -198,6 +249,8 @@ Numbered, with explicit rollback points (RB-N) and "what's safe to interleave" a
 
 ### Phase -1: Framework alignment (gembaflow v1.5.0)
 
+**v4 STATUS: COMPLETED (2026-06-30).** Landed via PRs #232, #235, #236. Closed tickets: #224 (epic), #225-#231 (sub-tasks), #233 (json-validate ruleset split), #234 (bot.reviewer alignment). The local fork is at gembaflow v1.5.0 with `.gembaflow-*` metadata. The body of this section is retained as historical record; no further action required.
+
 This phase exists because upstream renamed `vibeacademy/agile-flow` → `vibeacademy/gembaflow` and shipped v1.5.0 while we sat on v1.3.0. The local fork still has `.agile-flow-*` metadata files and CLAUDE.md / UPSTREAM.md / VERSIONING.md still say "Agile Flow". **This phase lands before the existing Phase 0** because the masterkey rename (Phases 0-5 below) touches the same `.agile-flow-overrides` file and the same agent persona files that the v1.5.0 sync auto-migrates. Sequencing matters: do the framework alignment first, get a clean baseline at v1.5.0 with `.gembaflow-*` dotfiles, THEN start the masterkey rename. The reverse order produces dual-state and merge-conflict pain.
 
 #### What changes
@@ -286,35 +339,25 @@ Pre-Phase-(-1) SHA captured in step (-1).1. Rollback is `git reset --hard <pre-P
 
 ### Phase 0 — Pre-flight (read-only, no production impact)
 
-1. Inventory all open + closed tickets on `orgs/vibeacademy/projects/29`. Export to a local JSON file. (`gh api graphql` with `node(id: $projectId) { items(...) }`.)
-2. Snapshot the existing state into `snapshots/` (per S2):
+**v4 STATUS: MOSTLY OBSOLETE.** Steps 2-4 (GCP snapshots, WIF binding shape verification, Cloud Logging enumeration) require access to the old GCP project, which the operator no longer has. They are unobtainable and dropped — see §6 reconciliation for ticket-level actions. The only steps still valid in v4 are step 1 (GitHub board inventory — #187), step 5 (open-PR check), and step 6 (forks enumeration). v4 Phase 0 collapses to "GitHub-side inventory only."
+
+1. Inventory all open + closed tickets on `orgs/vibeacademy/projects/29`. Export to a local JSON file. (`gh api graphql` with `node(id: $projectId) { items(...) }`.) **STILL VALID.**
+2. ~~Snapshot the existing state into `snapshots/`~~ **OBSOLETE — old project inaccessible.** All four snapshot artifacts (`agile-flow-app.pre-rename.yaml`, `revisions.pre-rename.yaml`, `sa-iam.pre-rename.yaml`, `secrets.pre-rename.yaml`) are unobtainable. Rollback artifacts are now only the snapshots of the NEW project that #237 takes after provisioning — which is a different category of artifact (forward-looking baseline, not backward-looking rollback).
    - `gcloud run services describe agile-flow-app --region=us-central1 --format=yaml > snapshots/agile-flow-app.pre-rename.yaml`
    - `gcloud run revisions list --service=agile-flow-app --region=us-central1 --format=yaml > snapshots/revisions.pre-rename.yaml`
    - `gcloud iam service-accounts get-iam-policy $SA_EMAIL --format=yaml > snapshots/sa-iam.pre-rename.yaml`
    - `gcloud secrets list --project=$GCP_PROJECT_ID --format=yaml > snapshots/secrets.pre-rename.yaml`
    These are the rollback artifacts if the new service goes sideways.
-3. **Verify WIF wiring.** Confirm the binding shape matches what `provision-gcp-project.sh` provisioned:
-   ```bash
-   SA_EMAIL=$(gcloud secrets versions access latest --secret=gcp-deployer-sa-email --project=$GCP_PROJECT_ID 2>/dev/null) \
-     || SA_EMAIL="<read from GCP_SERVICE_ACCOUNT secret>"
-   gcloud iam service-accounts get-iam-policy "$SA_EMAIL" \
-     --project=$GCP_PROJECT_ID --format=json \
-     | jq '.bindings[] | select(.role | IN("roles/iam.workloadIdentityUser","roles/iam.serviceAccountTokenCreator"))'
-   ```
-   Expect to see `principalSet://.../attribute.repository/cubrox/cubrox` for BOTH roles. Provider's attribute condition is `assertion.repository != ''` (trivially true) — confirm with `gcloud iam workload-identity-pools providers describe ... --format=value(attributeCondition)`. **There is nothing to edit at the provider level**; the work is at the SA IAM binding (Phase 2 step 16).
-4. Enumerate Cloud Logging / Monitoring assets (resolved Q7):
-   ```bash
-   gcloud logging metrics list --project=$GCP_PROJECT_ID
-   gcloud alpha monitoring policies list --project=$GCP_PROJECT_ID --format='value(displayName,combiner)'
-   gcloud monitoring dashboards list --project=$GCP_PROJECT_ID --format='value(displayName)'
-   ```
-   Most likely returns empty (per ADR-004); if non-empty, queue those entries for Phase 5 step 39.
-5. Confirm zero open PRs (preview deploys in flight are a hazard for Phase 4). If any exist, ask their authors to rebase after the rename — don't try to migrate live revision tags. Verified at v1 review time: `gh pr list --state open` returns `[]`.
-6. Enumerate external forks: `gh api repos/cubrox/cubrox/forks --jq '.[].full_name'` (per R15). If any exist, notify the fork owners.
+3. ~~**Verify WIF wiring.**~~ **OBSOLETE — old project inaccessible.** Closed via #189 (not-planned) 2026-06-30. The new project's WIF wiring is now an output of #237's provisioning, not a pre-flight verification.
+4. ~~Enumerate Cloud Logging / Monitoring assets~~ **OBSOLETE — old project inaccessible.** The expected output was empty anyway (per ADR-004); the new project starts empty by construction. Phase 5 step 39 collapses to a one-line confirmation that the new project's logging filters reference `service_name="masterkey"` correctly (which they do by default, since the service was created with that name).
+5. Confirm zero open PRs (preview deploys in flight are a hazard for the cutover window). If any exist, ask their authors to rebase after #237 lands and `vars.CLOUD_RUN_SERVICE` is set — don't leave preview deploys pointing at a non-existent old service. **STILL VALID.**
+6. Enumerate external forks: `gh api repos/cubrox/cubrox/forks --jq '.[].full_name'` (per R15). If any exist, notify the fork owners. **STILL VALID.**
 
 **RB-0:** Trivial — nothing changed.
 
 ### Phase 1 — Code-only changes on a feature branch
+
+**v4 STATUS: STILL VALID, unchanged scope.** The codebase rename PR (E2-T1 through E2-T8 / #192-#199) is GCP-independent. The only v3 detail that changes is Phase 1 step 15's preview-deploy expectation: in v3 the preview was expected to land on `agile-flow-app`; in v4 it lands on `masterkey` from the start (assuming #237 lands before Phase 1 PR is opened). The "live no-op proof" framing changes to "preview deploy validates new-project plumbing simultaneously with code rename."
 
 7. Branch: `feature/refactor-cubrox-to-masterkey`.
 8. Apply ALL §2.2 code/test/template renames AND `.github/workflows/ci.yml:218,307,315` rename (B1). Drive via:
@@ -330,26 +373,34 @@ Pre-Phase-(-1) SHA captured in step (-1).1. Rollback is `git reset --hard <pre-P
 12. Update `supabase/config.toml` `project_id`.
 13. **Disable synthetic monitor schedule for the cutover window** (resolved Q9): comment out the `schedule:` block in `.github/workflows/synthetic-monitor.yml` on this branch. Add a TODO in the PR body to restore it in a small follow-up PR after Phase 4 step 32.
 14. Run full local test suite: `uv run pytest`, `uv run ruff check`, `uv run ruff format --check`, `uv run mypy app/`, and `tests/a11y` (locally against `supabase start`).
-15. Open PR. **The preview deploy on this PR will still go to the old `agile-flow-app` service** because we haven't flipped `vars.CLOUD_RUN_SERVICE` yet. That's the validation: a green preview here proves the code rename is functionally a no-op.
+15. Open PR. **v4 update:** Once #237 is merged (sets `vars.CLOUD_RUN_SERVICE=masterkey` and `vars.ARTIFACT_REPO=masterkey`), the preview deploy on this PR lands on the NEW `masterkey` Cloud Run service in the new GCP project from the start. A green preview validates both the code rename AND the new-project plumbing simultaneously. (v3 narrative: "preview goes to old `agile-flow-app` to prove rename is a no-op, then re-deploy after var flip" — no longer applicable in v4.)
 
 **RB-1:** Close PR, no impact. Nothing has been deployed.
 
-### Phase 2 — GitHub repo + board migration + WIF dual-write (independent of code)
+### Phase 2 — GitHub repo + board migration + WIF re-bind for renamed repo (independent of code)
 
-Can run in parallel with Phase 1 (the code-only branch). Four operations; order matters within this phase — WIF binding MUST land before the repo rename.
+Can run in parallel with Phase 1 (the code-only branch). v4 reshapes step 16: the v3 "dual-write before rename" is replaced by "re-point the freshly-provisioned WIF binding at the renamed repo." Order within this phase still matters — WIF must work for `cubrox/masterkey` before the first CI run on the renamed repo, otherwise every workflow that authenticates to GCP starts failing with `iam.serviceAccounts.getAccessToken denied`.
 
-16. **WIF dual-write (NEW step, was 11.5 in DevOps review — must happen BEFORE the repo rename).** Add a parallel `principalSet` IAM binding on the deployer SA for `cubrox/masterkey` with BOTH `roles/iam.workloadIdentityUser` AND `roles/iam.serviceAccountTokenCreator`:
+16. **WIF re-bind after repo rename (v4 REPLACES v3's dual-write).** #237 provisions a single WIF binding on the new deployer SA for `principalSet://.../attribute.repository/cubrox/cubrox` (matching the repo name at provisioning time). Once #201 (repo rename) lands, GitHub's OIDC token will present `repository = cubrox/masterkey`, which won't match. **Architect's chosen approach: dual-write the new binding BEFORE running the repo rename, then prune the old one in Phase 5** — same shape as v3's plan, just executed in the new project instead of the old one. Reasons:
+    1. **Symmetry with the rest of the plan.** Every other piece of Phase 2 dual-writes (Supabase Auth allowlist keeps old + new entries, board exists in both places during migration). A WIF dual-write keeps the mental model uniform.
+    2. **Recoverability.** If the repo rename half-completes (e.g., GitHub UI hangs after the rename succeeds but before our local remote update), having both bindings live means CI doesn't immediately go red. Single-binding-pointed-at-`cubrox/masterkey` would mean any in-flight workflow run keyed to the old `cubrox/cubrox` reference fails.
+    3. **Cheaper than re-running `provision-gcp-project.sh`.** Re-running the provision script would attempt to re-create the SA, re-create the WIF pool, etc. — most steps would no-op idempotently, but it's a heavier hammer than `add-iam-policy-binding`.
+    4. **No cost overhead.** IAM bindings are free; the dual-state lasts only until Phase 5.
+
+    Concrete steps (executed against the NEW GCP project provisioned by #237):
     ```bash
-    SA_EMAIL=$(gcloud secrets versions access latest --secret=gcp-deployer-sa-email --project=$GCP_PROJECT_ID 2>/dev/null) \
+    SA_EMAIL=$(gcloud secrets versions access latest --secret=gcp-deployer-sa-email --project=$NEW_GCP_PROJECT_ID 2>/dev/null) \
       || SA_EMAIL="<read from GCP_SERVICE_ACCOUNT secret>"
-    PROJECT_NUMBER=$(gcloud projects describe $GCP_PROJECT_ID --format='value(projectNumber)')
+    PROJECT_NUMBER=$(gcloud projects describe $NEW_GCP_PROJECT_ID --format='value(projectNumber)')
     NEW_MEMBER="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/attribute.repository/cubrox/masterkey"
     for role in roles/iam.workloadIdentityUser roles/iam.serviceAccountTokenCreator; do
       gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" \
-        --role="$role" --member="$NEW_MEMBER" --project=$GCP_PROJECT_ID
+        --role="$role" --member="$NEW_MEMBER" --project=$NEW_GCP_PROJECT_ID
     done
     ```
-    The old `cubrox/cubrox` binding remains intact in parallel — both names resolve during the grace window. **Verify:** trigger `workflow_dispatch` on `rollback-production.yml` with `revision=<currentRevision>` and `reason='WIF binding verification'`. This auths to GCP but only acts on user-confirmed input — safe to dry-run. If the auth step passes, the binding is plumbed.
+    Old `cubrox/cubrox` binding stays intact in parallel until Phase 5 step 38. **Verify (v4.1 — BC3 fix):** trigger `workflow_dispatch` on `synthetic-monitor.yml` against the new service. It auths via WIF (lines 59-61 mirror `deploy.yml`), resolves the service URL via `gcloud run services describe masterkey`, and runs the auth probe. **Why this and not `rollback-production.yml`:** `rollback-production.yml` does NOT have a dry-run mode — supplying `revision=<currentRevision>` causes `gcloud run services update-traffic` (lines 100-108) followed by a smoke test (lines 127-146). On a fresh single-revision `masterkey` service that's an operational no-op, but it's NOT side-effect-free; on a multi-revision service or with a typo'd revision name, it actively reroutes traffic. `synthetic-monitor.yml workflow_dispatch` is side-effect-free except for sending a magic-link email to the smoke-test address (fine). The fact that Phase 1 step 13 commented out `synthetic-monitor.yml`'s `schedule:` block doesn't disable `workflow_dispatch` — those are independent triggers. If the WIF probe passes, the new binding is plumbed. **Recovery if it fails (per NS5):** re-run `scripts/provision-gcp-project.sh` with `GCP_PROJECT_ID=$NEW_GCP_PROJECT_ID GITHUB_OWNER=cubrox GITHUB_REPO=masterkey ARTIFACT_REPO=masterkey CLOUD_RUN_SERVICE=masterkey GITHUB_REPOSITORY=cubrox/masterkey` set — the script's idempotency (lines 414, 427) skips the pool/provider but the SA binding loop (line 466) adds the missing `cubrox/masterkey` principalSet binding without manual `gcloud iam` surgery.
+
+    **Why this instead of "re-provision in place against the renamed repo":** the operator's `scripts/provision-gcp-project.sh` reads `GITHUB_REPO` once and bakes it into the WIF binding. Re-running with `GITHUB_REPO=cubrox/masterkey` would add the new binding but would not remove the old one (the script is additive). Same net effect as the explicit `add-iam-policy-binding` calls above, but with hundreds of lines of script execution and the side-effect of re-touching the SA, AR repo, and project APIs (most no-op, some emit log noise). Explicit two-line bindings are auditable and minimal.
 17. **Repo rename:** `gh repo rename masterkey --repo cubrox/cubrox` (or via GH UI). GitHub auto-redirects git clone URLs for 30 days, but:
     - **Immediately** update local remotes on every developer machine: `git remote set-url origin git@github.com:cubrox/masterkey.git`.
     - Verify branch-protection ruleset (id 15886599) still applies: `gh api repos/cubrox/masterkey/rulesets` (per S3).
@@ -361,10 +412,26 @@ Can run in parallel with Phase 1 (the code-only branch). Four operations; order 
 
 ### Phase 3 — Cloud Run + Artifact Registry preparation (no traffic yet)
 
-20. Create new Artifact Registry repo `masterkey` in the same region: `gcloud artifacts repositories create masterkey --repository-format=docker --location=us-central1`.
-21. Grant the runtime SA `roles/artifactregistry.reader` on the new repo (usually inherited from project-level, but verify).
-22. **Build + push** an image to the new repo manually as a smoke test: `docker build -t us-central1-docker.pkg.dev/$PROJECT/masterkey/masterkey:smoke . && docker push ...`.
-23. **Pre-create** the Cloud Run service `masterkey` with a placeholder revision pointing at the smoke image, mounting the same secrets as `agile-flow-app`. **CRITICAL (B3 / R13):** match `deploy.yml`'s env-var TYPES exactly — `DATABASE_URL` and `ANTHROPIC_API_KEY` MUST be plain literals via `--set-env-vars`, NEVER `--set-secrets`. Cloud Run's literal-vs-secret env-var type is sticky per name; switching requires a destructive service recreate. Production currently uses literals (per `deploy.yml:216-217`); the placeholder must do the same:
+**v4 STATUS: REPLACED BY #237.** Steps 20-23 in v3 (pre-create AR repo, grant runtime SA reader, smoke-push image, pre-create Cloud Run service with sticky env-var types) are all absorbed into #237's provisioning of the new GCP project. There is no parallel "old service serving prod while we pre-create the new" window because there's no old service we can touch. Phase 3 collapses to a verification-only stage that runs **after #237 lands**:
+
+**v4 Phase 3 (replacement) — verification-only checklist:**
+
+1. Confirm `masterkey` AR repo exists in the new project: `gcloud artifacts repositories describe masterkey --location=us-central1 --project=$NEW_GCP_PROJECT_ID`.
+2. Confirm `masterkey` Cloud Run service exists and serves: `gcloud run services describe masterkey --region=us-central1 --project=$NEW_GCP_PROJECT_ID --format='value(status.url)'` returns a URL; `curl $URL/api/health` returns 200; `curl $URL/api/health/db` returns 200.
+3. **Critically:** verify env-var TYPES on the new service match `deploy.yml`'s shape (R13 still applies — the new project is fresh, but the first deploy still locks in env-var types per name). `gcloud run services describe masterkey --format=yaml | grep -E 'name: (DATABASE_URL|ANTHROPIC_API_KEY)' -A 2` — values must be literals, not `valueFrom: secretKeyRef:`. If #237 set them as secret-refs, the next `deploy.yml` will fail with the sticky-type error and we have to destructively recreate the service (which is much less painful in v4 than v3, but still annoying). **Architect's recommendation:** add an explicit check to #237's Definition of Done so this is caught at provisioning time, not at first-deploy time.
+4. Capture the new service URL `$NEW_URL` and pin it into `docs/LAUNCH-CHECKLIST.md` line 10 (and lines 12, 45-46, 51) plus `CLAUDE.md` Project Information block (per S6).
+5. Add Supabase Auth redirect allowlist entries for the new URLs (R4 + R12 — still valid):
+   - Production: `https://masterkey-<hash>-uc.a.run.app/auth/callback`
+   - Preview pattern: `https://pr-*---masterkey-*-uc.a.run.app/auth/callback`
+   - Do NOT remove old `agile-flow-app-*` entries — they're harmless (the old service still receives traffic from anyone with a stale link, and removing them only matters once the legacy runtime is decommissioned, which we cannot control).
+6. (Optional) Run a dry-run preview-deploy PR (mirrors v3's #208 / E4-T5). With `vars.CLOUD_RUN_SERVICE=masterkey` already set, this exercises preview-deploy + preview-cleanup + Supabase branching end-to-end. Less critical in v4 (no race condition to verify) but useful as a smoke test before Phase 1 PR lands. If skipped, the Phase 1 PR's own preview deploy serves the same role.
+
+The original step numbers (20-26) are OBSOLETE; they referenced operations against the old project that no longer exist. Below are the v3 step descriptions preserved as historical commentary — none should be executed in v4.
+
+~~20. Create new Artifact Registry repo `masterkey` in the same region~~ **OBSOLETE — folded into #237.**
+~~21. Grant the runtime SA `roles/artifactregistry.reader`~~ **OBSOLETE — folded into #237.**
+~~22. Build + push an image to the new repo manually as a smoke test~~ **OBSOLETE — first preview-deploy or production deploy serves this role.**
+~~23. Pre-create the Cloud Run service `masterkey` with a placeholder revision~~ **OBSOLETE — #237's first deploy creates the service; placeholder no longer needed since there's no old service serving prod to coexist with.**
     ```
     gcloud run deploy masterkey \
       --image=us-central1-docker.pkg.dev/$PROJECT/masterkey/masterkey:smoke \
@@ -378,29 +445,34 @@ Can run in parallel with Phase 1 (the code-only branch). Four operations; order 
       --no-traffic
     ```
     (Per resolved Q10: `--min-instances=0` for the placeholder, not 1 — the placeholder shouldn't actually run the smoke image hot. `deploy.yml:168` will flip it to 1 on the real Phase 4 deploy.) Then `--to-latest` traffic shift, but **only on the new service in isolation** — `agile-flow-app` still serves prod.
-24. Curl the new service's URL — `/api/health` (200), `/api/health/db` (200), then `/` (200, sees Master Key landing). **Capture the new URL** for `docs/LAUNCH-CHECKLIST.md` (B5):
+24. **v4 NOTE:** still valid as a verification step (folded into the "v4 Phase 3 verification-only checklist" above), but no longer "after pre-creating the service" — runs against the only-and-only `masterkey` service. Curl the new service's URL — `/api/health` (200), `/api/health/db` (200), then `/` (200, sees Master Key landing). **Capture the new URL** for `docs/LAUNCH-CHECKLIST.md` (B5):
     ```bash
     NEW_URL=$(gcloud run services describe masterkey --region=us-central1 --format='value(status.url)')
     echo "$NEW_URL"  # e.g. https://masterkey-aBcDeFgH-uc.a.run.app
     ```
     Amend the still-open Phase 1 PR (or open a small doc PR if Phase 1 has already merged) to pin `$NEW_URL` into `docs/LAUNCH-CHECKLIST.md` line 10, and `CLAUDE.md`'s Project Information block per S6. Update §2.C health-probe instructions (lines 45-46) and §2.D auth-test (line 51) of the launch checklist to reference `$NEW_URL`.
-25. **Dry-run preview-deploy + preview-cleanup against the new service (was Phase 4 R1 mitigation; now an explicit numbered step per S4).** Open a throwaway PR with a trivial change AND a `supabase/migrations/<timestamp>_rename_smoke.sql` empty file (per R10 — exercises the Supabase branching path). Confirm:
-    - First push (with `vars.CLOUD_RUN_SERVICE` still `agile-flow-app`): preview goes to the old service. ✓
-    - Flip `vars.CLOUD_RUN_SERVICE=masterkey` temporarily, push a new commit: preview-deploy run pushes to `masterkey/masterkey:pr-N-<sha>`, tags `masterkey` service, smoke-test passes, PR comment updates in place (verified by R1's marker-string match in v1). ✓
-    - Close the PR: preview-cleanup runs against `masterkey`, finds and removes the `pr-N` tag (handles missing-tag idempotently per workflow code). ✓
-    - **Flip the var BACK to `agile-flow-app` immediately** after the dry-run completes — Phase 4 step 27 needs the old var still in effect when Phase 1 PR merges.
-    - Label the dry-run PR `phase3-dryrun` so cleanup is easy to confirm.
-26. **Add the new service URL + preview pattern to the Supabase Auth redirect allowlist** (per R4 + R12). Both production URLs allowed simultaneously; old ones stay until Phase 5 cleanup. Patterns to add: `https://masterkey-<hash>-uc.a.run.app/auth/callback` (production) AND `https://pr-*---masterkey-*-uc.a.run.app/auth/callback` (preview).
+25. **v4 SIMPLIFIED:** Dry-run preview-deploy is now OPTIONAL. The var-flip race window that motivated v3's explicit dry-run does not exist in v4 (vars are at their target `masterkey` values from #237 onward; there's no flip-and-flip-back dance). If executed as a smoke test: open a throwaway PR with a trivial change plus a `supabase/migrations/<timestamp>_rename_smoke.sql` empty file (per R10 — exercises Supabase branching), confirm preview lands on `masterkey`, close PR, confirm cleanup. Skip the "flip var back" step. Label the dry-run PR `phase3-dryrun`. If skipped, Phase 1 PR's own preview deploy serves the same role.
+26. **v4 STILL VALID:** Add the new service URL + preview pattern to the Supabase Auth redirect allowlist (per R4 + R12). Patterns to add: `https://masterkey-<hash>-uc.a.run.app/auth/callback` (production) AND `https://pr-*---masterkey-*-uc.a.run.app/auth/callback` (preview). v4 note: old `agile-flow-app-*` entries can stay indefinitely since the legacy runtime is orphaned outside our control — removing them gains nothing operational.
 
-**RB-3:** Delete the `masterkey` service + Artifact Registry repo. Revert the temporary var flip done in step 25. No prod impact (the old `agile-flow-app` service was never touched).
+**RB-3 (v4):** Delete the `masterkey` service + Artifact Registry repo in the new project (if needed during early provisioning). No old prod to fall back to — the orphaned legacy runtime is not a rollback target since we cannot manage it. Effective rollback in v4 is "fix forward in the new project."
 
-### Phase 4 — Cutover (re-sequenced per B7 to eliminate the var-flip-before-merge race)
+### Phase 4 — Cutover (v4 dramatically simplified — no var-flip dance, no dual-state race)
 
-The v1 ordering had a race window where `vars.CLOUD_RUN_SERVICE=masterkey` could be live while the Phase 1 PR was still unmerged — meaning any preview-deploy fired between var flip and merge would try to push to the new AR/service with OLD code (which still references `CUBROX_TEST_SEED_ENABLED`). The new ordering ships exactly one risk per step.
+**v4 STATUS: COLLAPSED.** v3's B7-mandated re-sequencing (merge PR → verify old service → flip vars → trivial commit → verify new service) existed to eliminate a race window where `vars.CLOUD_RUN_SERVICE=masterkey` could be live while the Phase 1 PR was still unmerged. In v4 there is no flip — the vars are set as part of #237 and stay set. The Phase 1 PR's `deploy.yml` run lands on `masterkey` directly. The cutover collapses to: merge Phase 1 PR → verify new service → restore synthetic monitor.
 
-27. **Merge the Phase 1 PR** (vars STILL point at `agile-flow-app`). The merge triggers `deploy.yml`, which builds the post-rename code and deploys to the **old** `agile-flow-app` service. This is the live verification that the code rename is a functional no-op (satisfies Phase 1 step 15's acceptance criterion against production rather than just preview).
-28. **Verify production health on the old service URL** after the merge-triggered deploy. `curl https://agile-flow-app-heo5ry7rua-uc.a.run.app/api/health` and `/api/health/db`; run `scripts/smoke_auth.py` against the old URL. If any of these fail, **stop and roll back the merge** — do not flip vars while production is unhealthy.
-29. **Flip GitHub vars** (instantaneous, atomic from the deploy pipeline's perspective):
+**v4 Phase 4 (replacement, 3 steps):**
+
+1. **Merge the Phase 1 PR.** Triggers `deploy.yml`, which (with vars already set to `masterkey` from #237) builds the post-rename code into `masterkey/masterkey:<sha>` and deploys to the `masterkey` Cloud Run service in the new GCP project. The first real production deploy.
+2. **Verify `masterkey` production health.** `curl $NEW_URL/api/health`, `/api/health/db`, `/`. Run `scripts/smoke_auth.py` against `$NEW_URL`. Confirm Supabase magic-link round-trip succeeds (synthetic monitor is still disabled per E2-T8 — manual smoke is the only signal until step 3 runs).
+3. **Re-enable synthetic monitor** (E5-T6 / #215 — still valid). Open small follow-up PR restoring `schedule:` block. Next :17-past-hour run hits `masterkey`-resolved URL automatically.
+
+Steps 4-6 (announce new URL, prune Supabase allowlist 24-48h post-cutover, etc.) are still valid but mostly cosmetic in v4.
+
+**v3 step descriptions preserved as historical commentary — none should be executed in v4 against the original GCP project:**
+
+~~27. Merge the Phase 1 PR (vars STILL point at agile-flow-app)~~ **OBSOLETE — vars already point at masterkey from #237.** Merge still happens; just no longer carries the "live no-op proof against old service" framing.
+~~28. Verify production health on the old service URL~~ **OBSOLETE — old service inaccessible.** v4 verifies on `masterkey` only.
+29. ~~Flip GitHub vars~~ **OBSOLETE — done by #237.**
     ```bash
     gh variable set CLOUD_RUN_SERVICE --body masterkey
     gh variable set ARTIFACT_REPO --body masterkey
@@ -411,29 +483,41 @@ The v1 ordering had a race window where `vars.CLOUD_RUN_SERVICE=masterkey` could
 33. **Inform users / update external URL references.** If a custom domain is in play (currently isn't), no action. If we're on `*.run.app`, the user-facing URL has changed — announce the new URL. Update any docs that reference the production URL but were not touched in Phase 3 step 24.
 34. **Keep both Supabase Auth allowlist entries** (old + new, production + preview patterns) for 24-48h post-cutover. Phase 5 step 37 prunes the old ones.
 
-**RB-4 (critical rollback):**
-- If step 30's `deploy.yml` run fails: the new service either has a bad revision (use `gcloud run services update-traffic masterkey --to-revisions=<prev>=100`) or never deployed (the old service is still serving prod via the deploy from step 27, the rename is just stalled — fix the workflow and re-run).
-- If the deploy succeeds but real traffic shows breakage: `gh variable set CLOUD_RUN_SERVICE --body agile-flow-app` and `gh variable set ARTIFACT_REPO --body agile-flow`. Push another trivial commit to trigger `deploy.yml`. The old service was never deleted (Phase 5 hasn't run), so this is a clean revert.
-- The new service can be deleted once safe: `gcloud run services delete masterkey`.
-- If WIF auth fails despite the dual-write: confirm the new binding actually applied via `gcloud iam service-accounts get-iam-policy $SA_EMAIL`. The provider's attribute condition is trivially true, so the only possible cause is the binding not being present.
+**RB-4 (v4 — critical rollback):**
+- If Phase 1 PR merge's `deploy.yml` run fails: the new `masterkey` service either has a bad revision (use `gcloud run services update-traffic masterkey --to-revisions=<prev>=100 --region=us-central1`) or never deployed (fix the workflow and re-run). **There is no fallback to the old service** — the legacy `agile-flow-app` runtime in the inaccessible project is not a managed target.
+- If the deploy succeeds but real traffic shows breakage: fix-forward in the new project. Roll back the merge via `git revert` PR; the previous `masterkey` revision will be re-deployed.
+- If WIF auth fails despite the new binding: confirm the binding actually applied via `gcloud iam service-accounts get-iam-policy $SA_EMAIL --project=$NEW_GCP_PROJECT_ID`. The provider's attribute condition is trivially true (same as v3); the only possible cause is the binding not being present in the new project.
 
-### Phase 5 — Cleanup (30 days after cutover per resolved Q4, no rollback expected)
+### Phase 5 — Cleanup (v4 substantially simplified — no old project to clean up)
 
-35. Delete the old Cloud Run service: `gcloud run services delete agile-flow-app --region=us-central1`.
-36. Delete the old Artifact Registry repo (after confirming no images are pulled from it): `gcloud artifacts repositories delete agile-flow --location=us-central1`. Note: this is destructive and loses image history; archive the latest few image manifests first if forensics matter. **30-day grace window** lets us re-pull any commit-SHA-tagged image for incident triage.
-37. Remove the old `agile-flow-app-*.run.app` production URL AND the old `pr-*---agile-flow-app-*` preview pattern from the Supabase Auth redirect allowlist (per R12).
-38. **Remove the old WIF binding:**
+**v4 STATUS: ~50% of v3 work eliminated.** Steps 35, 36, 38 (delete old Cloud Run service, delete old AR repo, prune old WIF binding) all assumed access to the old GCP project. v4 cannot execute them — the project is inaccessible. The legacy runtime continues to serve indefinitely from a no-longer-managed deployment until Google reclaims it for non-payment or quota-eviction (timing unknown — could be months or years).
+
+What's still valid in v4 Phase 5:
+
+1. **WIF binding cleanup (v4-style).** If Phase 2 step 16 dual-wrote a `cubrox/masterkey` binding alongside the original `cubrox/cubrox` binding in the NEW project, prune the old one once stable:
     ```bash
     OLD_MEMBER="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/attribute.repository/cubrox/cubrox"
     for role in roles/iam.workloadIdentityUser roles/iam.serviceAccountTokenCreator; do
       gcloud iam service-accounts remove-iam-policy-binding "$SA_EMAIL" \
-        --role="$role" --member="$OLD_MEMBER" --project=$GCP_PROJECT_ID
+        --role="$role" --member="$OLD_MEMBER" --project=$NEW_GCP_PROJECT_ID
     done
     ```
-39. Update Cloud Logging saved queries, dashboards, and any alert policies enumerated in Phase 0 step 4 to reference `resource.labels.service_name="masterkey"`. Likely a no-op per ADR-004 (no custom alerts/dashboards configured), but verify.
-40. Close the `cubrox/cubrox` repo redirect note in CHANGELOG.
+2. **Remove old Supabase Auth allowlist entries (optional).** v4 note: this is a judgement call — the `agile-flow-app-*` entries are harmless and removing them gains nothing since the legacy URL is orphaned. Architect's recommendation: leave them for 6+ months, then audit.
+3. **Memory MCP audit.** Run `prune-memory` pass to rename "Cubrox" entities (R7). STILL VALID.
+4. **ADR-007 "Rename to Master Key / masterkey".** Write the architectural ADR per §2.6. STILL VALID. v4 version of the ADR should explicitly document the GCP pivot (project-lost-then-re-provisioned) as part of the consequences, since it's now a load-bearing fact of the rename history.
+5. **Doc / link cleanup.** v4 NEW scope — enumerate external references to `agile-flow-app-heo5ry7rua-uc.a.run.app` (R20) and either redirect them (where we control the surface) or document them as legacy (where we don't). `rg agile-flow-app-heo5ry7rua` across the repo; check team-comms surfaces.
+6. **CHANGELOG entry.** Close out the rename with a CHANGELOG note documenting the new production URL + the orphaned legacy URL.
 
-**RB-5:** Past this point, rollback means re-creating from snapshots (Phase 0 step 2). Don't run Phase 5 until Phase 4 has been stable for at least 30 days.
+v3 step descriptions preserved as historical commentary — none should be executed in v4:
+
+~~35. Delete the old Cloud Run service `gcloud run services delete agile-flow-app`~~ **N/A — old project inaccessible.**
+~~36. Delete the old Artifact Registry repo~~ **N/A — same reason.**
+~~37. Remove the old `agile-flow-app-*.run.app` allowlist entries from Supabase~~ **Optional in v4; see step 2 above.**
+~~38. Remove the old WIF binding for `cubrox/cubrox` in the old project~~ **N/A — that project is inaccessible.** The v4 analogue is pruning the same-shape binding in the NEW project after the repo rename (step 1 above).
+~~39. Update Cloud Logging saved queries in old project~~ **N/A — old project inaccessible.** The new project starts empty by construction; no inherited filters to update.
+~~40. Close the `cubrox/cubrox` repo redirect note in CHANGELOG~~ **STILL VALID** — folded into step 6 above.
+
+**RB-5 (v4):** Past this point, rollback means re-provisioning from scratch (re-run #237's provisioning recipe) plus re-applying the Phase 1 code rename. Phase 0 snapshots are unobtainable; the only "snapshot" we have is `scripts/provision-gcp-project.sh` itself plus this plan document. Don't run v4 Phase 5 step 1 (WIF prune) until the new service has been stable for at least 30 days.
 
 ---
 
@@ -465,16 +549,18 @@ The v1 ordering had a race window where `vars.CLOUD_RUN_SERVICE=masterkey` could
 - Phase 5 step 36: archive image manifests before deleting AR repo.
 - Cloud Logging retains logs by project + resource label for 30 days minimum (configurable); old service logs are still query-able as long as the project lives.
 
-### R3 — WIF auth fails after repo rename (REVISED per B2)
+### R3 — WIF auth fails after repo rename (v4: SUBSTANTIALLY MITIGATED by clean provisioning, residual risk addressed by Phase 2 step 16 dual-write in the new project)
 
-**Likelihood:** Certain if Phase 2 step 16 (dual-write) is skipped.
-**Impact:** Every workflow that authenticates to GCP starts failing with `iam.serviceAccounts.getAccessToken denied`. `deploy.yml`, `preview-deploy.yml`, `synthetic-monitor.yml`, `rollback-production.yml`, `preview-cleanup.yml` are all affected. Production isn't down (last good revision still serves) but no new deploys can ship — including rollback. **This is the single most likely "stuck in the middle" failure mode.**
+**v4 STATUS:** Substantially resolved. #237 provisions WIF cleanly in the new project from day 1 (bound to `cubrox/cubrox`, the repo name at provisioning time). The residual risk is that the binding doesn't auto-update when the repo is renamed to `cubrox/masterkey` — same mechanism as v3, but now executed against a project we know is correctly wired (since #237 just provisioned it). Phase 2 step 16's dual-write (now performed against the new project) addresses the residual risk identically to v3.
+
+**Likelihood (v4):** Low — the dual-write step is well-understood and the new project's WIF binding has a known-good baseline. Higher only if Phase 2 step 16 is skipped.
+**Impact:** Every workflow that authenticates to GCP starts failing with `iam.serviceAccounts.getAccessToken denied`. `deploy.yml`, `preview-deploy.yml`, `synthetic-monitor.yml`, `rollback-production.yml`, `preview-cleanup.yml` are all affected. Production isn't down (last good revision still serves) but no new deploys can ship — including rollback. **This was the single most likely "stuck in the middle" failure mode in v3; in v4 it's downgraded because the dual-write is now a one-time operation against a fresh project rather than a "modify the existing prod environment" operation.**
 
 **Mechanism:** Per `provision-gcp-project.sh:437-439, 465-474`, the WIF provider's attribute-condition is trivially true (`assertion.repository != ''`). The repo pin lives on the **deployer SA's IAM policy** as `principalSet://.../attribute.repository/cubrox/cubrox`, with BOTH `roles/iam.workloadIdentityUser` AND `roles/iam.serviceAccountTokenCreator`. After the repo rename, GitHub's OIDC token presents `repository = cubrox/masterkey`, which doesn't match the bound principalSet, so token-exchange fails. **There is nothing to change at the provider level** — the v1 plan's "edit the attribute condition" path was wrong.
 
 **Mitigation:**
 - Phase 2 step 16 dual-writes the new binding BEFORE the rename. The old binding stays alongside until Phase 5 step 38 removes it. Both names resolve for the entire grace window.
-- Verification: `workflow_dispatch` on `rollback-production.yml` with `revision=<current>` and `reason='WIF binding verification'` after step 16 but before step 17 (the repo rename).
+- Verification (v4.1 — BC3 fix): `workflow_dispatch` on `synthetic-monitor.yml` after step 16 but before step 17 (the repo rename). The workflow auths via WIF and probes the service URL — no traffic-shift side effect. Previously this called for `rollback-production.yml workflow_dispatch`, but that workflow mutates traffic via `gcloud run services update-traffic` and lacks a dry-run mode; DevOps flagged it as unsafe. `workflow_dispatch` on `synthetic-monitor.yml` works even though Phase 1 step 13 commented out its `schedule:` block — the two triggers are independent.
 - The per-repo binding kept narrow (not widened to org-level per resolved Q5) — accidental sibling repos created under `cubrox` never inherit deploy capability.
 
 ### R4 — Supabase magic-link sign-in breaks (redirect URL not in allowlist)
@@ -617,6 +703,83 @@ None of our internal code imports the package by its `pyproject.toml` name (the 
 - Step (-1).1 captures the pre-Phase-(-1) SHA AND a copy of v1.3.0 `template-sync.sh` to `/tmp/template-sync.v1.3.0.sh` as the bootstrap-of-bootstrapper rollback path.
 - `curl -fsSL` is used (lowercase `f` exits non-zero on HTTP error; `S` shows errors; `L` follows redirects) — explicit choice to fail loud on 404.
 
+### R19 — GCP billing on new project (NEW per v4)
+
+**Likelihood:** Medium. The operator's billing org may have quotas / budgets / limits that differ from the lost project's posture.
+**Impact:** First deploy fails with quota exhaustion or billing-not-enabled error; or, more insidiously, succeeds but consumes more budget than expected once preview deploys multiply (each preview is a separate Cloud Run revision drawing min-instance and request-billed CPU/memory).
+
+**Mitigation:**
+- #237's Definition of Done includes a billing-account verification step (confirm billing is enabled and a budget alert is set at ≥ $50/month threshold).
+- Audit default Cloud Run quotas via `gcloud compute project-info describe --project=$NEW_GCP_PROJECT_ID` post-provisioning; raise if needed before first deploy.
+- Verify Artifact Registry storage quota; default is multi-TB so unlikely to bind.
+- Enable Cloud Logging exclusion filters for noisy preview-deploy logs if cost ramp surprises (likely a no-op given low traffic).
+
+### R20 — External links pointing at legacy production URL (NEW per v4)
+
+**Likelihood:** Medium. The legacy URL `agile-flow-app-heo5ry7rua-uc.a.run.app` is referenced in `docs/LAUNCH-CHECKLIST.md` (line 10 and others), `CLAUDE.md`, possibly session journals, possibly older PR descriptions, possibly external surfaces (team Slack, blog posts, README badges). The legacy runtime continues to serve for an unknown period from the inaccessible project; eventually Google reclaims it for non-payment, after which the URL 404s.
+**Impact:** Two layered failure modes:
+1. **Short term (legacy runtime still up, possibly serving stale code):** users / scripts / docs that link to the old URL get a response — but it's from the orphaned runtime, NOT the new `masterkey` deployment. They see stale UI, stale data semantics, stale auth allowlist behavior. Confusing but recoverable.
+2. **Long term (legacy URL reclaimed):** anything still linking to it 404s. Less surprising than (1) but more disruptive if it happens during an active user session.
+
+**Mitigation:**
+- v4 Phase 5 step 5 enumerates external references via `rg 'agile-flow-app-heo5ry7rua' .` across the repo, plus a manual audit of team comms surfaces.
+- Update `docs/LAUNCH-CHECKLIST.md`, `CLAUDE.md`, and any other repo-controlled doc to point at the new `masterkey-*.run.app` URL (this is partially handled by E4-T3 / #206 already).
+- For external surfaces (blog, Slack history): add a sticky-pin note explaining the URL change. Cannot redirect at the DNS layer since we don't own a custom domain.
+- The session-journal historical record is intentionally NOT updated — it's a log, not a maintained reference (consistent with §6 policy).
+- Accept that the legacy URL will eventually 404 silently; this is the cost of losing project ownership and was already absorbed in the operator's pivot decision.
+
+### R21 — `provision-gcp-project.sh` defaults `ARTIFACT_REPO=agile-flow` if env var unset (NEW per v4.1 / DevOps)
+
+**Likelihood:** Certain if #237's happy-path step 4 omits `ARTIFACT_REPO=masterkey` (the current ticket body does omit it).
+**Impact:** Script creates an Artifact Registry repo named `agile-flow` in the new project. Subsequent CI deploys (with `vars.ARTIFACT_REPO=masterkey`) try to push to a `masterkey` AR repo that doesn't exist; deploy fails with `repository not found`. Operator now has a dead `agile-flow` AR repo in the new project + must create a `masterkey` repo separately. Re-running the script with the corrected env vars is idempotent (per `provision-gcp-project.sh:308`) but leaves the `agile-flow` repo as dead weight.
+
+**Mitigation:**
+- #237's body MUST explicitly set `ARTIFACT_REPO=masterkey` in step 4 (per the v4.1 §6 callout — BC2 correction). Same for `CLOUD_RUN_SERVICE=masterkey`.
+- #237's DoD MUST include `gcloud artifacts repositories describe masterkey --location=us-central1 --project=$NEW_GCP_PROJECT_ID` returning success (per the v4.1 §6 DoD check 2).
+- Overlap with B4-listed #196 (rename script defaults from `agile-flow*` to `masterkey*`) — but #196 lands in the Phase 1 PR AFTER #237 runs, so the rename doesn't help #237. Operator must override the defaults at invocation time.
+
+### R22 — Placeholder Cloud Run service ships with no env vars; R13 still applies on first real deploy (NEW per v4.1 / DevOps)
+
+**Likelihood:** Low for the steady state; medium if anyone manually `gcloud run deploy`s between #237 finishing and the first `deploy.yml` run.
+**Impact:** `provision-gcp-project.sh:800-825` creates the placeholder Cloud Run service with `--image=us-docker.pkg.dev/cloudrun/container/hello`, `--allow-unauthenticated`, `--port=8080`, and **no `--set-env-vars`**. First `deploy.yml` run uses `--update-env-vars` semantics (set/replace per the deploy.yml comment lines 192-196), so it creates all env vars as literals — matches the deploy.yml intent and works cleanly. **The R13 risk re-applies** only if anyone manually `gcloud run deploy`s with `--set-secrets DATABASE_URL=...` between #237 finishing and the first `deploy.yml` run; that would brick the service per Cloud Run's env-var-type stickiness, requiring destructive recreate.
+
+**Mitigation:**
+- Phase 3 verification checklist step 3 (already in plan) explicitly verifies env-var types match `deploy.yml`'s shape (literals for `DATABASE_URL` / `ANTHROPIC_API_KEY`, `valueFrom: secretKeyRef:` for Supabase keys).
+- #237's DoD check 4 (v4.1) explicitly runs `gcloud run services describe masterkey --format=yaml | grep -E 'name: (DATABASE_URL|ANTHROPIC_API_KEY)' -A 2` and requires empty output (or literal-only) — catches any manual `--set-secrets` interference before the first preview-deploy lands.
+- Operational convention: do NOT manually `gcloud run deploy` against `masterkey` between #237 finish and Phase 1 PR merge; let `deploy.yml` be the first thing to populate env vars.
+
+### R23 — API-enable list mismatch between #237 body and `provision-gcp-project.sh` (NEW per v4.1 / DevOps)
+
+**Likelihood:** Certain (the two lists disagree today).
+**Impact:** Low. #237's step 3 enables `run`, `artifactregistry`, `iamcredentials`, `cloudbuild`, `secretmanager` (5 APIs). `provision-gcp-project.sh:297-304` enables `run`, `artifactregistry`, `secretmanager`, `iam`, `iamcredentials`, `billingbudgets` (6 APIs). Differences: #237 includes `cloudbuild` (NOT used by `deploy.yml`, which does a local `docker build`); #237 OMITS `iam` (usually enabled by default on new projects, but if not, the script's own IAM-policy-binding calls fail) and `billingbudgets` (needed for R19's budget alert).
+
+If the operator runs #237 step 3 verbatim and skips step 4 (or runs them in either order), the resulting project may be missing `billingbudgets` (R19 mitigation breaks) and have `cloudbuild` enabled gratuitously (no impact, just a wasted enabled API). The script's step 5 (line 297-304) re-enables APIs idempotently, so running the script masks the issue — but only if step 4 runs at all.
+
+**Mitigation:**
+- #237's body (per v4.1 §6 callout) reconciles step 3's API list with the script's (use the script's 6-API list; drop `cloudbuild`).
+- Defense-in-depth: the script's idempotent re-enable in step 5 means even if #237 step 3 is wrong, running step 4 fixes it.
+
+### R24 — Supabase webhook URLs unaffected by GCP project change (NEW per v4.1 / DevOps — informational, no action)
+
+**Likelihood:** N/A (clarification, not a risk).
+**Impact:** N/A — read-only verification confirms no impact.
+
+**Note:** The Supabase GitHub App's per-PR branching webhooks point at supabase.com endpoints, NOT at our Cloud Run service. Switching GCP projects has no effect on those URLs. The Supabase Auth dashboard's redirect-URL allowlist IS scoped to OUR Cloud Run URLs (R4 / R12 still apply) but is keyed against the Supabase project (`gnswmcgaztcxslirulwm`), unaffected by GCP project changes. Logged here for completeness so a future reviewer doesn't re-investigate.
+
+### R25 — Old GCP project may still be accruing charges despite IAM access loss (NEW per v4.1 / DevOps)
+
+**Likelihood:** High. "Operator lost access" likely means lost IAM access to the project, not loss of the billing relationship — billing keeps running until the billing-org owner intervenes.
+**Impact:** Orphaned legacy runtime continues to accrue:
+- Cloud Run charges (`deploy.yml:168` hardcodes `--min-instances=1`, so the service draws min-instance billing 24/7).
+- Cloud Logging ingestion charges (logs retention is per-project; even orphaned services emit logs).
+- Artifact Registry storage charges for the historical image manifests.
+The cost is bounded (small Cloud Run service, low traffic) but not zero — likely tens of dollars per month, indefinitely, until the billing org owner shuts it down or Google reclaims the project for non-payment of an unrelated invoice.
+
+**Mitigation:**
+- Operator should file a billing-org case to either (a) regain access enough to set `--min-instances=0` and stop logging ingestion, or (b) initiate project shutdown via the billing console (Project Settings → Shut down). Project shutdown is available to anyone with `roles/billing.admin` on the billing account regardless of project-level IAM, so this is achievable even without project-level access.
+- If (a) and (b) are both unavailable: accept the cost until Google reclaims the project for non-payment of some other invoice. The legacy URL `agile-flow-app-heo5ry7rua-uc.a.run.app` continues to serve from the orphaned runtime until that happens (R20 short-term failure mode).
+- Recommend operator at minimum escalate to the billing org owner before accepting indefinite charges. This is a one-email task, not a multi-step recovery.
+
 ---
 
 ## 5. Resolved decisions (was "open questions" in v1)
@@ -638,10 +801,193 @@ All ten v1 open questions have been resolved by DevOps. Folded into the plan as 
 
 ---
 
-## 6. Out of scope
+## 6. Backlog reconciliation post-pivot (v4 NEW)
+
+Explicit per-ticket actions in light of the GCP pivot. Three action verbs:
+
+- **KEEP** — ticket is unchanged in scope and acceptance criteria; just proceed.
+- **REWORK** — ticket's intent is still valid but the description / steps / DoD need editing for the new context. A "what changes" note is provided.
+- **CLOSE** — ticket is obsolete (the work no longer exists, or was never doable in the post-pivot reality). Close as not-planned with a comment pointing at this plan §6 row.
+
+This table is the to-do list for whoever does the post-pivot grooming pass. **No tickets are closed automatically by this plan revision; the operator (or PO) executes the reconciliation table.**
+
+| # | Title (abbreviated) | Action | Reason / what changes |
+|---|---------------------|--------|------------------------|
+| #181 | Epic 1 — Phase 0 (epic) | REWORK | Narrow scope: GCP snapshot work N/A; epic is now GitHub-side inventory only (board items #187, open-PR check, forks). Update epic body to describe v4 narrowed scope. |
+| #182 | Epic 2 — Phase 1 (epic) | KEEP | Codebase rename PR is GCP-independent. Sub-tickets #192-#199 unchanged. |
+| #183 | Epic 3 — Phase 2 (epic) | KEEP | Repo rename + board migration + WIF re-bind (in new project). Sub-ticket #200's intent shifts (see below) but epic shape is the same. |
+| #184 | Epic 4 — Phase 3 (epic) | REWORK | Narrow scope: most pre-create infra work is absorbed by #237. Epic becomes "verification + Supabase allowlist + optional dry-run". |
+| #185 | Epic 5 — Phase 4 (epic) | REWORK | Collapse to 3 steps: merge PR, verify masterkey health, restore synthetic monitor. The var-flip dance (#212, #213) and old-service health check (#211) disappear. |
+| #186 | Epic 6 — Phase 5 (epic) | REWORK | Half the work is N/A (old project inaccessible). Epic now: WIF prune in new project, Memory MCP audit, ADR-007, doc cleanup including new R20. |
+| #187 | Inventory `vibeacademy/projects/29` | KEEP | Still valid; feeds #203 (board migration). |
+| #188 | Snapshot Cloud Run + SA IAM + secrets | CLOSE | Obsolete — old project inaccessible; cannot snapshot. |
+| #189 | Verify WIF binding shape | ALREADY CLOSED 2026-06-30 | Same reason; closed not-planned. |
+| #190 | Enumerate Cloud Logging | CLOSE | Obsolete — old project inaccessible. New project starts empty. |
+| #191 | Bundle Phase 0 snapshots into PR | CLOSE | Obsolete — nothing to bundle without #188/#190. |
+| #192 | Rename `CUBROX_TEST_SEED_ENABLED` env var | KEEP | Codebase change; GCP-independent. |
+| #193 | Rename `window.cubroxLineCount` | KEEP | Same. |
+| #194 | Rename app metadata strings | KEEP | Same. |
+| #195 | Rename `tests/a11y` package | KEEP | Same. |
+| #196 | Rename `provision-gcp-project.sh` + `diagnose-cloudrun.sh` defaults | KEEP | Same. Note: `provision-gcp-project.sh` was recently used by #237, so post-rename it documents the new project's recreation steps. |
+| #197 | Update `supabase/config.toml` + `CLAUDE.md` | REWORK | Add line for new GCP project ID. Add line for new production URL (gets a placeholder until #206 captures it). |
+| #198 | `.gembaflow-overrides` agent persona renames | KEEP | Same. |
+| #199 | Disable synthetic monitor schedule for cutover | KEEP | Same. The cutover window risk shape is identical. |
+| #200 | E3-T1 WIF dual-write | REWORK (v4.1 — explicitly NOT superseded by #237; BC1 / NS4) | **NOT superseded by #237.** #237 provisions ONE binding (`cubrox/cubrox`, matching the repo name at provisioning time); #200 adds the SECOND binding (`cubrox/masterkey`) on the same NEW project's deployer SA BEFORE `gh repo rename` fires (#201). Both bindings live in parallel through the rename and are pruned to one (`cubrox/masterkey` only) in Phase 5 via #220. Operator confirmed the dual-write approach 2026-06-30. **What changes vs. v3:** member URI uses `$NEW_GCP_PROJECT_ID`'s project number (not the legacy project's). DoD: verify both bindings exist on the new SA before #201 fires, via `gcloud iam service-accounts get-iam-policy $SA_EMAIL --project=$NEW_GCP_PROJECT_ID --format=json` showing two `principalSet://` entries (one per WIF role × principalSet). Verification dispatch is `synthetic-monitor.yml workflow_dispatch` against the new service (v4.1 BC3 — NOT `rollback-production.yml`, which mutates traffic). |
+| #201 | E3-T2 `gh repo rename cubrox/cubrox → cubrox/masterkey` | KEEP | Independent of GCP project identity. Pre-flight checklist still valid (drops the "vars unflipped" check since there's no flip). |
+| #202 | E3-T3 Create new project board | ALREADY DONE | Board #2 created on cubrox user account 2026-06-30. Close as done with link to board. |
+| #203 | E3-T4 Migrate 67 items from old board | KEEP | Independent of GCP. |
+| #204 | E4-T1 Create masterkey AR repo + grant SA reader | CLOSE | Obsolete — folded into #237's provisioning. Add a verification comment to #237 confirming AR repo + IAM binding exist. |
+| #205 | E4-T2 Pre-create Cloud Run masterkey service (R13 env-var types) | REWORK | Reframe as a verification-only ticket: confirm the `masterkey` service exists post-#237 with correct env-var types (`DATABASE_URL` + `ANTHROPIC_API_KEY` as literals, Supabase keys as `valueFrom: secretKeyRef:`). If #237 set them wrong, recreate the service before any preview deploy lands. |
+| #206 | E4-T3 Capture new service URL + pin to docs | KEEP | Still valid — runs against the post-#237 service. The "new URL" is just the masterkey service URL once #237 finishes. |
+| #207 | E4-T4 Add new Supabase Auth allowlist entries | KEEP | Still valid. v4 note: keep old `agile-flow-app-*` entries indefinitely (harmless; legacy URL is orphaned). |
+| #208 | E4-T5 Dry-run preview-deploy against masterkey | REWORK | Downgrade priority P0 → P1 (or P2). The race window it was meant to verify does not exist in v4. Useful as a smoke test but optional; Phase 1 PR's own preview serves the same role. |
+| #209 | E4-T6 Verify Supabase GitHub App allowlist post-rename | KEEP | Still valid; the rename still triggers the App allowlist re-verification. |
+| #210 | E5-T1 Merge Phase 1 PR with vars STILL `agile-flow-app` | REWORK | Drop the "with old vars" framing. Reframe as: "Merge Phase 1 PR; `deploy.yml` deploys to `masterkey` directly (vars are already set by #237)." Remove guardrails that check var values are still `agile-flow-app`. |
+| #211 | E5-T2 Verify agile-flow-app health post-merge | CLOSE | Obsolete — old service inaccessible and would not receive the new deploy anyway (vars point at masterkey from day 1 in v4). |
+| #212 | E5-T3 Flip GitHub vars to masterkey | CLOSE | Obsolete — done by #237. Optionally: rework to a one-line "verify `gh variable list` shows masterkey already set" check, but that's a 30-second task that doesn't need its own ticket. Close as superseded. |
+| #213 | E5-T4 Push trivial CHANGELOG commit to trigger deploy | REWORK | Demote to optional. v4 reframing: Phase 1 PR merge already triggers `deploy.yml`. A separate trivial-commit ticket is needed ONLY if Phase 1 PR is delayed and we want to verify deploy plumbing before then. Otherwise close as duplicate of #210. |
+| #214 | E5-T5 Verify masterkey service health after first real deploy | KEEP | Still valid — only verification step in v4 Phase 4. Becomes more important since there's no second-chance "old service serving prod" fallback. |
+| #215 | E5-T6 Re-enable synthetic monitor | KEEP | Pairs with #199. |
+| #216 | E5-T7 Announce new URL + update external references | KEEP | Still valid; folds in R20 enumeration work. |
+| #217 | E6-T1 Delete old Cloud Run service | CLOSE | N/A — old project inaccessible. |
+| #218 | E6-T2 Archive image manifests + delete old AR repo | CLOSE | N/A — same reason. |
+| #219 | E6-T3 Remove old Supabase Auth allowlist entries | REWORK | Demote to optional (P2 → P3). The old entries are harmless once the legacy runtime is orphaned. Architect's recommendation: leave them for 6+ months. |
+| #220 | E6-T4 Remove old WIF binding for cubrox/cubrox | REWORK | What changes: now refers to the binding in the NEW project (added by #237 at provisioning time, before repo rename). After Phase 2 step 16 dual-writes the `cubrox/masterkey` binding, this ticket prunes the `cubrox/cubrox` binding in the SAME new project. |
+| #221 | E6-T5 Update Cloud Logging saved queries | REWORK | Most likely closes as no-op (new project starts empty by construction; no inherited filters). Confirm and close. |
+| #222 | E6-T6 Memory MCP audit | KEEP | Still valid. |
+| #223 | E6-T7 Write ADR-007 + resolve PLATFORM-GUIDE drift | REWORK | Add to ADR-007 scope: document the GCP pivot (project-lost-then-re-provisioned) as a load-bearing fact of the rename history. |
+| #224-#231 | Phase -1 epic + sub-tickets | ALREADY CLOSED | Closed via PR #232 and follow-ups. |
+| #233 | json-validate ruleset split | ALREADY CLOSED | Closed via PR #236. |
+| #234 | bot.reviewer alignment | ALREADY CLOSED | Closed via PR #235. |
+| #237 | Provision new GCP project as masterkey from day 1 | REWORK BODY (v4.1 — BC1 + BC2) — KEEP scope, IN FLIGHT | The umbrella ticket that triggers this v4 revision. Must complete before #200 + #201 fire. **Body needs three edits — see `#237 body MUST include` callout below this table.** Scope of WORK is unchanged; only the ticket's body text changes. |
+
+#### `#237 body MUST include` callout (v4.1 — BC1 + BC2)
+
+The orchestrator must edit issue #237's body to reflect three corrections that the current body gets wrong. Plan content here is the authoritative spec for what the body should say. This plan does NOT edit the issue itself — that's the orchestrator's job.
+
+**Correction 1 — WIF dual-write IS required (BC1).** #237's current body says, in its "Blocks / supersedes" section, that #200 is "superseded; this ticket creates the binding fresh, no dual-write needed." That statement is WRONG and must be replaced. The correct statement:
+
+> **#200 remains REQUIRED — not superseded.** This ticket (#237) provisions ONE WIF binding on the new project's deployer SA for `principalSet://.../attribute.repository/cubrox/cubrox` (matching the repo name at provisioning time, since the rename has not yet happened). Before `gh repo rename cubrox/cubrox → cubrox/masterkey` fires (#201, Phase 2 step 17), #200 must add a SECOND parallel binding for `principalSet://.../attribute.repository/cubrox/masterkey` to the same SA, on the same new project. Without #200, every workflow that authenticates to GCP after the rename will fail with `iam.serviceAccounts.getAccessToken denied` — same R3 failure mode v3 was engineered to prevent. The dual-write is pruned to a single binding (`cubrox/masterkey`) in Phase 5 via #220. Operator confirmed this approach 2026-06-30.
+
+Any nearby text in #237 implying that "Epics 3-5 collapse" applies to Phase 2's WIF re-bind step is ALSO wrong and must be reworded — Phases 3 / 4 / 5 do collapse substantially per v4, but the Phase 2 WIF re-bind (step 16) is NOT collapsed; the dual-write executes as written above.
+
+**Correction 2 — `provision-gcp-project.sh` env-var contract (BC2).** #237's current happy-path step 4 invokes the provision script with `GCP_PROJECT_ID=<NEW> GITHUB_REPO=cubrox/cubrox bash scripts/provision-gcp-project.sh`. This is WRONG and causes silent skip of the entire WIF setup block. Verified by reading `scripts/provision-gcp-project.sh` lines 402-478:
+
+- Line 404: `WIF_OWNER="${GITHUB_OWNER:-${GITHUB_USERNAME:-}}"` — sources from `GITHUB_OWNER` or `GITHUB_USERNAME`, NOT from `GITHUB_REPO`.
+- Line 405: `WIF_REPO_NAME="${GITHUB_REPO:-agile-flow-gcp}"` — `GITHUB_REPO` is the BARE REPO NAME within the owner, not `owner/name`.
+- Line 407: `if [[ -n "$WIF_OWNER" ]]; then` — guards the entire WIF block (pool create, provider create, SA bindings).
+- Line 478: `[skip] WIF setup not requested (GITHUB_OWNER and GITHUB_USERNAME unset)` — silent skip path.
+- Line 60: `ARTIFACT_REPO` defaults to `agile-flow` if unset (R21).
+- Line 800: `SERVICE_NAME` defaults to `agile-flow-app` if `CLOUD_RUN_SERVICE` is unset.
+- Line 465: `WIF_MEMBER="principalSet://.../attribute.repository/${WIF_OWNER}/${WIF_REPO_NAME}"` — note the slash is inserted by the script, so passing `GITHUB_REPO=cubrox/cubrox` (with the slash already in it) would produce a malformed 3-segment URI even if `WIF_OWNER` were correctly set.
+- Line 862: GitHub-secrets push is gated on `GITHUB_REPOSITORY` being set; without it, secrets are printed rather than pushed.
+
+The correct invocation #237's step 4 must read:
+
+```bash
+GCP_PROJECT_ID=<new-project-id> \
+ARTIFACT_REPO=masterkey \
+CLOUD_RUN_SERVICE=masterkey \
+GITHUB_OWNER=cubrox \
+GITHUB_REPO=cubrox \
+GITHUB_REPOSITORY=cubrox/cubrox \
+bash scripts/provision-gcp-project.sh
+```
+
+Note: `GITHUB_REPO=cubrox` (bare repo name) because the GitHub slug is `cubrox/cubrox` (owner `cubrox`, repo `cubrox`); the `WIF_MEMBER` URI assembled by line 465 then correctly resolves to `.../attribute.repository/cubrox/cubrox`. `GITHUB_REPOSITORY=cubrox/cubrox` enables the Step 7 auto-push of `GCP_PROJECT_ID`, `GCP_SERVICE_ACCOUNT`, and `GCP_WORKLOAD_IDENTITY_PROVIDER` GitHub Actions secrets — without it #237's step 6 ("verify secrets") would be doing work that step 4 should have already done.
+
+**Correction 3 — Post-provisioning DoD checks (BC1 + BC2 + R19 + R22).** #237's Definition of Done must include the following one-line verification commands; each catches a v4.1-flagged failure mode before the next phase starts:
+
+1. `gcloud iam service-accounts get-iam-policy "$SA_EMAIL" --project="$NEW_GCP_PROJECT_ID" --format=json | grep -c 'principalSet'` MUST return ≥ 2 (two WIF roles × one binding for `cubrox/cubrox`). If 0, BC2 happened: WIF was silently skipped — re-run the script with the env vars above. (BC2 verification.)
+2. `gcloud artifacts repositories describe masterkey --location=us-central1 --project="$NEW_GCP_PROJECT_ID"` MUST succeed. If the script created `agile-flow` instead, R21 happened — set `ARTIFACT_REPO=masterkey` and re-run. (R21 verification.)
+3. `gcloud run services describe masterkey --region=us-central1 --project="$NEW_GCP_PROJECT_ID" --format='value(status.url)'` MUST return a URL. If it returns "service not found" or describes `agile-flow-app` instead, the `CLOUD_RUN_SERVICE` default fired — set the env var and re-run. (BC2 + R21 sibling check.)
+4. `gcloud run services describe masterkey --region=us-central1 --project="$NEW_GCP_PROJECT_ID" --format=yaml | grep -E 'name: (DATABASE_URL|ANTHROPIC_API_KEY)' -A 2` — the placeholder service has NO env vars per `provision-gcp-project.sh:800-825` (uses the hello image). First `deploy.yml` run populates them via `--update-env-vars` semantics. **R22 risk:** if anyone manually `gcloud run deploy`s with `--set-secrets DATABASE_URL=...` between #237 finishing and the first `deploy.yml` run, R13 (env-var type stickiness) bricks the service. DoD: confirm output is empty (or only contains literals matching `deploy.yml`'s shape) before the first preview-deploy lands. (R22 verification.)
+5. `gcloud billing projects describe "$NEW_GCP_PROJECT_ID" --format='value(billingEnabled)'` MUST return `True` AND `gcloud billing budgets list --billing-account=$BILLING_ACCOUNT --format='value(displayName)' | grep -c "$NEW_GCP_PROJECT_ID"` MUST return ≥ 1 (budget alert exists). If 0, R19 happened — operator must set up the budget alert manually via the billing console. (R19 verification, per NS1.)
+6. `gh variable list --repo cubrox/cubrox | grep -E 'CLOUD_RUN_SERVICE|ARTIFACT_REPO'` MUST show both as `masterkey`. If absent, the Step 7 auto-push was skipped because `GITHUB_REPOSITORY` was unset — set it and re-run, or push the vars manually with `gh variable set`. (BC2 sibling check.)
+
+Additionally: the API-enable list in #237's step 3 (`run`, `artifactregistry`, `iamcredentials`, `cloudbuild`, `secretmanager`) does NOT match `provision-gcp-project.sh:297-304` (`run`, `artifactregistry`, `secretmanager`, `iam`, `iamcredentials`, `billingbudgets`). The script's list is more accurate for our shape — `deploy.yml` does NOT use Cloud Build (it runs a local `docker build` then pushes), and `billingbudgets` is needed for R19's mitigation. Reconcile #237's step 3 to use the script's six-API list (`run`, `artifactregistry`, `secretmanager`, `iam`, `iamcredentials`, `billingbudgets`) and drop `cloudbuild`. (R23 reconciliation.)
+
+**Reconciliation summary (47 table rows covering 53 in-scope tickets — one row aggregates the 8 Phase -1 sub-tickets #224-#231; v4.1 updates #237's classification from KEEP to REWORK-BODY):**
+- **CLOSE** (obsolete): 8 tickets — #188, #190, #191, #204, #211, #212, #217, #218.
+- **REWORK** (intent valid; scope/steps change — includes 4 epic-body refreshes and v4.1's #237 body edit): 15 tickets — #181, #184, #185, #186, #197, #200, #205, #208, #210, #213, #219, #220, #221, #223, #237 (v4.1 — body edit only; scope unchanged).
+- **KEEP** (unchanged scope and acceptance criteria): 19 tickets — #182, #183, #187, #192, #193, #194, #195, #196, #198, #199, #201, #203, #206, #207, #209, #214, #215, #216, #222.
+- **ALREADY CLOSED / DONE pre-v4** (action: none): 11 tickets — #189 (closed 2026-06-30), #202 (board #2 created 2026-06-30), #224-#231 (Phase -1, PR #232), #233 (PR #236), #234 (PR #235).
+
+Net: of 53 in-scope tickets (#181-#223 + #233, #234, #237), v4.1 closes 8 as obsolete, reworks 15 (one of which is #237's body-only edit), keeps 19 unchanged, and inherits 11 already done. Critical chain shrinks from v3's 12 tickets to v4's 8 (unchanged in v4.1).
+
+---
+
+## 6.1 Updated dependency graph (v4)
+
+The v3 critical chain (`E1-T3 → E3-T1 → E3-T2 → E4-T2 → E4-T3 → E4-T4 → E4-T5 → E5-T1 → E5-T2 → E5-T3 → E5-T4 → E5-T5`) collapses substantially. v4 chain:
+
+```
+#237 (provision new GCP project as masterkey)
+   │
+   │   • new project ID, deployer SA, WIF binding (cubrox/cubrox)
+   │   • GitHub repo secrets rotated: GCP_PROJECT_ID, GCP_SERVICE_ACCOUNT,
+   │     GCP_WORKLOAD_IDENTITY_PROVIDER
+   │   • GitHub repo vars set: CLOUD_RUN_SERVICE=masterkey, ARTIFACT_REPO=masterkey
+   │   • first deploy creates `masterkey` Cloud Run service
+   ▼
+#187 (inventory legacy board)   ──┐
+#199 (disable synthetic monitor) ──┤  Parallel-OK with Phase 1
+ALL #192-#198 (Phase 1 code) ─────┤  ← single PR (Phase 1 PR)
+                                  ▼
+                            #200 (WIF dual-write for cubrox/masterkey
+                                  in NEW project — Phase 2 step 16)
+                                  │
+                                  ▼
+                            #201 (gh repo rename cubrox/cubrox → cubrox/masterkey)
+                                  │
+                                  ├──► #202 already done (board #2 created)
+                                  ├──► #203 (migrate 67 items)
+                                  ├──► #209 (Supabase GitHub App allowlist verify)
+                                  ▼
+                            #205 (verify masterkey service env-var types)
+                                  │
+                                  ▼
+                            #206 (capture URL → docs)
+                                  │
+                                  ▼
+                            #207 (Supabase Auth allowlist + new URLs)
+                                  │
+                                  ▼
+                            (optional) #208 (dry-run preview-deploy)
+                                  │
+                                  ▼
+                            #210 (merge Phase 1 PR → deploys to masterkey)
+                                  │
+                                  ▼
+                            #214 (verify masterkey health)
+                                  │
+                                  ▼
+                            #215 (re-enable synthetic monitor)
+                                  │
+                                  ▼
+                            #216 (announce new URL, R20 enumeration)
+                                  │                30-day timer
+                                  ╰─────────────────────────► Phase 5
+                                                #220 (prune cubrox/cubrox WIF
+                                                       binding in new project)
+                                                #221 (Cloud Logging — likely no-op)
+                                                #222 (Memory MCP audit)
+                                                #223 (ADR-007)
+                                                (#219 demoted to optional)
+```
+
+**v4 critical chain (8 tickets, was 12):** `#237 → ALL #192-#198 (Phase 1) → #200 → #201 → #205 → #207 → #210 → #214`.
+
+**What blocks the most downstream work in v4:** still #201 (repo rename). It unblocks: #203, #209, #205, #206, #207, #208, #210, #214, #215, #216, #220. Eleven downstream tickets — down from v3's 23, because Phases 3/4/5 are dramatically simpler.
+
+---
+
+## 7. Out of scope
 
 Explicitly NOT part of this refactor:
 
+- **Old GCP project recovery.** Per v4 operator decision 2026-06-30. The legacy project is abandoned; we don't attempt to regain access. (Was implicit in v3; explicit in v4.)
+- **Custom domain to mask the legacy URL.** v4 R20 documents the orphaned legacy URL as an accepted cost. A custom domain would cleanly cover it but remains deferred per resolved Q1 + Q6.
 - **GCP project ID rename.** Per locked scope. Would require recreating IAM bindings, WIF pool, secrets, the whole project — orders of magnitude more work.
 - **Supabase project ref change.** Per locked scope. Would require database migration, RLS re-deploy, JWT signing-key rotation, redirect-URL migration, magic-link template re-deploy, and a downtime window for the cutover. Out of scope.
 - **Supabase org rename.** If the Supabase org happens to be named `vibeacademy` in the dashboard, that's a separate change managed in the Supabase UI and not coupled to this refactor.
@@ -661,9 +1007,12 @@ Explicitly NOT part of this refactor:
 
 ---
 
-**Result:** Refactor plan revised (v2) for re-review.
-Scope: `cubrox` codebase + infra identifier rename to `masterkey`
-Recommendation: 5-phase staged cutover with pre-created Cloud Run service; WIF dual-write before repo rename; var-flip after PR merge to eliminate race
-Required changes since v1: 7 blockers (B1-B7) all incorporated; R10/R12/R13/R14/R15 added; Q1-Q10 resolved
-Risks: 15 identified; R3 (WIF auth — now mitigated by Phase 2 step 16 dual-write) and R1 (preview-deploy break — mitigated by Phase 3 step 25 dry-run) remain highest-leverage
-Out of scope: GCP project, Supabase project ref, public brand, framework artifacts not in `.agile-flow-overrides`, `pyproject.toml`, custom domain, CLB
+**Result:** Refactor plan revised (v4.1) — DevOps revision pass on v4 (2026-06-30) addressing BC1/BC2/BC3 from `reports/refactor/02c-devops-signoff-v4.md`.
+Scope (unchanged from v4): `cubrox` codebase + infra identifier rename to `masterkey`, executed against a NEW GCP project provisioned by #237 (legacy project inaccessible).
+Recommendation (v4.1): orchestrator edits #237 body per the §6 "**#237 body MUST include**" callout (BC1 + BC2 fixes); then #237 fires; then Phase 1 codebase PR → #200 WIF dual-write (NOT skipped — `cubrox/masterkey` binding lands on new project's SA BEFORE rename) → repo rename → board migration → cutover (single Phase 1 PR merge) → Phase 5 cleanup. v4.1 unchanged from v4 in critical-chain ordering; the changes are in #237's body specification, Phase 2 step 16's verification mechanism, and §6 row clarity.
+Phase -1 (framework alignment to gembaflow v1.5.0): DONE 2026-06-30.
+Risks (v4.1): 22 identified (R1-R20 from v4 + R21 AR repo default + R22 placeholder env vars + R23 API list mismatch + R24 Supabase webhooks unaffected/informational + R25 legacy project billing). R3 (WIF auth) substantially mitigated by clean from-scratch provisioning + the explicit Phase 2 step 16 dual-write (now verified via `synthetic-monitor.yml workflow_dispatch` per BC3, not `rollback-production.yml`). R20 remains highest-attention residual risk; R25 surfaces an adjacent concern (legacy project still billing).
+Reconciliation (§6): 8 tickets CLOSE, 15 REWORK (v4.1 reclassifies #237 from KEEP to REWORK-BODY — scope unchanged, body needs edits), 19 KEEP, 11 already done. Net work-effort reduction vs. v3: roughly half of Phase 3-5 work eliminated.
+Out of scope: old GCP project recovery, GCP project ID rename, Supabase project ref, public brand, framework artifacts not in `.gembaflow-overrides`, `pyproject.toml`, custom domain, CLB.
+
+**v4.1 highest-risk uncertainty to flag for operator:** the v4 dual-write decision stands. The v4.1 revision pass focuses on getting #237 to actually execute the dual-write correctly — namely, fixing #237's body so it (a) doesn't say "#200 superseded" (it isn't) and (b) invokes `provision-gcp-project.sh` with the right env vars so WIF setup doesn't silently no-op. The architectural choice ("dual-write in new project, prune old in Phase 5" vs. "re-run provision script after rename") is unchanged from v4 — both work; dual-write is cheaper and is what the operator's lock confirms.

--- a/reports/refactor/01-architecture-plan.md
+++ b/reports/refactor/01-architecture-plan.md
@@ -431,20 +431,7 @@ The original step numbers (20-26) are OBSOLETE; they referenced operations again
 ~~20. Create new Artifact Registry repo `masterkey` in the same region~~ **OBSOLETE — folded into #237.**
 ~~21. Grant the runtime SA `roles/artifactregistry.reader`~~ **OBSOLETE — folded into #237.**
 ~~22. Build + push an image to the new repo manually as a smoke test~~ **OBSOLETE — first preview-deploy or production deploy serves this role.**
-~~23. Pre-create the Cloud Run service `masterkey` with a placeholder revision~~ **OBSOLETE — #237's first deploy creates the service; placeholder no longer needed since there's no old service serving prod to coexist with.**
-    ```
-    gcloud run deploy masterkey \
-      --image=us-central1-docker.pkg.dev/$PROJECT/masterkey/masterkey:smoke \
-      --region=us-central1 \
-      --service-account=$RUNTIME_SA \
-      --port=8080 --memory=512Mi --cpu=1 \
-      --min-instances=0 --max-instances=10 \
-      --allow-unauthenticated \
-      --set-env-vars="ENVIRONMENT=production,DATABASE_URL=$PROD_DB_URL,ANTHROPIC_API_KEY=$KEY" \
-      --set-secrets="SUPABASE_URL=supabase-url:latest,SUPABASE_ANON_KEY=supabase-anon-key:latest,SUPABASE_SERVICE_KEY=supabase-service-key:latest" \
-      --no-traffic
-    ```
-    (Per resolved Q10: `--min-instances=0` for the placeholder, not 1 — the placeholder shouldn't actually run the smoke image hot. `deploy.yml:168` will flip it to 1 on the real Phase 4 deploy.) Then `--to-latest` traffic shift, but **only on the new service in isolation** — `agile-flow-app` still serves prod.
+~~23. Pre-create the Cloud Run service `masterkey` with a placeholder revision~~ **OBSOLETE — #237's first deploy creates the service; placeholder no longer needed since there's no old service serving prod to coexist with.** (v3's `gcloud run deploy` recipe with `--min-instances=0`, split env-vars/secrets per R13, and `--no-traffic` isolation from `agile-flow-app` is no longer applicable — the new project has no `agile-flow-app` to coexist with.)
 24. **v4 NOTE:** still valid as a verification step (folded into the "v4 Phase 3 verification-only checklist" above), but no longer "after pre-creating the service" — runs against the only-and-only `masterkey` service. Curl the new service's URL — `/api/health` (200), `/api/health/db` (200), then `/` (200, sees Master Key landing). **Capture the new URL** for `docs/LAUNCH-CHECKLIST.md` (B5):
     ```bash
     NEW_URL=$(gcloud run services describe masterkey --region=us-central1 --format='value(status.url)')
@@ -861,7 +848,7 @@ This table is the to-do list for whoever does the post-pivot grooming pass. **No
 | #234 | bot.reviewer alignment | ALREADY CLOSED | Closed via PR #235. |
 | #237 | Provision new GCP project as masterkey from day 1 | REWORK BODY (v4.1 — BC1 + BC2) — KEEP scope, IN FLIGHT | The umbrella ticket that triggers this v4 revision. Must complete before #200 + #201 fire. **Body needs three edits — see `#237 body MUST include` callout below this table.** Scope of WORK is unchanged; only the ticket's body text changes. |
 
-#### `#237 body MUST include` callout (v4.1 — BC1 + BC2)
+### `#237 body MUST include` callout (v4.1 — BC1 + BC2)
 
 The orchestrator must edit issue #237's body to reflect three corrections that the current body gets wrong. Plan content here is the authoritative spec for what the body should say. This plan does NOT edit the issue itself — that's the orchestrator's job.
 

--- a/reports/refactor/02c-devops-signoff-v4.md
+++ b/reports/refactor/02c-devops-signoff-v4.md
@@ -1,0 +1,217 @@
+# DevOps Sign-off: `cubrox` -> `masterkey` Rename Plan v4 (GCP pivot)
+
+**Reviewer:** DevOps Engineer persona
+**Date:** 2026-06-30
+**Plan under review:** `reports/refactor/01-architecture-plan.md` (v4 — 2026-06-30)
+**Prior sign-off:** `reports/refactor/02b-devops-signoff.md` (v3 / v2 — ALIGNED)
+**Anchor for pivot:** Issue #237 (locked operator decisions)
+
+---
+
+## Verdict
+
+**NEEDS_REVISION**
+
+v4's overall direction is correct and the architectural simplification is sound. R19 (billing) and R20 (orphaned legacy URL) are characterized well. The Phase 4 collapse from 8 steps to 3 is genuinely safe — there is no "var-flip race" left to engineer around once #237 sets the vars at provisioning time.
+
+However, three concrete gaps need fixing before #237 fires, all order-of-operations issues the operator can actually trip over:
+
+1. **#237's body literally says "no dual-write needed" and lists #200 as superseded** (CLOSE), while v4 plan §6 keeps #200 as REWORK and the Phase 2 step 16 text reinstates the dual-write. The architect's intent and the operator's just-confirmed lock are aligned (dual-write IS happening), but #237's body is now stale and contradicts that. Whoever runs #237 will read its body, see "no dual-write needed," skip #200, and the next CI run after `gh repo rename` fails with `iam.serviceAccounts.getAccessToken denied` — exact same R3 failure mode as v3, just on the renamed repo path.
+2. **`scripts/provision-gcp-project.sh` expects `GITHUB_OWNER` AND `GITHUB_REPO` as two separate env vars.** #237's happy-path step 4 writes `GITHUB_REPO=cubrox/cubrox`, which the script will treat as `WIF_REPO_NAME=cubrox/cubrox` (literally including the slash) AND `WIF_OWNER=` (empty, because `GITHUB_OWNER` is unset). With `WIF_OWNER` empty, line 478's `[skip] WIF setup not requested` fires and the entire WIF block is silently skipped. The deployer SA never gets bound to the GitHub repo principalSet. The first preview-deploy after #237 still gets `iam.serviceAccounts.getAccessToken denied`. This is a "you read the wrong env var name" footgun and it's in the locked ticket body, so the architect's plan inherits it.
+3. **The v4 Phase 2 step 16 verification mechanism is the wrong workflow.** The plan suggests `workflow_dispatch` on `rollback-production.yml` with `revision=<currentRevision>` as the WIF auth probe. That workflow doesn't have a safe dry-run mode — it actually re-routes traffic to the supplied revision (lines 100-108), then smoke-tests it (lines 127-146). On a brand-new `masterkey` service that has exactly one revision, supplying that revision is a no-op but it's not zero-impact: the workflow will run `gcloud run services update-traffic` and the smoke test against the production URL. `synthetic-monitor.yml` is the cleaner probe (its `workflow_dispatch` only describes the service URL and runs the auth flow) but it's disabled per Phase 1 step 13 during the cutover window.
+
+None of these break the v4 architecture. They break the executability of #237 and Phase 2 step 16 as currently written.
+
+---
+
+## What I re-verified
+
+- `reports/refactor/01-architecture-plan.md` v4 changelog (lines 12-47) — read in full, including the seven "what survives" / "what's invalidated" bullets
+- `01-architecture-plan.md` §3 Phase 0 (v4 STATUS: MOSTLY OBSOLETE, lines 330-344), Phase 2 step 16 (rewritten, lines 372-391), Phase 3 (replaced by verification checklist, lines 401-446), Phase 4 (collapsed, lines 447-477), Phase 5 (~50% eliminated, lines 479-508) — read end-to-end
+- `01-architecture-plan.md` §4 risk register: R3 status downgrade (lines 540-553), R19 new (lines 694-703), R20 new (lines 705-717)
+- `01-architecture-plan.md` §6 reconciliation table (lines 750-798) and §6.1 dependency graph (lines 810-871) — row-by-row
+- Issue #237 body — read in full via `gh issue view 237`
+- `scripts/provision-gcp-project.sh` lines 60 (default `ARTIFACT_REPO=agile-flow`), 351-368 (5 project-level IAM roles), 402-479 (WIF block — pool, provider, BOTH bindings via for-loop), 800 (`SERVICE_NAME` default `agile-flow-app`), 862-906 (Step 7 GitHub secret push), 1011 (next-steps echo)
+- `.github/workflows/deploy.yml` lines 22-26 (env defaults), 60-71 (WIF auth), 131-225 (deploy step + env_vars + secrets)
+- `.github/workflows/preview-deploy.yml` lines 24-28 (same env defaults pattern)
+- `.github/workflows/rollback-production.yml` end-to-end — confirmed there's no auth-only mode
+- `.github/workflows/synthetic-monitor.yml` lines 19-46 (workflow_dispatch present; would be a cleaner WIF probe)
+- Repo state today: `gh variable list` confirms NO `vars.CLOUD_RUN_SERVICE` / `vars.ARTIFACT_REPO` set today; the defaults `agile-flow-app` / `agile-flow` are firing in all workflows. Confirms v4's premise that #237 must set these.
+
+---
+
+## Blocking concerns
+
+### BC1 — #237's body and v4 §6 contradict each other on WIF dual-write
+
+**Where:** #237's "Blocks / supersedes" list says `#200 (E3-T1 WIF dual-write) — superseded; this ticket creates the binding fresh, no dual-write needed`. v4 plan §6 row #200: `REWORK | What changes: now executed against the NEW GCP project (provisioned by #237) rather than the legacy project.` v4 Phase 2 step 16 (line 372): describes the dual-write in detail.
+
+**Why it breaks things:** Whoever executes #237 reads the ticket body as the authoritative spec — they don't necessarily re-read the architecture plan. They will mark #200 as superseded and skip it. After #201 (repo rename) fires, the WIF binding still pins to `cubrox/cubrox` while GitHub's OIDC token presents `cubrox/masterkey`. Every workflow that authenticates to GCP starts failing with `iam.serviceAccounts.getAccessToken denied` — production deploys, preview deploys, synthetic monitor, rollback. Same R3 failure mode v3 was engineered to prevent; v4 reintroduces it by leaving #237's body unedited.
+
+**Fix:** Edit #237's body. Strike "superseded" on #200; replace with: "**#200 remains REQUIRED:** dual-write a second WIF binding for `cubrox/masterkey` on the new project's deployer SA BEFORE running `gh repo rename`. Operator confirmed this approach 2026-06-30." Also strike the implication elsewhere in #237's body that the rename plan "Epics 3-5 collapse significantly" — that's still true for Phases 3/4/5, but Phase 2's WIF re-bind step is NOT collapsed.
+
+### BC2 — #237 happy-path step 4 sets the wrong env-var name; WIF setup silently no-ops
+
+**Where:** #237 step 4: `GCP_PROJECT_ID=<NEW> GITHUB_REPO=cubrox/cubrox bash scripts/provision-gcp-project.sh`. Script line 404: `WIF_OWNER="${GITHUB_OWNER:-${GITHUB_USERNAME:-}}"`. Script line 407: `if [[ -n "$WIF_OWNER" ]]; then` — guards the entire WIF block. Script line 478: `[skip] WIF setup not requested (GITHUB_OWNER and GITHUB_USERNAME unset)`.
+
+**Why it breaks things:** `GITHUB_REPO=cubrox/cubrox` does not satisfy `WIF_OWNER`. `WIF_OWNER` reads only from `GITHUB_OWNER` or `GITHUB_USERNAME`. Without one of those set, the entire `if [[ -n "$WIF_OWNER" ]]` block (pool create, provider create, SA bindings) is skipped. The script completes "successfully," prints the next-steps block, but the WIF provider does not exist and the deployer SA has no GitHub principalSet binding. The next preview-deploy auth step fails with `Permission denied on resource (or it may not exist)` from the WIF provider lookup. Worse, the script then proceeds to Step 7 (line 862) and may try to push `GCP_WORKLOAD_IDENTITY_PROVIDER` to GitHub secrets — but `WIF_PROVIDER_RESOURCE` (set on line 476) is also unset, so the secret push (line 882: `if [[ -n "${WIF_PROVIDER_RESOURCE:-}" ]]`) is also skipped silently. The operator gets a "complete" provisioning with WIF broken end-to-end.
+
+Additionally, the literal `GITHUB_REPO=cubrox/cubrox` would (if WIF_OWNER were also set correctly) produce a malformed `WIF_MEMBER` URI: `principalSet://.../attribute.repository/<owner>/cubrox/cubrox` — three path segments after `attribute.repository/` instead of two — which doesn't match what GitHub's OIDC token presents.
+
+**Fix:** Edit #237 step 4 to `GCP_PROJECT_ID=<NEW> GITHUB_OWNER=cubrox GITHUB_REPO=cubrox bash scripts/provision-gcp-project.sh` (the repo NAME within the owner is just `cubrox`, since the GitHub slug is `cubrox/cubrox`). Also add to #237's Definition of Done a one-line post-provisioning check: `gcloud iam service-accounts get-iam-policy $SA_EMAIL --project=$NEW_GCP_PROJECT_ID --format=json | grep -c principalSet` MUST return ≥ 2 (one for each of the two WIF roles). If it returns 0, WIF wasn't set up; re-run with the correct env vars.
+
+### BC3 — Phase 2 step 16's WIF verification workflow has side effects
+
+**Where:** v4 plan line 389: `Verify: trigger workflow_dispatch on rollback-production.yml with revision=<currentRevision> and reason='WIF binding verification'. This auths to GCP but only acts on user-confirmed input — safe to dry-run.`
+
+**Why it breaks things:** `rollback-production.yml` does NOT have a dry-run mode (verified by reading lines 100-146). On dispatch with a `revision=<currentRevision>` input, it will execute `gcloud run services update-traffic masterkey --to-revisions=<currentRevision>=100` — which, when the supplied revision is already at 100%, is operationally a no-op, BUT the workflow also runs a smoke test against the live production URL (lines 127-146) and writes a "Rollback complete" log entry. On a freshly-provisioned `masterkey` service with exactly one revision, this works without traffic disruption — but if there are multiple revisions or if the supplied revision-name is wrong (typo'd, copy-paste error), the workflow will actively reroute traffic to whatever was supplied. Calling this "safe to dry-run" is misleading.
+
+A cleaner WIF probe is `synthetic-monitor.yml` (`workflow_dispatch` with optional `base_url` input) — but Phase 1 step 13 explicitly disables its `schedule:` block. The `workflow_dispatch` trigger should still work even with `schedule:` commented out, so this is actually a viable WIF probe — but the v4 plan doesn't mention it.
+
+**Fix:** Replace the "use rollback-production.yml" instruction in Phase 2 step 16 with one of:
+- **Option A (preferred):** Use `synthetic-monitor.yml workflow_dispatch` against the new service. It auths via WIF (lines 59-61 mirror deploy.yml), describes the service URL, and runs the smoke auth. Side-effect: it'll send a magic-link email to the smoke-test address — fine.
+- **Option B:** Add a tiny ephemeral workflow (or a `workflow_dispatch` job in deploy.yml gated behind a `dry_run` input) that authenticates via WIF and does `gcloud auth print-access-token` then exits. Pure auth-only probe, zero side effects. This is the kind of fix #237 should ship as a follow-up.
+- **Option C (acceptable):** Note in the plan that `rollback-production.yml` IS being used as the probe and explicitly acknowledge the side effect (a benign traffic-shift call against a single-revision service). Document the precondition: "only safe when `masterkey` has exactly one ready revision."
+
+---
+
+## Non-blocking suggestions
+
+### NS1 — Update #237's Definition of Done with billing-budget verification
+
+R19's mitigation says "#237's Definition of Done includes a billing-account verification step (confirm billing is enabled and a budget alert is set at ≥ $50/month threshold)." #237's actual DoD (read in full) doesn't include this. Either edit #237's DoD to add it, or accept that R19's mitigation is aspirational and the operator must remember to set the budget manually. Recommend the former.
+
+### NS2 — §2.3 inventory table still has v3 language
+
+Lines 138-147 of the plan describe Cloud Run / AR / WIF transitions as if executing in-place against an existing project ("Today: agile-flow-app"). v4 changes the meaning of "Today" — there is no `agile-flow-app` we can see in OUR project. The table is technically still descriptive of the inventory of identifiers but a reviewer reading top-to-bottom might miss that lines 138-150 describe the v3 framing. Add a v4 banner to §2.3 ("§2.3 below describes the resource-shape inventory; in v4 only resources in the new project exist; resources in the old project are inferred from this repo's history but cannot be touched") OR strike the "Today" column and replace with "Identifier."
+
+### NS3 — Phase 5 step 1 (WIF binding cleanup) should explicitly verify before removing
+
+The v4 Phase 5 step 1 `remove-iam-policy-binding` for the `cubrox/cubrox` principalSet. Before running it, confirm the `cubrox/masterkey` binding exists AND a recent successful workflow run used it. The `gcloud iam service-accounts get-iam-policy` output should show both bindings; the audit log should show a recent successful `getAccessToken` against the new principalSet. v3 Phase 5 step 38 had similar prudence; v4's compressed version drops the explicit "verify the new binding has been exercised first" guard. Add it.
+
+### NS4 — §6 reconciliation row for #200 should explicitly cite the v4 dual-write requirement
+
+Row #200 reads "REWORK | What changes: now executed against the NEW GCP project." This is correct but doesn't loudly counter #237's claim that #200 is superseded. Add: "**NOT superseded by #237** — #237 provisions ONE binding (`cubrox/cubrox`); #200 adds the SECOND binding (`cubrox/masterkey`) before the repo rename. Both are required."
+
+### NS5 — Add a one-line "what to do if WIF check fails post-#237" to the runbook
+
+The simplification of Phase 3 to "verification only" assumes #237 set everything up correctly. If WIF wasn't set up (BC2), Phase 3 step 6's dry-run preview-deploy will reveal the breakage. The plan should explicitly say: "if WIF verification fails post-#237, re-run `scripts/provision-gcp-project.sh` with `GITHUB_OWNER=cubrox GITHUB_REPO=cubrox` set; the script's idempotency lines (414, 427) skip the pool/provider but the SA binding loop on line 466 will add the missing principalSet bindings." This gives the operator a recovery path that doesn't require manual `gcloud iam` surgery.
+
+---
+
+## Additional risks beyond R19/R20
+
+### R21 — `provision-gcp-project.sh` defaults `ARTIFACT_REPO=agile-flow` (line 60), not `masterkey`
+
+If the operator runs #237's happy-path step 4 without explicitly setting `ARTIFACT_REPO=masterkey`, the script will create an Artifact Registry repo named `agile-flow` in the new project. Subsequent deploys (with `vars.ARTIFACT_REPO=masterkey` per #237 step 7) will then try to push to a `masterkey` repo that doesn't exist. The script's idempotency-via-`describe` (line 308) means a re-run with the corrected env var will create the second repo cleanly, but the operator now has TWO AR repos in the new project — one of which is dead weight. **Mitigation:** edit #237 step 4 to `GCP_PROJECT_ID=<NEW> ARTIFACT_REPO=masterkey GITHUB_OWNER=cubrox GITHUB_REPO=cubrox bash scripts/provision-gcp-project.sh`. Note: this overlaps with B4-listed ticket #196 (rename script defaults), but #196 lands in the Phase 1 PR AFTER #237 runs, so the rename doesn't help #237.
+
+### R22 — `provision-gcp-project.sh:800` Step 5.8 creates a Cloud Run service with `--image=us-docker.pkg.dev/cloudrun/container/hello`
+
+The placeholder revision uses the public hello image; first real deploy overwrites it. This is fine in steady state, but the placeholder is created with `--allow-unauthenticated` and `--port=8080` — no `--set-env-vars` for `DATABASE_URL` or `ANTHROPIC_API_KEY`. **R13 (env-var type stickiness) re-applies:** when `deploy.yml` first deploys, it does `--update-env-vars` (set/replace semantics, per the deploy.yml comment on lines 192-196). The hello placeholder has NO env vars set, so all of `deploy.yml`'s env vars are created fresh as literals — this is actually fine and matches `deploy.yml`'s intent. But if anyone manually `gcloud run deploy`s with `--set-secrets DATABASE_URL=...` between #237 finishing and the first `deploy.yml` run, they'd brick the service per R13. Phase 3 verification step 3 (line 409 in the plan) is the right place to catch this; recommend explicitly checking `gcloud run services describe masterkey --format='value(spec.template.spec.containers[0].env)'` returns empty (or contains only the literal vars from deploy.yml's first run) and NOT any `valueSource: secretKeyRef:` entries on DATABASE_URL / ANTHROPIC_API_KEY.
+
+### R23 — Cloud Logging / Cloud Build / IAM credentials APIs may not all be auto-enabled
+
+`provision-gcp-project.sh:297-304` enables six APIs: `run`, `artifactregistry`, `secretmanager`, `iam`, `iamcredentials`, `billingbudgets`. #237 step 3 enables a different five-API set: `run`, `artifactregistry`, `iamcredentials`, `cloudbuild`, `secretmanager`. Notably #237 lists `cloudbuild` (not in the script) and OMITS `iam` and `billingbudgets`. `deploy.yml` does NOT use Cloud Build (it does a local `docker build` then pushes); so `cloudbuild.googleapis.com` is unnecessary. `iam.googleapis.com` IS needed (for the `get-iam-policy` calls in the script) — but it's usually enabled by default on new projects. `billingbudgets.googleapis.com` is needed if R19's budget alert is set up. **Mitigation:** unify the API list in #237 step 3 with the script's enable call at line 297 (use the script's six-API list, plus add `logging.googleapis.com` if R20's enumeration work needs it later, which it probably doesn't since the new project starts empty).
+
+### R24 — Supabase Auth allowlist may have org/project scoping affected by GCP project change
+
+The Supabase Auth dashboard's redirect-URL allowlist is keyed against the Supabase project (`gnswmcgaztcxslirulwm`), not the GCP project. R4/R12 are still correctly characterized. However, the Supabase GitHub App's allowlist (R10) tracks the GitHub repo, and the per-PR branching plumbing reads from GitHub Actions secrets that include `SUPABASE_ACCESS_TOKEN` and `SUPABASE_DB_URL`. **R24 (low risk):** confirm that switching GCP projects doesn't affect Supabase's `webhook` callback URLs registered against the GitHub App — these point at supabase.com endpoints, not our Cloud Run service, so should be unaffected. Read-only verification only; no action.
+
+### R25 — The legacy Cloud Run URL `agile-flow-app-heo5ry7rua-uc.a.run.app` may continue billing in the old project despite "inaccessible"
+
+"Operator lost access" likely means lost IAM access to the project, not loss of the billing relationship. The orphaned runtime may continue accruing Cloud Run charges (min-instances=1 per deploy.yml:168) AND Cloud Logging charges (logs retention) AND Artifact Registry storage charges until the billing org owner manually shuts it down. **The cost is bounded but not zero.** Recommend the operator at least file a billing-org case to either (a) regain access enough to set `--min-instances=0` and stop logging ingestion, or (b) accept the cost until Google reclaims the project for non-payment of some other invoice. R19's mitigation focuses on the NEW project's billing; R25 highlights that the OLD project's billing is still happening and the operator may have legal/financial recourse to stop it that isn't IAM-access dependent.
+
+---
+
+## WIF dual-write specific check
+
+**Operator's locked decision:** dual-write the new project's deployer SA with bindings for BOTH `cubrox/cubrox` AND `cubrox/masterkey` principalSets BEFORE the repo rename; prune the `cubrox/cubrox` binding in Phase 5.
+
+**v4 plan ordering check (Phase 2 step 16 → step 17):**
+
+- v4 Phase 2 step 16 (line 372): "WIF re-bind after repo rename (v4 REPLACES v3's dual-write). ... **Architect's chosen approach: dual-write the new binding BEFORE running the repo rename, then prune the old one in Phase 5** — same shape as v3's plan, just executed in the new project instead of the old one."
+- v4 Phase 2 step 17 (line 392): "Repo rename: `gh repo rename masterkey --repo cubrox/cubrox` ..."
+
+The plan text says "BEFORE the rename" in step 16. The numerical ordering 16-then-17 reinforces this. **Order is correct: the `cubrox/masterkey` binding lands before `gh repo rename` fires.**
+
+**Mechanism check:** the v4 plan's bash snippet (lines 379-388) adds the new binding via two `gcloud iam service-accounts add-iam-policy-binding` calls (one per role) against the NEW project's deployer SA, with member `principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/attribute.repository/cubrox/masterkey`. The old `cubrox/cubrox` binding stays untouched. This is correct shape and matches what `provision-gcp-project.sh:465-474` did originally for the `cubrox/cubrox` binding.
+
+**Why this matters (R3 failure mode prevention):** with both bindings in place at the moment `gh repo rename` fires, GitHub's OIDC token presents `repository = cubrox/cubrox` for any in-flight workflow run AND `repository = cubrox/masterkey` for any newly-triggered run after the rename — both match a `principalSet` binding on the deployer SA. No `iam.serviceAccounts.getAccessToken denied`. After Phase 5's stability window, the `cubrox/cubrox` binding is pruned.
+
+**Confirmed:** the v4 plan's order-of-operations puts the `cubrox/masterkey` binding in place before the rename. The mechanism matches the operator's locked decision exactly.
+
+**Caveat:** this is contingent on #237 NOT being interpreted to mean "#200 superseded, skip it" (BC1). If #200 is skipped, the dual-write never happens, and the rename triggers R3. The architectural intent is right; the ticket-state hygiene needs the BC1 fix.
+
+---
+
+## `provision-gcp-project.sh` audit
+
+#237's happy path assumes the script, run with `GCP_PROJECT_ID=<NEW> GITHUB_REPO=cubrox/cubrox`, does the following:
+1. Enable APIs
+2. Create AR repo named `masterkey`
+3. Create deployer SA
+4. Bind 4 project-level IAM roles
+5. Create WIF pool + provider, bind 2 SA-level roles to the GitHub repo principalSet
+6. Create Cloud Run service named `masterkey` with a placeholder image
+7. Push GitHub Actions secrets (`GCP_PROJECT_ID`, `GCP_SERVICE_ACCOUNT`, `GCP_WORKLOAD_IDENTITY_PROVIDER`)
+
+What the script ACTUALLY does on a fresh project with `GCP_PROJECT_ID=<NEW> GITHUB_REPO=cubrox/cubrox` (and nothing else set):
+
+| # | Step | Status |
+|---|------|--------|
+| 1 | Enable 6 APIs (lines 296-304: `run`, `artifactregistry`, `secretmanager`, `iam`, `iamcredentials`, `billingbudgets`) | OK. Note #237 lists 5 different APIs — see R23. |
+| 2 | Create AR repo (line 313) | **WRONG NAME** — defaults to `agile-flow` (line 60), not `masterkey`. Need `ARTIFACT_REPO=masterkey` env var. See R21. |
+| 3 | Create deployer SA `deployer@<project>.iam.gserviceaccount.com` (line 331) | OK. |
+| 4 | Bind 4 project-level IAM roles (lines 360-368: `run.admin`, `artifactregistry.writer`, `serviceAccountUser`, `secretmanager.secretAccessor`) | OK. |
+| 5 | Create WIF pool + provider + bind 2 SA-level roles | **SILENTLY SKIPPED** — `WIF_OWNER` is empty because `GITHUB_OWNER` and `GITHUB_USERNAME` are unset (lines 404, 407). The entire block including the SA binding is skipped (line 478 prints `[skip] WIF setup not requested`). See BC2. |
+| 6 | Create Cloud Run service (line 809) | **WRONG NAME** — defaults to `agile-flow-app` (line 800), not `masterkey`. Need `CLOUD_RUN_SERVICE=masterkey` env var. |
+| 7 | Push GitHub Actions secrets (line 862-906) | **SILENTLY SKIPPED** — gated on `GITHUB_REPOSITORY` env var being set (line 862). #237 doesn't set this. Falls back to printing values. Even if `GITHUB_REPOSITORY` were set, `GCP_WORKLOAD_IDENTITY_PROVIDER` push (line 882) is gated on `WIF_PROVIDER_RESOURCE` being set, which it isn't from step 5. |
+
+**Net effect of #237 as currently written:** a new GCP project with the wrong AR repo name (`agile-flow`), the wrong Cloud Run service name (`agile-flow-app`), no WIF, and no secrets auto-pushed. The operator would then manually create the `masterkey` AR repo, manually create the `masterkey` Cloud Run service, manually set up WIF, and manually push secrets — essentially re-doing 80% of the script's work by hand. The first `deploy.yml` run would still fail because WIF auth isn't plumbed.
+
+**Idempotency check (fresh project tolerance):** the script IS designed to be idempotent. Each step's `describe`-then-create pattern (lines 207-235, 308-319, 325-349, 414-441) tolerates pre-existing state. Re-running with the correct env vars after a partial first run will create only the missing resources without errors. The retry helper (lines 86-142) absorbs eventual-consistency lag from fresh-project IAM propagation. So a recovery path exists: fix the env vars and re-run; the script picks up where the broken run left off.
+
+**Conclusion:** `provision-gcp-project.sh` is well-built for the workflow #237 intends, but #237's invocation contract (env vars set) is mis-specified. The script will silently do the wrong thing because the env vars don't drive the code paths #237 assumes. Fix is environmental (BC2, R21), not in the script itself.
+
+**Required env-var invocation for #237 to actually do what its happy-path says:**
+
+```bash
+GCP_PROJECT_ID=<NEW> \
+ARTIFACT_REPO=masterkey \
+CLOUD_RUN_SERVICE=masterkey \
+GITHUB_OWNER=cubrox \
+GITHUB_REPO=cubrox \
+GITHUB_REPOSITORY=cubrox/cubrox \
+bash scripts/provision-gcp-project.sh
+```
+
+(With `GITHUB_REPOSITORY=cubrox/cubrox` set, Step 7 will auto-push the secrets and #237 step 6 becomes a no-op verification.)
+
+---
+
+## Summary table
+
+| # | Status | Item |
+|---|--------|------|
+| BC1 | BLOCKING | #237 body contradicts v4 §6 on WIF dual-write necessity; edit #237 to clarify #200 is still required |
+| BC2 | BLOCKING | #237 step 4 env vars wrong; WIF silently no-ops; fix to `GITHUB_OWNER=cubrox GITHUB_REPO=cubrox` |
+| BC3 | BLOCKING | Phase 2 step 16 verification via `rollback-production.yml` has side effects; use `synthetic-monitor.yml workflow_dispatch` or add an auth-only probe |
+| NS1 | suggestion | Add billing-budget check to #237 DoD per R19 |
+| NS2 | suggestion | §2.3 still has v3 framing; add v4 banner |
+| NS3 | suggestion | Phase 5 WIF prune should verify new binding has been exercised first |
+| NS4 | suggestion | §6 row #200 should loudly counter #237's "superseded" claim |
+| NS5 | suggestion | Add WIF-recovery one-liner to Phase 3 |
+| R21 | new risk | `ARTIFACT_REPO` defaults to `agile-flow`; #237 must set it |
+| R22 | new risk | Placeholder Cloud Run service has no env vars; first `deploy.yml` populates them but watch for manual interference per R13 |
+| R23 | new risk | API-enable list in #237 differs from script's; reconcile |
+| R24 | new risk (low) | Supabase webhook URLs unaffected by GCP project change — read-only check only |
+| R25 | new risk | Old GCP project may still be accruing charges despite IAM access loss; recommend billing-org escalation |
+
+---
+
+**Result:** Plan needs three blocker fixes before #237 fires; v4 architecture is otherwise sound.
+Blocking concerns raised: 3 (BC1-BC3)
+Non-blocking suggestions: 5 (NS1-NS5)
+Additional risks identified: 5 (R21-R25)
+WIF dual-write order: confirmed correct (binding lands before rename per Phase 2 step 16 → step 17)
+`provision-gcp-project.sh` happy-path audit: script is sound; #237's env-var contract is wrong

--- a/reports/refactor/02d-devops-signoff-v4.1.md
+++ b/reports/refactor/02d-devops-signoff-v4.1.md
@@ -1,0 +1,175 @@
+# DevOps Sign-off: `cubrox` -> `masterkey` Rename Plan v4.1 (round-2 focused revision)
+
+**Reviewer:** DevOps Engineer persona
+**Date:** 2026-06-30
+**Plan under review:** `reports/refactor/01-architecture-plan.md` (v4.1 — 2026-06-30)
+**Prior sign-off:** `reports/refactor/02c-devops-signoff-v4.md` (v4 — NEEDS_REVISION with BC1/BC2/BC3 + R21-R25)
+
+---
+
+## Verdict
+
+**ALIGNED**
+
+v4.1 fully resolves all three blockers from v4 and folds R21-R25 into the risk register with workable mitigations. The architect did not gold-plate — they made surgical edits in the exact places the v4 review called out, preserved everything that was already accepted, and the resulting plan is internally consistent. Most importantly, the #237 body-edit callout in §6 is precise, paste-correct, and matches the script's actual env-var contract on every name. The Phase 2 step 16 switch from `rollback-production.yml` to `synthetic-monitor.yml` is the right call for the right reason — `synthetic-monitor.yml workflow_dispatch` exercises the same `google-github-actions/auth@v3` step shape as `deploy.yml` (verified line-by-line) without any traffic-shift side effect.
+
+No new blockers. One observation worth surfacing as a non-blocking suggestion (NS-V41-1 below) about the smoke-auth probe failing past the WIF step against the hello placeholder service — operator should know to read the run log for the auth-step pass/fail rather than just the overall workflow status. Not blocking because the recovery path is correct interpretation, not re-execution.
+
+Cleared to fire #237 with the corrected body.
+
+---
+
+## Blocker resolution table
+
+| ID | Resolved? | Where in v4.1 | Notes |
+|----|-----------|---------------|-------|
+| BC1 | Yes | §6 row #200 (line 835) + §6 row #237 (line 862) + §6 callout "Correction 1" (lines 868-872) + §3 Phase 2 step 16 preamble (lines 382, 384) | #200 explicitly REWORK not CLOSE; #237 row tagged "REWORK BODY"; callout dictates the exact replacement text including "operator confirmed 2026-06-30" provenance; the implied "Epics 3-5 collapse applies to Phase 2's WIF step" misreading is explicitly called out and forbidden. Cross-reference to step 16's preamble closes the loop between the §6 callout and the operational steps. |
+| BC2 | Yes | §6 callout "Correction 2" (lines 874-897) + DoD check 1 (line 901) + DoD check 6 (line 906) + R21 (line 731) + R23 (line 751) | All six env vars listed correctly: `GCP_PROJECT_ID`, `ARTIFACT_REPO=masterkey`, `CLOUD_RUN_SERVICE=masterkey`, `GITHUB_OWNER=cubrox`, `GITHUB_REPO=cubrox` (bare repo name, not slug), `GITHUB_REPOSITORY=cubrox/cubrox`. Each name verified against script reality (see #237 body delta sanity check below). Each silent-skip failure mode (line 478 WIF skip, line 60 `ARTIFACT_REPO` default, line 800 `SERVICE_NAME` default, line 862 secret-push gate) is documented with the script line number that fires it. DoD checks 1, 2, 3, 6 each catch a specific BC2-flagged failure mode with a one-line `gcloud` or `gh` invocation. |
+| BC3 | Yes | §3 Phase 2 step 16 verification block (line 401) + R3 mitigation (line 563) | Verification switched from `rollback-production.yml workflow_dispatch` to `synthetic-monitor.yml workflow_dispatch`. Plan explicitly explains why `rollback-production.yml` was rejected (mutates traffic via `gcloud run services update-traffic`, no dry-run mode), why `synthetic-monitor.yml`'s `schedule:` block being commented out per Phase 1 step 13 doesn't disable `workflow_dispatch` (the two triggers are independent), and provides an NS5 recovery path (re-run provision script with corrected env vars). R3 mitigation paragraph mirrors the rationale. |
+
+All three blockers resolved with the right shape and the right level of explicitness.
+
+---
+
+## Risk register check (R21-R25)
+
+| ID | Present? | Severity / Likelihood | Mitigation | Notes |
+|----|----------|----------------------|------------|-------|
+| R21 | Yes (lines 731-739) | Certain / High impact (dead AR repo + push failure) | #237 body sets `ARTIFACT_REPO=masterkey`; DoD check 2 verifies it; #196 doesn't help since it lands later | Correctly flags overlap with #196 timing. Mitigation is environmental at #237 invocation. Workable. |
+| R22 | Yes (lines 741-749) | Low steady-state / Medium if manual `gcloud run deploy` interferes | Phase 3 verification step 3 + #237 DoD check 4 verify env-var types; operational convention "don't manually deploy between #237 finish and Phase 1 PR merge" | Honest about the residual: WIF auth itself isn't the issue; the issue is human discipline between two events. Mitigation is documentation + a single grep that catches the failure mode. Reasonable. |
+| R23 | Yes (lines 751-760) | Certain mismatch / Low impact | #237 body reconciled to script's 6-API list (`run`, `artifactregistry`, `secretmanager`, `iam`, `iamcredentials`, `billingbudgets`); script's idempotent re-enable acts as defense-in-depth | Drops `cloudbuild` correctly (deploy.yml does local `docker build`, not Cloud Build). Right reconciliation direction. |
+| R24 | Yes (lines 762-767) | N/A / Informational | None needed; documented as read-only check | Correctly downgraded from "risk" to "clarification so future reviewers don't re-investigate." Right call. |
+| R25 | Yes (lines 769-781) | High / Tens of $$/month, bounded | Billing-org escalation: either regain access to set `min-instances=0`, or initiate project shutdown via billing console (works even without project-level IAM since `roles/billing.admin` operates on billing account); accept indefinite cost if both unavailable | Operationally sound. The "project shutdown via billing console works without project-level IAM" detail is correct and gives the operator a real recovery path. |
+
+All five risks present. No new risks I'd flag that aren't already in the register. R25's mitigation is the most actionable single recovery the operator should do regardless — this is the highest-leverage item in the entire v4.1 risk register and the plan correctly identifies it as a one-email task.
+
+---
+
+## #237 body delta sanity check (paste-into-terminal correctness)
+
+The v4.1 callout proposes #237's step 4 invocation be:
+
+```bash
+GCP_PROJECT_ID=<new-project-id> \
+ARTIFACT_REPO=masterkey \
+CLOUD_RUN_SERVICE=masterkey \
+GITHUB_OWNER=cubrox \
+GITHUB_REPO=cubrox \
+GITHUB_REPOSITORY=cubrox/cubrox \
+bash scripts/provision-gcp-project.sh
+```
+
+Cross-checked against `scripts/provision-gcp-project.sh` line-by-line:
+
+| Env var | Script line | Behavior | Plan's choice | Verdict |
+|---------|-------------|----------|---------------|---------|
+| `GCP_PROJECT_ID` | (used throughout, no default) | Required; script errors if unset | `<new-project-id>` placeholder | Correct |
+| `ARTIFACT_REPO` | 60 (`ARTIFACT_REPO="${ARTIFACT_REPO:-agile-flow}"`) | Defaults to `agile-flow` | `masterkey` | Correct — overrides the default |
+| `CLOUD_RUN_SERVICE` | 800 (`SERVICE_NAME="${CLOUD_RUN_SERVICE:-agile-flow-app}"`) | Defaults to `agile-flow-app` | `masterkey` | Correct — overrides the default |
+| `GITHUB_OWNER` | 404 (`WIF_OWNER="${GITHUB_OWNER:-${GITHUB_USERNAME:-}}"`) | Drives the WIF block gate (line 407) | `cubrox` | Correct — non-empty value enables WIF |
+| `GITHUB_REPO` | 405 (`WIF_REPO_NAME="${GITHUB_REPO:-agile-flow-gcp}"`) | BARE repo name, not slug; defaults to `agile-flow-gcp` | `cubrox` | Correct — bare name. Line 465 then assembles `principalSet://.../attribute.repository/cubrox/cubrox`. |
+| `GITHUB_REPOSITORY` | 862 (`if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then`) | Gates the `gh secret set` push (Step 7) | `cubrox/cubrox` | Correct — owner/repo slug, enables auto-push of GCP_PROJECT_ID, GCP_SERVICE_ACCOUNT, GCP_WORKLOAD_IDENTITY_PROVIDER |
+
+**WIF_MEMBER assembly check.** Script line 465: `WIF_MEMBER="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${WIF_POOL}/attribute.repository/${WIF_OWNER}/${WIF_REPO_NAME}"`. With `WIF_OWNER=cubrox` and `WIF_REPO_NAME=cubrox`, the URI assembles to `...attribute.repository/cubrox/cubrox` — exactly two path segments after `attribute.repository/`, matching what GitHub's OIDC token presents for `cubrox/cubrox`. Correct.
+
+**Step 7 secret-push behavior under this invocation.** With `GITHUB_REPOSITORY=cubrox/cubrox` set AND `WIF_PROVIDER_RESOURCE` populated (line 476 sets it because the WIF block executed), all three secrets (`GCP_PROJECT_ID`, `GCP_SERVICE_ACCOUNT`, `GCP_WORKLOAD_IDENTITY_PROVIDER`) get pushed via `gh secret set --repo cubrox/cubrox`. #237's step 6 (verify secrets) then becomes a no-op confirmation. Correct.
+
+**One-shot paste correctness:** the block as written above pastes cleanly into a bash terminal (line continuations are proper `\`-then-newline, no trailing whitespace risk that I can spot in the plan's markdown rendering). After pasting, the operator must replace `<new-project-id>` with the actual project ID — this is clearly templated and standard.
+
+**Conclusion:** the invocation as documented in v4.1's §6 callout is correct on every env-var name, every value, and every interaction with the script's internal logic. Paste-and-run will produce the intended provisioning state.
+
+---
+
+## Phase 2 step 16 WIF verification sanity check (synthetic-monitor.yml)
+
+**Question:** is `synthetic-monitor.yml workflow_dispatch` actually a safe (read-only) WIF probe?
+
+**Verified against `.github/workflows/synthetic-monitor.yml`:**
+
+- **Triggers (lines 19-28):** both `schedule:` and `workflow_dispatch:` are declared. Commenting out `schedule:` (per Phase 1 step 13) does NOT disable `workflow_dispatch` — GitHub Actions treats trigger keys independently. Correctly handled in the plan.
+- **WIF auth step (lines 75-80):** uses `google-github-actions/auth@v3` with `workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}` and `service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}` — line-for-line identical shape to `deploy.yml:60-65`. If WIF passes here, it passes for `deploy.yml`, `preview-deploy.yml`, and `rollback-production.yml` (which all use the same `google-github-actions/auth@v3` invocation).
+- **Read-only operations:**
+  - `gcloud run services describe ${SERVICE_NAME} --region=${GCP_REGION} --format='value(status.url)'` (line 104-106) — read-only.
+  - `gcloud secrets versions access latest --secret=supabase-url|supabase-anon-key|supabase-service-key` (lines 118-123) — read-only.
+- **Side effects in the post-auth steps:**
+  - `scripts/smoke_auth.py` (line 142) — drives a sign-in/logout flow against the live service URL via the Supabase service-key (mints a throwaway session). NOT a traffic-shift, NOT a service mutation. Side effect: creates a temporary Supabase auth user on `gnswmcgaztcxslirulwm` (the existing Supabase project, unaffected by GCP pivot).
+  - `actions/github-script@v7` (lines 148-204) — opens or comments on an alert issue ONLY on `failure()`. If the probe fails (e.g., because the hello-placeholder service can't actually sign anyone in — see NS-V41-1 below), this WILL create a `[ALERT] Synthetic auth monitor failed - 2026-06-30` issue in `cubrox/cubrox`. Benign, easy to close.
+
+**Comparison vs. `rollback-production.yml`:** `rollback-production.yml` runs `gcloud run services update-traffic` (re-routing traffic) followed by a smoke test against the production URL with the resupplied revision. On a freshly-provisioned single-revision `masterkey` service that's an operational no-op, BUT it WOULD write a "Rollback complete" log entry, mutate the service's traffic spec (even if to the same revision), and is brittle to typo'd revision names. `synthetic-monitor.yml` has none of that.
+
+**Conclusion:** `synthetic-monitor.yml workflow_dispatch` is the correct probe choice. The WIF auth step is the single test we care about — if it succeeds, the dual-write binding is plumbed correctly and the BC3 fix is validated.
+
+---
+
+## New blockers
+
+**None.**
+
+v4.1 made the three surgical edits I asked for and didn't introduce new operational risks. The plan is internally consistent, the #237 body callout is precise enough that the orchestrator can copy-paste it into the issue edit, and the risk register additions are honest about likelihood and impact.
+
+---
+
+## Non-blocking suggestions (v4.1-specific)
+
+### NS-V41-1 — Phase 2 step 16 synthetic-monitor probe will likely fail at the smoke_auth step (not at WIF auth)
+
+**Where:** §3 Phase 2 step 16 verification (line 401).
+
+**Why this surfaces now:** at Phase 2 step 16 execution time, #237 has provisioned the placeholder Cloud Run service using `--image=us-docker.pkg.dev/cloudrun/container/hello` (per R22 / script line 800-825). That hello image responds to HTTP probes but does NOT run the FastAPI app, does NOT have `/auth/callback`, does NOT integrate with Supabase. `scripts/smoke_auth.py` (line 142 of synthetic-monitor.yml) will fail because the live URL isn't actually serving the application — it's serving "Hello World" from a placeholder.
+
+**Net effect:** the overall workflow run will be RED, BUT the WIF auth step (lines 75-80) will have already turned green by that point. The BC3 verification mechanism still works — the operator just needs to read the run log for the "Authenticate to Google Cloud (Workload Identity Federation)" step specifically, not just look at the overall ✗.
+
+**Mitigation:** add one line to Phase 2 step 16's verification text: "**Expected:** WIF auth step (line 75-80 of synthetic-monitor.yml) shows green; subsequent smoke_auth step likely RED because the masterkey service is still the hello placeholder at this phase. Read the per-step status, not just the overall workflow ✗. Close any auto-filed `[ALERT] Synthetic auth monitor failed` issue that gets opened — it's expected, not a real outage."
+
+**Why non-blocking:** the operator gets the right signal (WIF works) from reading the per-step status. Misinterpretation produces only confusion, not damage. A doc clarification would help; a re-revision is not warranted.
+
+### NS-V41-2 — DoD check 6's `gh variable list` won't show `vars` set on the renamed repo
+
+**Where:** §6 callout DoD check 6 (line 906): `gh variable list --repo cubrox/cubrox | grep -E 'CLOUD_RUN_SERVICE|ARTIFACT_REPO'`.
+
+**Observation:** at #237 execution time, the repo is still `cubrox/cubrox`, so the command works. But the Step 7 secret push in `provision-gcp-project.sh` does NOT actually push GitHub Actions `vars` — only `secrets` (per lines 880-893). `CLOUD_RUN_SERVICE` and `ARTIFACT_REPO` are GitHub Actions **VARIABLES**, not secrets, and the script does NOT call `gh variable set`. So this DoD check, as worded, will return empty even after a fully-successful #237 run.
+
+**What the operator needs:** the operator (or #237's step 7) must `gh variable set CLOUD_RUN_SERVICE --body masterkey --repo cubrox/cubrox` and `gh variable set ARTIFACT_REPO --body masterkey --repo cubrox/cubrox` MANUALLY. These are not auto-pushed by the script.
+
+**Mitigation:** edit DoD check 6 to explicitly say "after manually running `gh variable set CLOUD_RUN_SERVICE --body masterkey` and `gh variable set ARTIFACT_REPO --body masterkey`, this check confirms both vars are set." OR add a separate Step 7.5 to #237's body: "Manually push GitHub Actions vars: `gh variable set CLOUD_RUN_SERVICE --body masterkey && gh variable set ARTIFACT_REPO --body masterkey`."
+
+**Why non-blocking:** today's repo (`gh variable list --repo cubrox/cubrox`) confirms neither variable is set today — so the operator will see they're missing post-#237 if they run the check, and remember to set them. Recovery is two `gh variable set` commands, trivially executable. Plan is correct in intent (the vars must be set); just unclear on the mechanism. Worth a small edit to either the DoD check or #237's body, but not block-worthy.
+
+---
+
+## What survives unchanged from v4 (DevOps-accepted in v4 sign-off — should not be re-litigated)
+
+- Phase -1 (framework alignment) is DONE — closed via PR #232. (line 42)
+- Phase 1 (codebase rename) shape unchanged. (line 43)
+- Phase 4 collapse to 3 steps (merge → verify → restore monitor) preserved. (lines 463-469)
+- Phase 5 ~50% elimination preserved. (lines 491-509)
+- R19 (billing) and R20 (orphaned URL) framings preserved. (lines 706-729)
+- Dependency graph (8-ticket critical chain) preserved. (line 979)
+- v4 §6 reconciliation table preserved with only #200 + #237 row edits and a new callout subsection appended.
+
+Nothing in v4.1 destabilizes anything I previously accepted.
+
+---
+
+## Sign-off statement
+
+I sign off on `reports/refactor/01-architecture-plan.md` v4.1 as **ALIGNED**.
+
+The three blockers from `reports/refactor/02c-devops-signoff-v4.md` (BC1, BC2, BC3) are fully resolved. R21-R25 are documented in the risk register with severity, likelihood, and workable mitigations. The #237 body-edit callout is precise and paste-correct against `scripts/provision-gcp-project.sh`'s actual env-var contract. The Phase 2 step 16 verification mechanism (`synthetic-monitor.yml workflow_dispatch`) is genuinely read-only at the WIF auth layer and is the right choice over `rollback-production.yml`.
+
+Two non-blocking suggestions documented (NS-V41-1 and NS-V41-2) for the operator to be aware of when executing #237 and Phase 2. Neither warrants a re-revision.
+
+**Cleared to proceed:** the orchestrator should edit #237's body per the v4.1 §6 callout, then fire #237. Phase 2 step 16's WIF dual-write and `synthetic-monitor.yml workflow_dispatch` verification follow as documented.
+
+---
+
+**Result:** v4.1 plan aligned; v4 blockers resolved; #237 can be re-bodied and fired.
+Blocking concerns raised: 0
+Non-blocking suggestions: 2 (NS-V41-1, NS-V41-2)
+Risk register additions verified: 5 (R21-R25 — all present with workable mitigation)
+#237 invocation paste-check: correct on all 6 env vars
+Phase 2 step 16 verification mechanism: `synthetic-monitor.yml workflow_dispatch` confirmed read-only at WIF layer
+
+SIGNOFF_SAVED: reports/refactor/02d-devops-signoff-v4.1.md
+VERDICT: ALIGNED
+ONE_LINE: v4.1 resolves BC1/BC2/BC3 cleanly; R21-R25 logged; #237 body delta is paste-correct against the script's env-var contract.

--- a/reports/refactor/06-v4.1-reconciliation-log.md
+++ b/reports/refactor/06-v4.1-reconciliation-log.md
@@ -1,0 +1,73 @@
+# v4.1 Backlog Reconciliation Log
+
+**Date executed:** 2026-06-30
+**Operator:** tck517 (solo-mode)
+**Source of truth:** `reports/refactor/01-architecture-plan.md` §6
+**Plan classification (v4.1):** 8 CLOSE, 15 REWORK (one — #237 — body-edited separately, leaving 14 here), 19 KEEP-as-is, 11 already-closed pre-v4.
+
+Net actions this run: 8 closed as obsolete, 14 reworked with appended `Scope update 2026-06-30 (v4.1 §6)` section. Project #2 board items for the 8 closed tickets moved to Done.
+
+---
+
+## Closed tickets (8)
+
+| #     | Title                                                                                          | Action timestamp     |
+|-------|------------------------------------------------------------------------------------------------|----------------------|
+| #188  | chore: Snapshot Cloud Run service + revisions + SA IAM + secrets                               | 2026-06-30           |
+| #190  | chore: Enumerate Cloud Logging metrics, alerts, dashboards                                     | 2026-06-30           |
+| #191  | chore: Confirm zero open PRs + enumerate forks, then bundle Phase 0 snapshots into PR          | 2026-06-30           |
+| #204  | infra: Create masterkey Artifact Registry repo + grant runtime SA reader                       | 2026-06-30           |
+| #211  | verify: Confirm agile-flow-app health post-merge before var flip                               | 2026-06-30           |
+| #212  | infra: Flip GitHub vars (CLOUD_RUN_SERVICE + ARTIFACT_REPO) to masterkey                       | 2026-06-30           |
+| #217  | infra: Delete old Cloud Run service agile-flow-app                                             | 2026-06-30           |
+| #218  | infra: Archive image manifests + delete old Artifact Registry repo agile-flow                  | 2026-06-30           |
+
+All closed with `--reason "not planned"`. Each got a closing comment citing plan §6 and #237. Each project #2 board item moved to `Status: Done` via GraphQL mutation.
+
+---
+
+## Reworked tickets (14)
+
+| #     | Title                                                                                                                 | Scope-update one-liner                                                                                                                                          |
+|-------|-----------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| #181  | epic: Phase 0 — Pre-flight discovery & state snapshots                                                                | Narrow to GitHub-side inventory only (board items, open PRs, forks); GCP snapshot sub-tickets closed.                                                            |
+| #184  | epic: Phase 3 — Pre-create masterkey infra and dry-run preview deploys                                                | Narrow to "verification + Supabase allowlist + optional dry-run"; pre-create infra absorbed by #237.                                                             |
+| #185  | epic: Phase 4 — Cutover (merge code PR, flip vars, deploy to masterkey)                                               | Collapse to 3 steps: merge Phase 1 PR (#210), verify masterkey health (#214), restore synthetic monitor (#215).                                                  |
+| #186  | epic: Phase 5 — Cleanup (delete old service, prune WIF, memory MCP audit)                                             | Half the work N/A (old project inaccessible); remaining scope: WIF prune in new project, Memory MCP audit, ADR-007, doc cleanup with R20.                       |
+| #197  | docs: Update supabase/config.toml project_id and CLAUDE.md project information block                                  | Add lines for new GCP project ID and new production URL (placeholder until #206 captures it).                                                                    |
+| #200  | infra: Dual-write WIF binding for cubrox/masterkey on deployer SA                                                     | NOT superseded by #237; #237 binds cubrox/cubrox, #200 adds cubrox/masterkey to same NEW project's SA before rename; member URI uses NEW project number.        |
+| #205  | infra: Pre-create Cloud Run masterkey service with correct env-var types (R13)                                        | Reframe as verification-only: confirm post-#237 service has correct env-var types (DATABASE_URL + ANTHROPIC_API_KEY literals; Supabase keys as secretKeyRef).    |
+| #208  | test: Dry-run preview-deploy + preview-cleanup + Supabase branching against masterkey                                 | Demote P0 → P1/P2; race window doesn't exist in v4; optional smoke test, Phase 1 PR preview covers it.                                                          |
+| #210  | release: Merge Phase 1 PR with vars STILL pointing at agile-flow-app                                                  | Drop "with old vars" framing; deploy.yml targets masterkey from day 1 (vars pre-set by #237); remove old-var guardrails.                                         |
+| #213  | release: Push trivial CHANGELOG commit to trigger deploy to masterkey                                                 | Demote to optional; #210 merge already triggers deploy.yml; close as duplicate of #210 once green.                                                               |
+| #219  | chore: Remove old Supabase Auth allowlist entries (production + preview)                                              | Demote P2 → P3; old entries harmless; leave for 6+ months per architect recommendation.                                                                          |
+| #220  | infra: Remove old WIF binding for cubrox/cubrox on deployer SA                                                        | Refers to binding in NEW project (added by #237); prune AFTER #200 dual-writes cubrox/masterkey and Phase 4 verifies green.                                      |
+| #221  | chore: Update Cloud Logging saved queries / dashboards / alerts (likely no-op)                                        | Most likely no-op close; new project starts empty; confirm zero legacy filters and close.                                                                        |
+| #223  | docs: Write ADR-007 "Rename to Master Key / masterkey" and resolve PLATFORM-GUIDE drift                               | Expand ADR-007 to document the GCP pivot (project-lost-then-re-provisioned) as load-bearing rename-history fact; PLATFORM-GUIDE drift work unchanged.            |
+
+All reworks done by **appending** a `## Scope update 2026-06-30 (v4.1 §6)` section to the existing body via `gh issue edit --body-file`. Original ticket content preserved verbatim. No status / column / label changes.
+
+---
+
+## Skipped / not touched
+
+- **#237** — body edits handled separately (per §6 explicit instruction "REWORK BODY — DONE").
+- **19 KEEP tickets** (#182, #183, #187, #192–#196, #198, #199, #201, #203, #206, #207, #209, #214, #215, #216, #222) — unchanged scope, no action.
+- **11 already-closed pre-v4** (#189, #202, #224–#231, #233, #234) — no action.
+
+---
+
+## Verification
+
+- `gh issue list --repo cubrox/cubrox --state closed --search "closed:>=2026-06-30"` returned all 8 CLOSE-list tickets plus the 11 already-closed pre-v4 tickets (#189 + #224–#231 + #233 + #234). Net new closes this run: 8.
+- Each closed ticket verified `state=CLOSED` and `stateReason=NOT_PLANNED`.
+- Each reworked ticket verified to contain `Scope update 2026-06-30` in its body (note #200's header carries the suffix `(v4.1 §6 — BC1 / NS4)` matching its more involved §6 row).
+- Project #2 board: 8 items moved to `Status: Done` via `updateProjectV2ItemFieldValue` GraphQL mutation against status field `PVTSSF_lAHOEMAdRM4BcBigzhWtZ-s` option `bcc8d933` (Done).
+
+---
+
+## Notes for follow-up reader
+
+- **#202** is listed in §6 as "ALREADY DONE — Board #2 created on cubrox user account 2026-06-30. Close as done with link to board." It was NOT closed by this run because the §6 row marks it as the operator's discretion (not on the CLOSE list — that list is reserved for "obsolete" tickets). If you want it closed as done, do it separately with `gh issue close 202 --reason completed`.
+- **#189** appears in the closed-since-2026-06-30 list because the §6 row tags it `ALREADY CLOSED 2026-06-30`. It was closed before this run started.
+- Pre-edit body snapshots saved to `/tmp/issue-<num>-before.md` during the run for emergency rollback; not checked in.


### PR DESCRIPTION
## Summary

Post-provisioning documentation update for #237. New production references land now that the fresh GCP project `master-key-501023` is provisioned with:
- Cloud Run service `masterkey` (URL `https://masterkey-7dit3lvmhq-uc.a.run.app`)
- Artifact Registry repo `masterkey`
- Deployer SA `deployer@master-key-501023.iam.gserviceaccount.com` with WIF bindings for `cubrox/cubrox` (both required roles)
- 3 Supabase secrets mirrored to GCP Secret Manager
- GitHub secrets + vars set (`CLOUD_RUN_SERVICE=masterkey`, `ARTIFACT_REPO=masterkey`, `GCP_REGION=us-central1`)

Also lands the architect's v4.1 plan revision + DevOps signoffs + reconciliation log (session artifacts that document the pivot).

## The smoking-gun test

This PR's `Deploy PR Preview to Cloud Run` check **must PASS** — that's been failing on every PR since session start due to the inaccessible-GCP-project issue. Green preview-deploy here proves #237's provisioning is fully working.

## Closes

- Contributes to #237 (steps 9, 10, 11 — test preview-deploy, prod deploy on merge, docs update)

## What changed

- `docs/LAUNCH-CHECKLIST.md`: production URL, orphaned-URL note, GCP project ID, repo + board URL corrections
- `CLAUDE.md`: Project Information block — repo + board URLs corrected (cubrox not vibeacademy), GCP project ID added, production URL added, AR repo location noted, organization corrected
- `reports/refactor/01-architecture-plan.md`: v4 + v4.1 changelog + §6 reconciliation table
- `reports/refactor/02c-devops-signoff-v4.md` (new): DevOps round-1 NEEDS_REVISION verdict
- `reports/refactor/02d-devops-signoff-v4.1.md` (new): DevOps round-2 ALIGNED verdict
- `reports/refactor/06-v4.1-reconciliation-log.md` (new): audit trail of 8 closes + 14 reworks

## Test plan

- [x] Pre-push hook clean (ruff + 271 pytest green)
- [ ] `Deploy PR Preview to Cloud Run` PASSES on this PR (the actual test — this has been failing all session)
- [ ] Preview URL returns 200 on `/healthz`
- [ ] All other CI checks stay green
- [ ] After merge: production deploy on main lands cleanly at masterkey service

🤖 Generated with [Claude Code](https://claude.com/claude-code)