### PR TITLE
docs(journal): log 2026-07-02 — auth-broken diagnosis + fixes

### DIFF
--- a/reports/session-journals/2026-07-02.md
+++ b/reports/session-journals/2026-07-02.md
@@ -1,0 +1,103 @@
+# Session Journal — 2026-07-02
+
+*(Short session focused on production auth-broken diagnosis + fixes. Continuation of the marathon that landed the masterkey rename on 2026-07-01.)*
+
+## 1. Session Summary
+
+Diagnosed and fully fixed a production auth outage that surfaced ~18 hours after the repo rename. Root cause was Supabase's default 30-emails-per-hour project-wide rate limit — a red herring wrapped in what initially looked like a URL-configuration bug. Shipped 2 PRs (429 status + Retry-After on rate limit; HTMX response-targets extension so users actually see the error), closed a Site URL drift ticket, and filed 4 follow-ups (Resend SMTP, Retry-After tuning, code-whitelist tightening, and the HTMX display work that became today's second PR).
+
+## 2. Tickets Delivered
+
+| Phase | PR | Tickets closed | What |
+|-------|----|----------------|------|
+| Auth response codes | #249 | #247 | Split `/login` catch-all `Exception → 502` into three tiers: `AuthApiError` + rate-limit code/message → 429 with `Retry-After: 300` and user-facing message; other `AuthApiError` → 502 (preserved enumeration guard); non-Supabase exceptions → 502. Added 3 tests. |
+| Rate-limit UX | #253 | #250 | Wired HTMX response-targets extension so 429 responses actually render in the sign-in form area. Changed 429 branch to return `HTMLResponse` fragment (not JSON `HTTPException`). Updated existing 429 test for HTML shape. |
+| Operator dashboard | — | #245, #248 | #245 (P0 auth-broken) resolved by operator bumping Supabase's email OTP rate-limit knob. #248 (Site URL drift) resolved by operator updating Supabase Auth Site URL from `agile-flow-app-heo5ry7rua` → `masterkey-7dit3lvmhq`. |
+
+**Total**: 4 issues closed, 2 PRs merged.
+
+## 3. Tickets In Review
+
+None open at session end.
+
+## 4. Challenges and Mitigations
+
+| Challenge | Root cause | Mitigation | Prevention |
+|---|---|---|---|
+| Prod `/login` returned 202 at first, then started returning 502 six minutes later | User was clicking Save on Supabase dashboard between the two events, but the actual cause was Supabase's shared-SMTP-pool rate limit (30/hr project-wide) firing after enough tests. The dashboard changes were coincidental. | Diagnosed via a standalone Python script (`/tmp/otp-test.py`) that called `client.auth.sign_in_with_otp(...)` directly with the deployed anon key. Got `AuthApiError: email rate limit exceeded` (429) — the actual Supabase error that our app's catch-all was collapsing to 502. | Two structural fixes filed: #247 (make rate-limit errors visible as 429 not 502) + #246 (custom SMTP via Resend so rate limits leave Supabase's shared pool). |
+| Cloud Logging query kept returning "No data found" for stderr logs | The default LQL syntax in Logs Explorer treats each token as a SEARCH() literal string search, not a label filter. Multi-line queries got parsed as multiple text-search clauses AND'd together, matching nothing. | Switched from complex multi-part query to simple label filter `resource.labels.service_name="masterkey"` with a tight time window. Also fell back entirely from log-explorer to the direct-Python-repro approach. | For future Cloud Logging diagnostics, either use the console-native filter (label:"value" syntax) or bypass entirely with a local repro script. |
+| gcloud auth expired mid-session (again) | Cached tokens exceeded refresh window; interactive re-auth impossible in scripted context. | Fetched anon key via `supabase projects api-keys` (which uses `SUPABASE_ACCESS_TOKEN`, a different auth flow, still valid). Also, standalone Python OTP test script worked without gcloud auth (only needed the raw anon key). | If diagnostic work is expected, cache the anon key as a shell variable early in the session instead of re-fetching. |
+| PR #253 pre-push hook rejected the `RATE_LIMIT_FRAGMENT` triple-quoted string | Two lines in the fragment (alert `<p>` and the `<input>` with all attributes) exceeded ruff's `E501` line-length limit of 100 chars. | Collapsed the fragment into a concatenated string with per-tag line breaks, all under 100 chars. Ruff cleaned up on second attempt. Amended commit + re-pushed. | HTML-in-Python fragments should be built as concatenated strings, not triple-quoted blocks, for automatic line-wrap compliance. |
+| Groomer's first attempt to file #250-#252 hit `label 'P3' not found` | Repo only has P0/P1/P2 labels — no P3. Ticket-create is atomic per label so all three failed. | Refiled with P2 label. All three landed on second attempt. | Grep `gh label list` before choosing labels on new tickets, or add a P3 label to the repo's convention if it's genuinely needed for polish work. |
+| Reviewer noted PR #249 didn't do the HTMX display work that #247's happy path had specified | Author (me) scoped #247's implementation to the auth.py change only, deferring the template work as too broad for the PR. Reviewer surfaced it as suggestion 1/3, which became this session's second PR (#253). | Filed as #250, immediately picked up as next work. Not a bug — a deliberate scope split that added one review round-trip but kept each PR tightly focused. | Two-PR splits are fine when each is genuinely independent; note the follow-up plan in the first PR body so reviewers can validate against original intent. |
+
+## 5. Insights and Learnings
+
+### Technical insights
+
+- **Supabase's default OTP rate limit is 30/hr PROJECT-WIDE, not per-email.** This is not documented prominently — the discovery came from a repro script hitting 429 even with a unique per-attempt email address. Custom SMTP (Resend, SendGrid) moves the rate limit off Supabase's shared pool onto your provider's tier (typically 100 req/sec on Resend Pro). File #246 tracks this.
+- **HTMX 2.x silently ignores 4xx responses by default.** No swap, no console error, no user-visible feedback. The `response-targets` extension makes 4xx addressable via `hx-target-4xx` (or `hx-target-4*` for wildcard). Load it in `base.html`; use `hx-ext="response-targets"` on the form.
+- **FastAPI `HTTPException` returns JSON regardless of the route's `response_class`.** To return HTML on an error, either use `HTMLResponse` directly (change return-branch to `return HTMLResponse(..., status_code=429, headers={...})` instead of `raise HTTPException(...)`), OR register a `RequestValidationError` / status-code handler that formats to HTML. The direct-return approach was simpler for this ticket.
+- **`AuthApiError.code` values are stable ErrorCode literals in `supabase-auth-py`** — code-match beats message-substring for reliability. Belt-and-suspenders (both) is defensible but flagged as broad by reviewer; #252 tightens to code-only whitelist.
+- **`gcloud run services describe <svc> --format=yaml` shows the LATEST revision, not the SERVING revision.** In a repo with active preview PRs, "latest" is usually a preview revision with 0% traffic and DIFFERENT env vars. Use `gcloud run revisions describe <specific-revision>` for the serving-revision config. Caught this during R13 verification but noting again — it's tricky.
+- **The reviewer's cross-check of `AuthApiError` attribute shape** (against upstream `supabase/auth-py`) is the kind of adversarial verification that catches copy-paste bugs. Worth doing on any new integration with an external library's error types.
+
+### Process insights
+
+- **Directly reproducing the failure via a local script beat 30 minutes of log-explorer debugging.** When application-level exception details are obscured by a catch-all, a minimal repro script (in this case, ~15 lines calling the same client method with the same credentials) yields the actual error message immediately. Should be the first diagnostic step for any "app returns 5xx, why?" investigation.
+- **Split PRs by scope, cross-reference in bodies.** #247's implementation deliberately omitted the HTMX display work (which became #250). Each PR was tightly focused and easy to review; the follow-up was tracked explicitly. Adds one review round-trip but keeps both PRs mergeable independently.
+- **The 3 review-suggestion follow-ups (#250, #251, #252) were filed BEFORE merging #249.** This preserves the reviewer's context and prevents the classic "we'll get to those later" losing track of them. Small overhead, big improvement in follow-through discipline.
+- **PR-link SOP applied cleanly on every ticket this session.** Automatic memory-file lookup ensured the SOP was applied without needing to re-derive it.
+
+### Domain insights
+
+- **Production authentication is now more resilient to Supabase rate-limit blips.** The 429 + Retry-After combo lets HTMX and browsers back off correctly; users see a friendly message instead of a bare 502. This matters more once real users onboard — a rate-limit event during launch would have been a serious UX problem.
+- **The Supabase OTP rate limit acts as a soft-DoS defense** but at a threshold that's easy for legitimate workshop bursts to trip. Custom SMTP is essentially required before any promoted signup event.
+- **"Auth broken" post-cutover is a foreseeable class of issue.** The magic-link path has ~5 distinct systems involved (app → Supabase Auth → SMTP → email deliverability → user click → Supabase verify → app callback). Any of them can silently drift post-cutover. `smoke_auth.py`'s admin-API path skips 3 of them (Supabase Auth → SMTP → user click). Real magic-link round-trip test is the only complete verification. Noted for future cutover DoDs.
+
+## 6. Tickets Created
+
+| # | Why |
+|---|---|
+| #245 | P0: /login broken on prod, root cause TBD at time of filing |
+| #246 | Configure custom SMTP via Resend (structural R26 mitigation) |
+| #247 | Handle Supabase rate-limit as 429 not 502 (code change) |
+| #248 | Update Supabase Site URL from old to new (drift cleanup) |
+| #250 | HTMX login form should display 429 (PR #249 review suggestion 1) |
+| #251 | Tune Retry-After on /login 429 (PR #249 review suggestion 2) |
+| #252 | Tighten 429 detection to code whitelist (PR #249 review suggestion 3) |
+
+## 7. Metrics
+
+- **PRs merged**: 2 (#249, #253)
+- **Issues closed**: 4 (#245, #247, #248, #250)
+- **Issues created**: 7 (#245, #246, #247, #248, #250, #251, #252)
+- **Board state**: 52 Done, 20 Backlog, 0 In Progress, 0 In Review, 0 Ready
+- **Tests**: 274 passing (was 271 at session start; +3 from #249's rate-limit tests, +0 net from #253 which updated existing tests without adding new ones)
+- **New risks flagged**: R26 (Supabase default rate limit is a real user-facing footgun)
+
+## 8. Next Up
+
+Small backlog, mostly optional. Priorities:
+
+1. **#246** (P1) — Configure custom SMTP via Resend. Blocked on operator DNS domain-verify. Unblocks: launch to any group larger than ~20 users at once.
+2. **#251** (P2) — Tune Retry-After on 429 (300 → 900+ or dynamic from Supabase response header). XS effort.
+3. **#252** (P2) — Tighten 429 detection to code whitelist (drop message-substring fallback). XS effort.
+4. **Phase 5 cleanup** — 17 tickets in Backlog, all 30-day-timer or v4.1-obsoleted. No urgency. Notable: #223 (ADR-007 for the rename decision), #222 (Memory MCP audit), #221 (Cloud Logging metric updates — likely no-op).
+5. **Session-postmortem insight worth codifying**: add a "real magic-link round-trip test" step to any future cutover DoD. `smoke_auth.py` alone is not sufficient.
+
+---
+
+## Memory Consolidation
+
+`→ Memory validation skipped — Memory MCP server not available` (this fork uses file-based memory at `~/.claude/projects/-Users-teddykim-projects-cubrox-cubrox/memory/`, no MCP server configured).
+
+Existing memory file: `feedback_pr-link-comment-sop.md` (applied cleanly this session — 3 PRs, 3 SOP comments posted per convention).
+
+Session insights worth memory promotion:
+
+- **`Lesson-supabase-otp-rate-limit`** — Supabase's default 30/hr shared-SMTP pool is a real production footgun; verify custom SMTP before any real-user launch. Could promote to a memory file if this comes up again.
+- **`Lesson-htmx-4xx-ignored-by-default`** — HTMX 2.x doesn't swap 4xx responses without the response-targets extension. Any error UX that relies on HTMX rendering needs this wired in.
+- **`Lesson-fastapi-httpexception-is-json-only`** — To return HTML on an error, use `return HTMLResponse(status_code=N, ...)` not `raise HTTPException(...)`.
+
+Not writing these to files this session — they're captured here + would only matter on similar-shape future work. Can promote as-needed.


### PR DESCRIPTION
Session journal for 2026-07-02: post-rename auth outage diagnosis + fixes. 2 PRs merged (#249 for 429 status, #253 for HTMX display), 4 tickets closed (#245, #247, #248, #250), 7 filed. Root cause: Supabase shared-SMTP rate limit — not URL config as first suspected. Structural follow-up (#246 Resend SMTP) tracked, blocked on operator DNS.

Captures 5 challenges + 6 technical insights + 4 process insights for future reference.