### PR TITLE
code: display /login 429 rate-limit message via HTMX response-targets ext (closes #250)

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -43,6 +43,27 @@ CurrentUser = Annotated[object, Depends(current_user)]  # User; loose typing for
 
 GENERIC_FRAGMENT = "<p>Check your inbox for a sign-in link.</p>"
 
+# Rate-limit fragment: re-renders the sign-in form (so the user can retry with
+# the same or a different address) plus an inline error message HTMX's
+# response-targets ext (#250) swaps into #signin-form on a 429. Kept minimal
+# and self-contained — no template round-trip so the /login handler stays
+# entirely synchronous. Matches the visual shape of the form in
+# templates/home.html so the swap doesn't feel jarring.
+RATE_LIMIT_FRAGMENT = (
+    '<form id="signin-form" hx-post="/login" hx-target="#signin-form"'
+    ' hx-swap="outerHTML" hx-ext="response-targets" hx-target-4*="#signin-form">'
+    '<p role="alert" class="error">Too many sign-in emails just now.'
+    " Please try again in a few minutes.</p>"
+    '<label for="email">Email'
+    '<input type="email" id="email" name="email" required autofocus'
+    ' autocomplete="email" placeholder="you@example.com">'
+    "<small>We'll email you a one-time sign-in link."
+    " No password to remember.</small>"
+    "</label>"
+    '<button type="submit">Send me a sign-in link</button>'
+    "</form>"
+)
+
 # Cookie max-age. Supabase access tokens default to 1 hour but the
 # client refreshes them automatically; the cookie's max-age is the
 # upper bound on how long the user stays signed in across reloads.
@@ -74,7 +95,7 @@ def login(
     request: Request,
     settings: SettingsDep,
     email: Annotated[str, Form()],
-) -> str:
+) -> Response:
     """Issue a Supabase magic-link to the supplied email.
 
     Returns the same 202 + fragment for any well-formed email
@@ -116,18 +137,21 @@ def login(
         # guard: we don't echo Supabase's message verbatim for non-rate-
         # limit errors (which can leak whether an email is known).
         if exc.code == "over_email_send_rate_limit" or "rate limit" in exc.message.lower():
-            raise HTTPException(
+            # Return HTML fragment (not JSON HTTPException) so HTMX's
+            # response-targets ext (#250) can swap it into #signin-form
+            # for the real user to see instead of a silent 4xx.
+            return HTMLResponse(
+                content=RATE_LIMIT_FRAGMENT,
                 status_code=429,
-                detail="Too many sign-in emails just now. Please try again in a few minutes.",
                 headers={"Retry-After": "300"},
-            ) from exc
+            )
         raise HTTPException(status_code=502, detail="Sign-in unavailable") from exc
     except Exception as exc:
         # Non-Supabase failure (network, config, code bug). Same 502 as
         # before so operators can spot the class from Cloud Logging.
         raise HTTPException(status_code=502, detail="Sign-in unavailable") from exc
 
-    return GENERIC_FRAGMENT
+    return HTMLResponse(content=GENERIC_FRAGMENT, status_code=202)
 
 
 @router.get("/auth/callback", response_model=None)

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,11 @@
 
   <!-- HTMX 2.x core. Add extensions from htmx.org/extensions as needed. -->
   <script src="https://unpkg.com/htmx.org@2.0.3/dist/htmx.min.js"></script>
+  <!-- response-targets: swap 4xx/5xx responses into hx-target-4xx / hx-target-5xx.
+       HTMX 2.x otherwise ignores error responses; we need this so the /login
+       429 rate-limit message actually renders in the sign-in form (#250, from
+       #247/#249 postmortem). Pinned major version for stability. -->
+  <script src="https://unpkg.com/htmx-ext-response-targets@2.0.2/response-targets.js"></script>
 
   <!-- Workshop-specific overrides -->
   <link rel="stylesheet" href="/static/style.css">

--- a/templates/home.html
+++ b/templates/home.html
@@ -20,7 +20,9 @@
   <form id="signin-form"
         hx-post="/login"
         hx-target="#signin-form"
-        hx-swap="outerHTML">
+        hx-swap="outerHTML"
+        hx-ext="response-targets"
+        hx-target-4*="#signin-form">
     <label for="email">
       Email
       <input

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -100,10 +100,18 @@ def test_supabase_rate_limit_returns_429_with_retry_after(
     )
     response = client.post("/login", data={"email": "reader@example.com"})
     assert response.status_code == 429
-    assert "Retry-After" in response.headers
-    assert response.headers["Retry-After"] == "300"
-    detail = response.json()["detail"]
-    assert "try again" in detail.lower()
+    assert response.headers.get("Retry-After") == "300"
+    # HTML fragment, not JSON — HTMX response-targets ext (#250) swaps this
+    # into #signin-form directly so the user sees the message.
+    assert response.headers["content-type"].startswith("text/html")
+    body = response.text
+    assert "try again" in body.lower()
+    # Fragment re-renders the sign-in form so the user can retry, AND carries
+    # the response-targets wiring so a subsequent 429 also swaps back into
+    # the form (not just the first one).
+    assert 'id="signin-form"' in body
+    assert 'hx-post="/login"' in body
+    assert 'hx-target-4*="#signin-form"' in body
 
 
 def test_supabase_rate_limit_by_message_returns_429(


### PR DESCRIPTION
## Summary

PR #249 introduced 429 responses on `/login` when Supabase's shared SMTP pool rate-limits us. But HTMX 2.x ignores 4xx by default — real users saw nothing. This PR makes the 429 message actually visible in the browser.

Closes #250.

## What changed

- **`templates/base.html`**: load [`htmx-ext-response-targets@2.0.2`](https://htmx.org/extensions/response-targets/) alongside htmx 2.0.3
- **`templates/home.html`**: add `hx-ext="response-targets"` and `hx-target-4*="#signin-form"` on the login form
- **`app/api/auth.py`**: 429 branch now returns `HTMLResponse` with a re-rendered sign-in form + inline alert message (`RATE_LIMIT_FRAGMENT` constant). 502 branches unchanged (still JSON `HTTPException` — preserves monitoring shape)
- **`tests/test_auth_login.py`**: updated the 429 test to assert HTML content-type, form re-render, and `hx-target-4*` wiring in body (so a repeat 429 also swaps into the form, not just the first one)

## Guardrails preserved (per #250 ticket)

- ✅ 200/202 happy-path swap unchanged
- ✅ 5xx responses still JSON (existing behavior)
- ✅ Enumeration guard preserved — 429 message doesn't vary by email

## Test plan

- [x] All 274 tests pass locally (was 274, no test count change)
- [x] Ruff check + format clean
- [ ] CI green
- [ ] After merge: manually trigger rate limit against prod, verify browser shows the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)