### PR TITLE
code: return 429 with Retry-After on Supabase rate-limit for /login (closes #247)

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -29,6 +29,7 @@ from typing import Annotated
 from email_validator import EmailNotValidError, validate_email
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse, RedirectResponse
+from supabase_auth.errors import AuthApiError
 
 from app.config import Settings, get_settings
 from app.integrations.supabase.auth import SUPABASE_COOKIE_NAME, current_user
@@ -81,9 +82,15 @@ def login(
     Supabase will create the user on first verify, and we deliberately
     don't surface "unknown email" so this route can't enumerate.
 
-    Only failure visible to the client is a 422 for malformed-format
-    input. Errors from Supabase (rate limit at their layer, transient)
-    surface as 502.
+    Failures visible to the client:
+      - 422 for malformed email format.
+      - 429 with Retry-After when Supabase's shared SMTP pool rate-
+        limits us (#247, from #245 postmortem) — the app maps this to
+        a user-facing "try again in a few minutes" message so HTMX/
+        browsers back off gracefully. Custom SMTP via Resend (#246)
+        moves rate limits off Supabase's shared pool structurally.
+      - 502 for anything else (network, config bug, non-rate-limit
+        Supabase error). Enumeration guard: generic message.
     """
     try:
         result = validate_email(email, check_deliverability=False)
@@ -101,9 +108,23 @@ def login(
                 "options": {"email_redirect_to": redirect_url},
             }
         )
+    except AuthApiError as exc:
+        # Supabase-side error. Distinguish rate limits from everything
+        # else so users get an actionable message and operators get a
+        # meaningful status code (429 is the standard signal that
+        # HTMX/browsers already know how to back off from). Enumeration
+        # guard: we don't echo Supabase's message verbatim for non-rate-
+        # limit errors (which can leak whether an email is known).
+        if exc.code == "over_email_send_rate_limit" or "rate limit" in exc.message.lower():
+            raise HTTPException(
+                status_code=429,
+                detail="Too many sign-in emails just now. Please try again in a few minutes.",
+                headers={"Retry-After": "300"},
+            ) from exc
+        raise HTTPException(status_code=502, detail="Sign-in unavailable") from exc
     except Exception as exc:
-        # Don't leak Supabase internals; log via Cloud Logging and
-        # return a 502 so the client knows the upstream failed.
+        # Non-Supabase failure (network, config, code bug). Same 502 as
+        # before so operators can spot the class from Cloud Logging.
         raise HTTPException(status_code=502, detail="Sign-in unavailable") from exc
 
     return GENERIC_FRAGMENT

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -9,6 +9,10 @@ Covers the Definition of Done for the rewritten route (SUPA-3 / #82):
     falls back to settings.app_url otherwise (local-dev path)
   - Supabase upstream errors surface as 502 (not 500) so monitoring
     can tell server-side vs upstream failures apart
+  - Supabase rate-limit errors (429 from the shared SMTP pool) are
+    remapped to 429 with Retry-After (#247, from #245 postmortem)
+    so HTMX + browsers can back off correctly and users see an
+    actionable message instead of a generic 502
 
 Rewritten in SUPA-5 (#84). The pre-SUPA-3 file tested Resend +
 MagicLinkToken; that whole flow no longer exists.
@@ -76,6 +80,60 @@ def test_redirect_url_uses_x_forwarded_headers_when_present(
     call = supabase_mock.auth.sign_in_with_otp.call_args
     redirect = call.args[0]["options"]["email_redirect_to"]
     assert redirect == "https://pr-42---masterkey-xyz.run.app/auth/callback"
+
+
+def test_supabase_rate_limit_returns_429_with_retry_after(
+    client: TestClient, supabase_mock: MagicMock
+) -> None:
+    """When Supabase's shared SMTP pool 429s the OTP request (30/hr project-wide
+    default), the app must return 429 with a Retry-After header and a user-
+    facing message. Root-caused during #245 postmortem — the old catch-all
+    Exception → 502 hid the rate limit for 20 minutes.
+
+    Enumeration guard: message must NOT vary based on whether the email
+    is registered — the 429 fires before any user-lookup happens.
+    """
+    from supabase_auth.errors import AuthApiError
+
+    supabase_mock.auth.sign_in_with_otp.side_effect = AuthApiError(
+        "email rate limit exceeded", 429, "over_email_send_rate_limit"
+    )
+    response = client.post("/login", data={"email": "reader@example.com"})
+    assert response.status_code == 429
+    assert "Retry-After" in response.headers
+    assert response.headers["Retry-After"] == "300"
+    detail = response.json()["detail"]
+    assert "try again" in detail.lower()
+
+
+def test_supabase_rate_limit_by_message_returns_429(
+    client: TestClient, supabase_mock: MagicMock
+) -> None:
+    """Belt-and-suspenders: even if Supabase's error code changes upstream,
+    a message containing 'rate limit' still maps to 429. Covers the case
+    where AuthApiError.code is None but message is descriptive."""
+    from supabase_auth.errors import AuthApiError
+
+    supabase_mock.auth.sign_in_with_otp.side_effect = AuthApiError(
+        "Email rate limit exceeded", 429, None
+    )
+    response = client.post("/login", data={"email": "reader@example.com"})
+    assert response.status_code == 429
+
+
+def test_supabase_non_rate_limit_authapierror_returns_502(
+    client: TestClient, supabase_mock: MagicMock
+) -> None:
+    """Non-rate-limit Supabase errors (invalid_grant, unauthorized, etc.)
+    still return 502 with the generic message — enumeration guard preserved."""
+    from supabase_auth.errors import AuthApiError
+
+    supabase_mock.auth.sign_in_with_otp.side_effect = AuthApiError(
+        "invalid grant", 400, "invalid_grant"
+    )
+    response = client.post("/login", data={"email": "reader@example.com"})
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Sign-in unavailable"
 
 
 def test_supabase_upstream_error_returns_502(client: TestClient, supabase_mock: MagicMock) -> None:


### PR DESCRIPTION
## Summary

Splits the catch-all `Exception → 502` in `login()` into three tiers so rate-limit errors from Supabase get their own HTTP status + user-facing message.

Root-caused during #245 postmortem 2026-07-01: the prior 502 hid a straightforward `email rate limit exceeded` (Supabase's default 30/hr shared SMTP pool) for 20 minutes because the log at Cloud Run level just said 502.

Closes #247.

## What changed

- **`app/api/auth.py`**: import `AuthApiError`; new `except AuthApiError` branch that maps rate-limit errors to 429 + `Retry-After: 300` + "Too many sign-in emails just now. Please try again in a few minutes." The non-rate-limit AuthApiError path still returns generic 502. Docstring updated.
- **`tests/test_auth_login.py`**: 3 new tests. Code-based 429, message-based 429 (belt-and-suspenders), non-rate-limit AuthApiError still 502.

## Test plan
- [x] All 274 tests pass (was 271)
- [x] Ruff check + format clean
- [x] Enumeration guard preserved (generic message for non-rate-limit path)
- [ ] CI green
- [ ] After merge: verify prod via the /tmp/otp-test.py path — Supabase rate-limit should surface as 429 not 502

## Not included (separately tracked)
- #245: bump Supabase's rate limit knob (immediate operator action)
- #246: configure custom SMTP via Resend so rate limits leave Supabase's shared pool entirely (structural fix, blocked on Resend domain-verify DNS)
- #248: update Supabase Site URL (drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)