### PR TITLE
refactor(E2 Phase 1): rename cubrox → masterkey identifiers (closes #192-#199)

### DIFF
--- a/.claude/PROJECT.md
+++ b/.claude/PROJECT.md
@@ -4,7 +4,7 @@
 
 - **Hosting**: gcp
 - **Compute**: Cloud Run
-- **Database**: Neon
+- **Database**: Supabase Postgres (project ref `gnswmcgaztcxslirulwm`)
 - **Selected**: 2026-05-02
 
 ## Stack
@@ -26,7 +26,7 @@
 
 ## Required secrets (Google Secret Manager → Cloud Run env)
 
-- `database-url` — Neon pooled connection string
+- `database-url` — Supabase pooled connection string
 - `anthropic-api-key` — Claude API key
 - `resend-api-key` — transactional email
 - `session-secret` — `itsdangerous` signing key (32 random bytes)
@@ -34,5 +34,6 @@
 ## Required GitHub Actions secrets
 
 - `GCP_PROJECT_ID`, `GCP_SERVICE_ACCOUNT`, `GCP_WORKLOAD_IDENTITY_PROVIDER`
-- `NEON_PROJECT_ID`, `NEON_API_KEY`, `PRODUCTION_DATABASE_URL`
-- `NEON_PARENT_BRANCH` (optional, defaults to `main`)
+- `SUPABASE_ACCESS_TOKEN` — for `supabase` CLI in CI (migrations, branching)
+- `SUPABASE_DB_URL` — session-pooler URL used by `baseline-migrations.yml`
+- `PRODUCTION_DATABASE_URL` — Supabase pooled URL for runtime

--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -68,8 +68,8 @@ Repository variables (non-sensitive):
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `GCP_REGION` | `us-central1` | Cloud Run + Artifact Registry region |
-| `ARTIFACT_REPO` | `agile-flow` | Artifact Registry repo name |
-| `CLOUD_RUN_SERVICE` | `agile-flow-app` | Cloud Run service name |
+| `ARTIFACT_REPO` | `masterkey` | Artifact Registry repo name |
+| `CLOUD_RUN_SERVICE` | `masterkey` | Cloud Run service name |
 | `APP_URL` | (none) | Runtime env var for self-referential URL construction |
 | `NEON_DB_USER` | `neondb_owner` | Neon database role |
 
@@ -304,8 +304,8 @@ Follow the Agent Output Format standard in CLAUDE.md.
 
 ```
 → CI green on main
-→ Previous revision: agile-flow-app-00042-xyz
-→ Built image: us-central1-docker.pkg.dev/myproject/agile-flow/agile-flow-app:abc1234
+→ Previous revision: masterkey-00042-xyz
+→ Built image: us-central1-docker.pkg.dev/myproject/masterkey/masterkey:abc1234
 → Pushed to Artifact Registry
 → Deployed new revision
 → Health check passed (200 OK)
@@ -317,11 +317,11 @@ Follow the Agent Output Format standard in CLAUDE.md.
 ---
 
 **Result:** Production deployed
-Service: agile-flow-app
+Service: masterkey
 Platform: GCP Cloud Run (us-central1)
-New revision: agile-flow-app-00043-abc
-Rollback target: agile-flow-app-00042-xyz
-URL: https://agile-flow-app-xyz.us-central1.run.app
+New revision: masterkey-00043-abc
+Rollback target: masterkey-00042-xyz
+URL: https://masterkey-xyz.us-central1.run.app
 Status: healthy
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
 
   a11y:
     # Accessibility & WCAG gate (A11Y-3 #26). Boots the FastAPI app with
-    # CUBROX_TEST_SEED_ENABLED=true so the test-only seed router is
+    # MASTERKEY_TEST_SEED_ENABLED=true so the test-only seed router is
     # mounted, then runs Playwright + axe-core against the reading
     # surface across four preference variants. Zero serious/critical
     # WCAG 2.0 A+AA violations is the merge gate.
@@ -314,7 +314,7 @@ jobs:
 
       - name: Run accessibility tests
         working-directory: tests/a11y
-        # CUBROX_TEST_SEED_ENABLED, SESSION_COOKIE_SECURE, and
+        # MASTERKEY_TEST_SEED_ENABLED, SESSION_COOKIE_SECURE, and
         # ENVIRONMENT are also set inside playwright.config.ts >
         # webServer.env, so the FastAPI subprocess sees them
         # regardless of whether the job-level env propagates.
@@ -322,7 +322,7 @@ jobs:
         # Supabase stack" step above) and are forwarded into the
         # uvicorn subprocess by playwright.config.ts.
         env:
-          CUBROX_TEST_SEED_ENABLED: 'true'
+          MASTERKEY_TEST_SEED_ENABLED: 'true'
           SESSION_COOKIE_SECURE: 'false'
           ENVIRONMENT: 'test'
         run: npx playwright test

--- a/.github/workflows/synthetic-monitor.yml
+++ b/.github/workflows/synthetic-monitor.yml
@@ -17,9 +17,15 @@ name: Synthetic Auth Monitor
 #     default) — that's how the throwaway session is minted.
 
 on:
-  schedule:
-    # Hourly at :17 past, to avoid top-of-hour runner congestion.
-    - cron: '17 * * * *'
+  # DISABLED for masterkey rename — restore in #215 (E5-T6). Cron can fire up
+  # to 15 min late; a fire mid-cutover would probe the resolved old-service
+  # URL and false-alert. workflow_dispatch stays enabled for manual diagnostic
+  # fires during the cutover window. TODO(#215): uncomment the schedule block
+  # once the masterkey Phase 4 cutover has landed and the new service is
+  # verified healthy for 24h.
+  # schedule:
+  #   # Hourly at :17 past, to avoid top-of-hour runner congestion.
+  #   - cron: '17 * * * *'
   workflow_dispatch:
     inputs:
       base_url:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Every agent output MUST follow these patterns. Full spec: `docs/AGENT-OUTPUT-STA
 ### Project Information
 
 - **License**: BSL 1.1 (converts to Apache 2.0 after 3 years per release)
-- **Project Name**: Cubrox (rename to Masterkey in flight — see plan v4.1)
+- **Project Name**: Master Key
 - **Repository**: https://github.com/cubrox/cubrox
 - **Project Board**: https://github.com/users/cubrox/projects/2
 - **Tech Stack**: FastAPI + Jinja2 + HTMX on Python 3.12
@@ -193,7 +193,7 @@ supabase start                                   # Start local Supabase stack (n
 supabase stop                                    # Stop local Supabase stack
 supabase status                                  # Show local stack URLs + keys
 supabase db reset                                # Reset local DB and re-apply migrations
-docker build -t agile-flow-app .                 # Local container build
+docker build -t masterkey .                      # Local container build
 ```
 
 ### Definition of Ready

--- a/app/api/home.py
+++ b/app/api/home.py
@@ -2,7 +2,7 @@
 
 GET / serves two audiences in one URL:
 
-  - **Anonymous visitors** see the Cubrox landing page with the
+  - **Anonymous visitors** see the Masterkey landing page with the
     sign-in form. The form posts to /login (AUTH-1) via HTMX, so a
     successful submit swaps the form for the "check your inbox"
     fragment without a page reload.

--- a/app/api/test_seed.py
+++ b/app/api/test_seed.py
@@ -29,7 +29,7 @@ SUPA-2c).
 This router must never load in production:
 
 1. **Module-level guard** (this file): the import itself raises
-   `RuntimeError` unless `CUBROX_TEST_SEED_ENABLED=true` OR
+   `RuntimeError` unless `MASTERKEY_TEST_SEED_ENABLED=true` OR
    `ENVIRONMENT=test`. Belt-and-braces — even a stray `import` from
    anywhere in the codebase fails loudly.
 
@@ -38,7 +38,7 @@ This router must never load in production:
    So unless the env var is explicitly set, the module is never
    imported in the first place.
 
-The CI a11y job sets `CUBROX_TEST_SEED_ENABLED=true` on the FastAPI
+The CI a11y job sets `MASTERKEY_TEST_SEED_ENABLED=true` on the FastAPI
 process via `playwright.config.ts > webServer.env`. Production Cloud
 Run revisions do not set this var; the seed router cannot be reached.
 """
@@ -63,12 +63,12 @@ from app.models.preference import Preference
 from app.services.comprehension import cache as comprehension_cache
 from app.services.comprehension.prompts import PROMPT_VERSION
 
-_SEED_ENABLED = os.environ.get("CUBROX_TEST_SEED_ENABLED") == "true"
+_SEED_ENABLED = os.environ.get("MASTERKEY_TEST_SEED_ENABLED") == "true"
 _TEST_ENV = os.environ.get("ENVIRONMENT") == "test"
 if not (_SEED_ENABLED or _TEST_ENV):
     raise RuntimeError(
         "app.api.test_seed loaded in non-test environment. "
-        "Set CUBROX_TEST_SEED_ENABLED=true (test envs only) or "
+        "Set MASTERKEY_TEST_SEED_ENABLED=true (test envs only) or "
         "ENVIRONMENT=test to enable."
     )
 

--- a/app/main.py
+++ b/app/main.py
@@ -56,12 +56,12 @@ app.include_router(passages.router)
 app.include_router(reading.router)
 
 # Test-only seed router (A11Y-2 #25, restored in #97). Only mounts when
-# CUBROX_TEST_SEED_ENABLED=true — the CI a11y job sets this via
+# MASTERKEY_TEST_SEED_ENABLED=true — the CI a11y job sets this via
 # playwright.config.ts > webServer.env. Production Cloud Run revisions
 # never set it, so the router is unreachable in prod. The router file
 # itself has a second module-level guard so a stray `import` would
 # also fail loudly.
-if os.environ.get("CUBROX_TEST_SEED_ENABLED") == "true":
+if os.environ.get("MASTERKEY_TEST_SEED_ENABLED") == "true":
     from app.api import test_seed
 
     app.include_router(test_seed.router)

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,7 @@ from fastapi.staticfiles import StaticFiles
 from app.api import auth, health, home, passages, reading, todos
 from app.integrations.supabase.auth import UnauthenticatedError
 
-app = FastAPI(title="Agile Flow GCP")
+app = FastAPI(title="Master Key")
 
 
 @app.exception_handler(UnauthenticatedError)

--- a/app/scripts/metric.py
+++ b/app/scripts/metric.py
@@ -27,7 +27,7 @@ DEFAULT_LOOKBACK_DAYS = 90
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        prog="cubrox-metric",
+        prog="masterkey-metric",
         description="Print reading-event totals since a given date.",
     )
     parser.add_argument(

--- a/app/services/ingestion/pdf.py
+++ b/app/services/ingestion/pdf.py
@@ -2,7 +2,7 @@
 
 Per ADR-003, this is the only library allowed for PDF parsing —
 PyMuPDF (`fitz`) is forbidden because its AGPL license would force
-the same terms onto Cubrox. pdfplumber is MIT-licensed.
+the same terms onto Masterkey. pdfplumber is MIT-licensed.
 
 Parsing happens in-process for ≤25 MB uploads (Cloud Run gives us
 32 MB of request-body headroom). The raw PDF bytes are never written

--- a/scripts/diagnose-cloudrun.sh
+++ b/scripts/diagnose-cloudrun.sh
@@ -20,7 +20,7 @@
 #   ./scripts/diagnose-cloudrun.sh --help
 #
 # Required: GCP_PROJECT_ID env or --project=<id>
-# Optional: GCP_REGION (default: us-central1), CLOUD_RUN_SERVICE (default: agile-flow-app)
+# Optional: GCP_REGION (default: us-central1), CLOUD_RUN_SERVICE (default: masterkey)
 #
 # Surfaced from the 2026-04-29 dry-run on tck517/tck517-app, where the
 # diagnostic command that cracked the case was a hand-composed multi-
@@ -32,7 +32,7 @@ set -uo pipefail
 
 PROJECT="${GCP_PROJECT_ID:-}"
 REGION="${GCP_REGION:-us-central1}"
-SERVICE="${CLOUD_RUN_SERVICE:-agile-flow-app}"
+SERVICE="${CLOUD_RUN_SERVICE:-masterkey}"
 
 print_help() {
   sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'

--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -797,7 +797,7 @@ fi
 #                              so first real deploy doesn't change ACL
 #   --port=8080 = matches the FastAPI Dockerfile and preview-deploy config
 
-SERVICE_NAME="${CLOUD_RUN_SERVICE:-agile-flow-app}"
+SERVICE_NAME="${CLOUD_RUN_SERVICE:-masterkey}"
 
 if gcloud run services describe "$SERVICE_NAME" \
     --region="$GCP_REGION" \
@@ -1008,7 +1008,7 @@ fi
 echo ""
 echo "   GCP_REGION             = $GCP_REGION"
 echo "   ARTIFACT_REPO          = $ARTIFACT_REPO"
-echo "   CLOUD_RUN_SERVICE      = agile-flow-app"
+echo "   CLOUD_RUN_SERVICE      = masterkey"
 echo "   NEXT_PUBLIC_APP_URL    = (your production URL)"
 echo ""
 echo "5. Push to main to trigger your first deployment."

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -2,11 +2,11 @@
 # https://supabase.com/docs/guides/local-development/cli/config
 #
 # Remote project ref: gnswmcgaztcxslirulwm
-# Org: vibeacademy · Plan: Pro · Branching: enabled (auto-branching via Supabase GitHub App)
+# Org: cubrox · Plan: Pro · Branching: enabled (auto-branching via Supabase GitHub App)
 #
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
-project_id = "cubrox"
+project_id = "masterkey"
 
 [api]
 enabled = true

--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -46,7 +46,7 @@
   {#
     METRIC-2: emit one reading_event on unload. The inline <script>
     measures the rendered <article>'s height in line-heights and stashes
-    the count on `window.cubroxLineCount`. The hidden <div> below uses
+    the count on `window.masterkeyLineCount`. The hidden <div> below uses
     hx-trigger="unload from:body" so HTMX fires the POST when the user
     leaves the page (close tab, navigate away, refresh). hx-vals 'js:'
     pulls the count from the window at fire time, not at render time.
@@ -57,7 +57,7 @@
     (function () {
       var surface = document.getElementById("reading-surface");
       if (!surface) {
-        window.cubroxLineCount = 1;
+        window.masterkeyLineCount = 1;
         return;
       }
       // Use computed line-height so a user's preference change (toggled
@@ -70,13 +70,13 @@
         lineHeight = parseFloat(cs.fontSize) * 1.2;
       }
       var lines = Math.max(1, Math.round(surface.scrollHeight / lineHeight));
-      window.cubroxLineCount = lines;
+      window.masterkeyLineCount = lines;
     })();
   </script>
   <div id="reading-close-beacon"
        hx-post="/passages/{{ passage.id }}/close"
        hx-trigger="unload from:body"
-       hx-vals='js:{lines: window.cubroxLineCount}'
+       hx-vals='js:{lines: window.masterkeyLineCount}'
        hx-swap="none"
        aria-hidden="true"
        style="display:none"></div>

--- a/tests/a11y/README.md
+++ b/tests/a11y/README.md
@@ -13,7 +13,7 @@ npx playwright test                 # spawns the FastAPI app, runs tests
 ```
 
 The config's `webServer` block starts `uv run uvicorn app.main:app --port 8080`
-from the repo root with `CUBROX_TEST_SEED_ENABLED=true` and a few other
+from the repo root with `MASTERKEY_TEST_SEED_ENABLED=true` and a few other
 test-only env vars, waits for `/api/health` to return 200, then runs the
 specs against `http://localhost:8080`.
 
@@ -35,9 +35,9 @@ route is implemented in [app/api/test_seed.py](../../app/api/test_seed.py)
 and gated by **two layers**:
 
 1. **Module guard** — `app/api/test_seed.py` raises `RuntimeError` on
-   import unless `CUBROX_TEST_SEED_ENABLED=true` OR `ENVIRONMENT=test`.
+   import unless `MASTERKEY_TEST_SEED_ENABLED=true` OR `ENVIRONMENT=test`.
 2. **Registration guard** — `app/main.py` only imports + mounts the
-   router when `CUBROX_TEST_SEED_ENABLED=true`. Production Cloud Run
+   router when `MASTERKEY_TEST_SEED_ENABLED=true`. Production Cloud Run
    revisions do not set this var, so the seed router is never loaded.
 
 The Python test suite covers the import guard

--- a/tests/a11y/fixtures/seed.ts
+++ b/tests/a11y/fixtures/seed.ts
@@ -13,7 +13,7 @@ export interface SeedResult {
  * BrowserContext so navigations are authenticated.
  *
  * The /test/seed-passage-and-login route is gated behind
- * CUBROX_TEST_SEED_ENABLED=true at app boot — see
+ * MASTERKEY_TEST_SEED_ENABLED=true at app boot — see
  * `app/api/test_seed.py`. Production Cloud Run revisions don't set
  * the var; the seed route returns 404 there because the router is
  * never registered.

--- a/tests/a11y/package-lock.json
+++ b/tests/a11y/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "cubrox-a11y-tests",
+  "name": "masterkey-a11y-tests",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cubrox-a11y-tests",
+      "name": "masterkey-a11y-tests",
       "devDependencies": {
         "@axe-core/playwright": "4.11.3",
         "@playwright/test": "1.60.0"
@@ -84,6 +84,20 @@
       }
     },
     "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/playwright-core": {
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",

--- a/tests/a11y/package.json
+++ b/tests/a11y/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cubrox-a11y-tests",
+  "name": "masterkey-a11y-tests",
   "private": true,
   "description": "Playwright + axe-core accessibility harness. Scoped to tests/a11y/ — production stays Node-free. See tests/a11y/README.md.",
   "scripts": {

--- a/tests/a11y/playwright.config.ts
+++ b/tests/a11y/playwright.config.ts
@@ -62,7 +62,7 @@ export default defineConfig({
       // Enable the test-only seed router (POST /test/seed-passage-and-login)
       // used by reading_surface.spec.ts. See app/api/test_seed.py for the
       // module-level guardrail; production Cloud Run never sets this.
-      CUBROX_TEST_SEED_ENABLED: "true",
+      MASTERKEY_TEST_SEED_ENABLED: "true",
       // Harness runs over http://localhost; secure-only cookies would
       // never be sent back to the seed-issued session.
       SESSION_COOKIE_SECURE: "false",

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -70,12 +70,12 @@ def test_redirect_url_uses_x_forwarded_headers_when_present(
         data={"email": "reader@example.com"},
         headers={
             "x-forwarded-proto": "https",
-            "x-forwarded-host": "pr-42---agile-flow-app-xyz.run.app",
+            "x-forwarded-host": "pr-42---masterkey-xyz.run.app",
         },
     )
     call = supabase_mock.auth.sign_in_with_otp.call_args
     redirect = call.args[0]["options"]["email_redirect_to"]
-    assert redirect == "https://pr-42---agile-flow-app-xyz.run.app/auth/callback"
+    assert redirect == "https://pr-42---masterkey-xyz.run.app/auth/callback"
 
 
 def test_supabase_upstream_error_returns_502(client: TestClient, supabase_mock: MagicMock) -> None:

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -94,9 +94,9 @@ def test_landing_page_signin_form_swaps_inline(client: TestClient) -> None:
 def test_landing_page_mentions_product_name(client: TestClient) -> None:
     """Basic branding sanity check — visiting the URL should make it
     obvious you're looking at Master Key (the public product name),
-    not the starter template's todo demo. 'Cubrox' remains the
-    internal codebase identifier (repo name, package name) but is
-    no longer surfaced to users."""
+    not the starter template's todo demo. Post-rename (Epic #182),
+    the internal codebase identifier is aligned with the public
+    brand: `masterkey` (repo name after #201, package + config)."""
     body = client.get("/").text
     assert "Master Key" in body
 

--- a/tests/test_passage_close.py
+++ b/tests/test_passage_close.py
@@ -218,20 +218,20 @@ def test_reading_view_template_contains_close_beacon(client: TestClient, session
     assert f'hx-post="/passages/{passage.id}/close"' in body
     assert 'hx-trigger="unload from:body"' in body
     # The hx-vals JS expression pulls from the inline-script-set global.
-    assert "window.cubroxLineCount" in body
+    assert "window.masterkeyLineCount" in body
 
 
 def test_reading_view_template_contains_line_count_script(
     client: TestClient, session: Session
 ) -> None:
     """The inline <script> that measures the rendered <article>'s
-    height and sets window.cubroxLineCount must be present. Pin it
+    height and sets window.masterkeyLineCount must be present. Pin it
     so a future refactor doesn't silently drop the measurement."""
     user = signed_in(session)
     passage = _make_passage(session, user.id)
 
     body = client.get(f"/read/{passage.id}").text
-    assert "window.cubroxLineCount" in body
+    assert "window.masterkeyLineCount" in body
     # The script reads computed line-height — pin the property reference
     # so a refactor that drops it surfaces here, not in production.
     assert "lineHeight" in body

--- a/tests/test_seed_route.py
+++ b/tests/test_seed_route.py
@@ -2,7 +2,7 @@
 
 These tests exercise the actual POST /test/seed-passage-and-login
 route. The conftest doesn't normally register this router (the
-conditional in `app/main.py` only fires when `CUBROX_TEST_SEED_ENABLED=true`
+conditional in `app/main.py` only fires when `MASTERKEY_TEST_SEED_ENABLED=true`
 at app boot), so we mount the router onto the existing test app via
 FastAPI's `include_router` for the duration of each test.
 

--- a/tests/test_test_seed_guard.py
+++ b/tests/test_test_seed_guard.py
@@ -2,7 +2,7 @@
 
 `app/api/test_seed.py` must NEVER load in a non-test environment.
 The module's import-time guard raises RuntimeError unless one of:
-  - CUBROX_TEST_SEED_ENABLED=true (set explicitly by the a11y harness)
+  - MASTERKEY_TEST_SEED_ENABLED=true (set explicitly by the a11y harness)
   - ENVIRONMENT=test (set by the conftest in unit-test runs)
 
 These tests simulate a production-like env (neither var set to a test
@@ -22,7 +22,7 @@ def test_test_seed_refuses_to_load_in_non_test_environment(
     """Belt-and-braces: even if someone bypasses the conditional import
     in app/main.py and tries to import the module directly, the
     module-level guard fires."""
-    monkeypatch.delenv("CUBROX_TEST_SEED_ENABLED", raising=False)
+    monkeypatch.delenv("MASTERKEY_TEST_SEED_ENABLED", raising=False)
     monkeypatch.setenv("ENVIRONMENT", "production")
 
     # Drop any previously cached import so we re-execute the module body
@@ -38,8 +38,8 @@ def test_test_seed_loads_when_explicitly_enabled(
 ) -> None:
     """Sanity check: with the harness env var set, the import succeeds
     and the router object is exposed. Mirrors what app/main.py does at
-    boot when CUBROX_TEST_SEED_ENABLED=true."""
-    monkeypatch.setenv("CUBROX_TEST_SEED_ENABLED", "true")
+    boot when MASTERKEY_TEST_SEED_ENABLED=true."""
+    monkeypatch.setenv("MASTERKEY_TEST_SEED_ENABLED", "true")
     monkeypatch.setenv("ENVIRONMENT", "production")  # still allowed by the guard
     sys.modules.pop("app.api.test_seed", None)
 
@@ -50,10 +50,10 @@ def test_test_seed_loads_when_explicitly_enabled(
 def test_test_seed_loads_in_test_environment_without_enable_var(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The pytest conftest may not set CUBROX_TEST_SEED_ENABLED, but
+    """The pytest conftest may not set MASTERKEY_TEST_SEED_ENABLED, but
     setting ENVIRONMENT=test is sufficient. This is the "running under
     pytest with explicit env=test" path."""
-    monkeypatch.delenv("CUBROX_TEST_SEED_ENABLED", raising=False)
+    monkeypatch.delenv("MASTERKEY_TEST_SEED_ENABLED", raising=False)
     monkeypatch.setenv("ENVIRONMENT", "test")
     sys.modules.pop("app.api.test_seed", None)
 


### PR DESCRIPTION
## Summary

Epic 2 (Phase 1) codebase rename — single feature branch with 8 focused commits, one per ticket. Every in-repo identifier that referred to `cubrox` or `agile-flow-app` now says `masterkey` (or `Master Key` where public brand is preferred).

Per plan v4.1, Phase 1 is unaffected by the GCP pivot — this is a pure code-level rename that ships behind no infra change. Since #237 already provisioned the new GCP project and #200 dual-wrote WIF, this PR's preview-deploy will land on `masterkey` naturally.

## Closes (via commit messages)

- Closes #192 — CUBROX_TEST_SEED_ENABLED → MASTERKEY_TEST_SEED_ENABLED
- Closes #193 — window.cubroxLineCount → window.masterkeyLineCount
- Closes #194 — app metadata strings (FastAPI title, metric prog, docstrings)
- Closes #195 — tests/a11y package + fixture URLs
- Closes #196 — .gembaflow-overrides script defaults (provision-gcp, diagnose-cloudrun)
- Closes #197 — supabase/config.toml project_id + CLAUDE.md project info
- Closes #198 — .gembaflow-overrides persona renames + PROJECT.md Supabase fix
- Closes #199 — disable synthetic-monitor cron for cutover window

## Commits (chronological)

```
1c5992d chore: disable synthetic-monitor cron for cutover (closes #199)
00541bf refactor: apply .gembaflow-overrides persona renames + PROJECT.md fix (closes #198)
befc859 docs: rename supabase/config.toml project_id + finish CLAUDE.md project block (closes #197)
a9d080d refactor: rename agile-flow-app → masterkey defaults in scripts (closes #196)
608ef18 refactor: rename tests/a11y package + fixture URLs (closes #195)
9999119 refactor: rename app metadata strings (closes #194)
a3f25b7 refactor: rename window.cubroxLineCount → window.masterkeyLineCount (closes #193)
ec3711f refactor: rename CUBROX_TEST_SEED_ENABLED → MASTERKEY_TEST_SEED_ENABLED (closes #192)
```

## Follow-ups explicitly deferred

- **#215 (E5-T6)** — restore synthetic-monitor cron after Phase 4 cutover completes + 24h stability. TODO comment in `synthetic-monitor.yml` references this.
- **#201** — `gh repo rename cubrox/cubrox → cubrox/masterkey`. Now unblocked once this Phase 1 PR merges.
- **#202 (board URL placeholder)** — already resolved during grooming (board #2 exists; ticket already closed as completed).

## Test plan

- [x] Pre-push hook clean (ruff + 271 pytest green)
- [ ] All framework CI checks green (lint, build, test, json-validate, version-parity, python, node, a11y, actionlint)
- [ ] `Deploy PR Preview to Cloud Run` green (should be — #237 + #200 landed)
- [ ] Preview URL responds with `Master Key` in `/` body

🤖 Generated with [Claude Code](https://claude.com/claude-code)