### PR TITLE
feat(skill): add /mockup design-review skill (retrofit)

### DIFF
--- a/.claude/commands/mockup.md
+++ b/.claude/commands/mockup.md
@@ -1,0 +1,204 @@
+---
+description: Compose a design brief and generate a throwaway HTML mockup for a proposed UX change before writing implementation tickets
+argument-hint: <slug>
+---
+
+<!--
+This skill is a DESIGN-REVIEW skill, NOT a bootstrap-chain gate.
+Masterkey has already run /bootstrap-architecture; this skill exists so that
+future major UX changes get a compose-brief -> generate-mockup step BEFORE
+tickets are filed against the change.
+
+This skill does NOT modify bootstrap-architecture. Do not add gate coupling
+in future revisions. If a future extension ever ties this skill to
+bootstrap-architecture, the gate must check *absence of
+docs/TECHNICAL-ARCHITECTURE.md* — NOT absence of a mockup — so re-runs on
+already-bootstrapped forks stay idempotent.
+
+Non-goals recorded from the retrofit design review:
+- No docs/MOCKUP.yaml sidecar (violates CLAUDE.md rule #7 — one canonical
+  location per fact; PRD already carries the source-of-truth content)
+- No --approve / --skip / --refine subcommands (re-run for iteration)
+- No docs/MOCKUP-APPROVAL.md audit trail (session journal is the audit trail)
+- No Path C starter-template hand-authoring (no consumer)
+-->
+
+Generate a throwaway HTML mockup grounded in this fork's product docs, for
+operator review before implementation tickets are written.
+
+## When to use
+
+Before filing tickets against any **major UX change** — new surface, redesigned
+existing surface, added funnel step. The mockup is a *low-cost gate* the
+operator reacts to in 15 minutes, ratifying design intent before the team
+spends days building against a mis-shaped hypothesis.
+
+**Not for:** small UI tweaks, copy edits, or already-scoped features that
+already have tickets. Overhead is not worth it below "major UX change" size.
+
+## Arguments
+
+- `<slug>` — a short kebab-case identifier for the mockup, e.g.
+  `reading-pane-v2`, `dashboards`, `subscription-flow`. Becomes the output
+  filename.
+
+Invocation:
+
+```text
+/mockup reading-pane-v2
+```
+
+## Preflight
+
+Verify inputs before composing the brief:
+
+1. **Required (hard):** `docs/PRODUCT-REQUIREMENTS.md` MUST exist. If missing,
+   STOP with `→ Missing docs/PRODUCT-REQUIREMENTS.md — run /bootstrap-product
+   first (or restore the file from git history)`.
+2. **Required (hard):** `docs/TECHNICAL-ARCHITECTURE.md` MUST exist. If
+   missing, STOP with `→ Missing docs/TECHNICAL-ARCHITECTURE.md — this fork
+   has not been bootstrapped, /mockup is a post-bootstrap design-review
+   skill`.
+3. **Soft (used if present):** `docs/POSITIONING-ANALYSIS.md`,
+   `docs/JOBS-TO-BE-DONE.md`, `docs/MARKET-RESEARCH.md`,
+   `docs/PRODUCT-ROADMAP.md`. Do NOT fail if these are absent — masterkey
+   may not have all of them. Log which ones are missing so the operator can
+   fill the gap by hand if it matters for this mockup.
+4. **Slug validation:** the argument must match `^[a-z0-9][a-z0-9-]*[a-z0-9]$`
+   (lowercase kebab-case). If invalid, STOP with `→ Invalid slug '<value>' —
+   use lowercase kebab-case, e.g. reading-pane-v2`.
+5. **Output collision check:** if `docs/mockups/<slug>-<YYYY-MM-DD>.html`
+   already exists for today's date, WARN and ask the operator whether to
+   overwrite. The mockup file is per-day-per-slug — a same-day re-run means
+   the operator is iterating, and overwrite is usually the intent.
+
+## Compose the design brief
+
+Extract these sections from the available docs:
+
+| Section | Source (in preference order) |
+|---|---|
+| Product summary (1 paragraph) | `PRODUCT-REQUIREMENTS.md` → executive summary or first section |
+| Target user + persona | `POSITIONING-ANALYSIS.md` (if present) → ICP + persona; else `PRODUCT-REQUIREMENTS.md` → user profile |
+| Core jobs to be done (3-5 statements) | `JOBS-TO-BE-DONE.md` (if present); else derive from PRD's user journey |
+| Screens to mock (5-8) | PRD's feature list, filtered to the ones the operator's slug covers |
+| Competitive landscape | `MARKET-RESEARCH.md` (if present); else omit — flag as gap in the brief |
+| Aesthetic / brand notes | Generic default: consumer-friendly, light theme (Notion / Linear-light). Masterkey has no brand-style doc; do NOT invent a palette |
+| Realistic content | Derive from PRD examples, not lorem ipsum. Match the persona and domain |
+| Explicit non-goals | Mockup is throwaway. Production stack is Jinja2 + HTMX per ADRs — mockup should NOT try to match that; whatever's cheapest to author is fine (Tailwind CDN is the empirical default) |
+
+The brief must be ~200-500 words, structured, and copy-pasteable directly
+into Claude Design or a Claude Artifacts conversation.
+
+Include an explicit instruction to the generator: **the output must be a
+single self-contained HTML file** (no build step, no external assets beyond
+CDN Tailwind + Google Fonts). Multi-screen mockups use a left-nav rail
+(`aside w-60`) that lets the reviewer step through screens in a single
+browser tab.
+
+## Path A — Claude Design (primary)
+
+If the operator has access to Claude Design (Pro / Max / Team / Enterprise):
+
+1. Emit the design brief in a fenced code block.
+2. Emit these steps for the operator:
+   1. Open [Claude Design](https://www.anthropic.com/news/claude-design-anthropic-labs).
+   2. Paste the brief. Attach `docs/PRODUCT-REQUIREMENTS.md` and any of the
+      soft docs that are present.
+   3. Iterate with Claude Design's inline commenting / adjustment knobs
+      until the mockup is close enough to react to substantively.
+   4. Export as **standalone HTML**.
+   5. Save the exported HTML to `docs/mockups/<slug>-<YYYY-MM-DD>.html`.
+3. Write a placeholder file at
+   `docs/mockups/<slug>-<YYYY-MM-DD>.html` containing:
+   - Line 1: `<!-- SPDX-License-Identifier: BUSL-1.1 -->`
+   - Line 2: `<!-- MOCKUP PLACEHOLDER — awaiting operator to paste Claude Design export. Slug: <slug>. Generated: YYYY-MM-DD. -->`
+   - A minimal `<!doctype html>` skeleton with a `<title>` reflecting the
+     slug, so opening the file in a browser confirms the path is correct.
+4. Confirm with the operator: `→ Placeholder written to docs/mockups/<slug>-<YYYY-MM-DD>.html. Paste your Claude Design export over it when ready.`
+
+## Path B — Claude Artifacts fallback
+
+If Claude Design is not available (any Claude account still has Artifacts):
+
+1. Emit the design brief in a fenced code block.
+2. Emit these steps:
+   1. Open a fresh conversation at [claude.ai](https://claude.ai).
+   2. Paste the brief. Also paste the contents of
+      `docs/PRODUCT-REQUIREMENTS.md` (and any soft docs, if referenced in
+      the brief).
+   3. Ask Claude to generate a single self-contained HTML mockup with a
+      left-nav rail covering the 5-8 screens listed in the brief.
+   4. Iterate 1-3 rounds via the Artifacts panel.
+   5. Copy the final HTML into `docs/mockups/<slug>-<YYYY-MM-DD>.html`.
+3. Write the same placeholder file described in Path A step 3 so the
+   destination path exists.
+4. Confirm as in Path A.
+
+## SPDX header enforcement
+
+The first line of every emitted `docs/mockups/*.html` MUST be:
+
+```html
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+```
+
+Masterkey is BSL 1.1; generated mockup HTML is derivative content and
+inherits the license. If the operator's Claude Design export doesn't
+include it, prepend the line manually before saving.
+
+## After the operator lands the artifact
+
+Once the real mockup HTML is in place (not the placeholder):
+
+1. Open the file in a browser to confirm it renders.
+2. Add a one-line entry to the current session journal
+   (`reports/session-journals/YYYY-MM-DD.md`) linking the mockup and
+   summarizing what the operator's reaction was. This is the audit
+   trail — no `MOCKUP-APPROVAL.md` sidecar is needed.
+3. If the mockup surfaces changes worth ticketing, use `/groom-backlog`
+   or `/create-ticket` to file them. Reference the mockup file path in
+   the ticket's Environment Context section.
+
+## Output format
+
+Report progress with per-step Progress Lines, then end with a Result Block:
+
+```text
+→ Preflight OK (hard: PRD + TECHNICAL-ARCHITECTURE; soft: 2/4 present)
+→ Slug validated: reading-pane-v2
+→ Composed 320-word design brief
+→ Emitted Path A instructions (Claude Design)
+→ Placeholder written to docs/mockups/reading-pane-v2-2026-07-02.html
+
+---
+
+**Result:** Mockup skill executed
+Slug: reading-pane-v2
+Placeholder: docs/mockups/reading-pane-v2-2026-07-02.html
+Path: A (Claude Design)
+Brief length: 320 words
+Missing soft inputs: POSITIONING-ANALYSIS.md, MARKET-RESEARCH.md
+Next: operator pastes Claude Design export over placeholder
+```
+
+If a hard input is missing, the Result Block reflects the halt:
+
+```text
+→ Preflight failed: docs/PRODUCT-REQUIREMENTS.md not found
+
+---
+
+**Result:** Preflight halted — /mockup did not run
+Missing: docs/PRODUCT-REQUIREMENTS.md
+Fix: run /bootstrap-product or restore the file from git history
+```
+
+## References
+
+- Upstream design plan (context only, not a runtime dependency):
+  `/Users/teddykim/projects/vibeacademy/gembaflow-meta/docs/plans/mockup-skill-downstream-implementation.md`
+- Reticle's mockup precedent (empirical single-file shape reference):
+  `feature-x/reticle:docs/MOCKUP.html`
+- Parent epic: #255 — `/mockup design-review skill (retrofit)`
+- ADR-008 (when merged): `/mockup` as design-review skill (retrofit reframing)

--- a/docs/mockups/test-mockup-2026-07-02.html
+++ b/docs/mockups/test-mockup-2026-07-02.html
@@ -1,0 +1,20 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+<!-- MOCKUP PLACEHOLDER — awaiting operator to paste Claude Design export. Slug: test-mockup. Generated: 2026-07-02. -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mockup placeholder — test-mockup</title>
+  </head>
+  <body>
+    <main>
+      <h1>Mockup placeholder — test-mockup</h1>
+      <p>
+        This file is a placeholder produced by the <code>/mockup</code> skill
+        on 2026-07-02. Paste your Claude Design (or Claude Artifacts) export
+        over this content when ready. Keep the SPDX header on line 1.
+      </p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Implements #256 — a downstream-scoped port of the upstream mockup-skill plan, reframed for `cubrox/masterkey` as a post-bootstrap **design-review skill**, not a bootstrap-chain gate. Future major UX changes get a compose-brief → generate-HTML-mockup step before implementation tickets are filed.

### What's added

- `.claude/commands/mockup.md` — the skill file
- `docs/mockups/test-mockup-2026-07-02.html` — dry-run output satisfying DoD

### Reduced scope vs. the upstream plan

Per the architect + devops joint review (both returned CONDITIONAL), the following were explicitly dropped from v1:

- Path C (starter-template hand-authoring) — no consumer
- `docs/MOCKUP.yaml` sidecar — CLAUDE.md rule #7 (one canonical location per fact); PRD carries source-of-truth content
- Modifications to `.claude/commands/bootstrap-architecture.md` — no gate coupling; noted explicitly in the skill's header comment
- `docs/MOCKUP-APPROVAL.md` audit trail — `reports/session-journals/` serves this purpose
- `--approve` / `--skip` / `--refine` subcommands — plain `/mockup <slug>` and re-run for iteration

## Adaptations for masterkey's actual doc state

The ticket's Environment Context claimed all four input docs exist. **Empirically, only `docs/PRODUCT-REQUIREMENTS.md` is present** — masterkey's bootstrap history did not produce `docs/POSITIONING-ANALYSIS.md`, `docs/JOBS-TO-BE-DONE.md`, or `docs/MARKET-RESEARCH.md`. Rather than hard-requiring docs that don't exist, the skill's preflight now:

- **Hard-requires**: `docs/PRODUCT-REQUIREMENTS.md` + `docs/TECHNICAL-ARCHITECTURE.md` (both present)
- **Soft-checks**: positioning / JTBD / market / roadmap docs — logs what's missing but does not fail
- Fails cleanly with actionable messages if the hard inputs are missing

## Dry-run verification

Executed the skill's placeholder-write path against slug `test-mockup`. Result:

```text
→ Preflight OK (hard: PRD + TECHNICAL-ARCHITECTURE; soft: 1/4 present — PRODUCT-ROADMAP.md)
→ Slug validated: test-mockup
→ Composed design brief (not executed — dry-run scope is placeholder write only)
→ Emitted Path A instructions (Claude Design)
→ Placeholder written to docs/mockups/test-mockup-2026-07-02.html

---

**Result:** Mockup skill executed
Slug: test-mockup
Placeholder: docs/mockups/test-mockup-2026-07-02.html
Path: A (Claude Design)
Next: operator pastes Claude Design export over placeholder
```

Verify the placeholder file's SPDX header (DoD line 3):

```console
$ head -1 docs/mockups/test-mockup-2026-07-02.html
<!-- SPDX-License-Identifier: BUSL-1.1 -->
```

## Preflight-failure path verification

Rather than temporarily renaming `docs/PRODUCT-REQUIREMENTS.md` (disruptive), the halt behavior is inspectable in the skill's Preflight section — when the hard input is missing, the skill emits:

```text
→ Preflight failed: docs/PRODUCT-REQUIREMENTS.md not found

---

**Result:** Preflight halted — /mockup did not run
Missing: docs/PRODUCT-REQUIREMENTS.md
Fix: run /bootstrap-product or restore the file from git history
```

The behavior is testable at any time by any operator with a fresh clone that lacks the PRD.

## DoD checklist

- [x] `.claude/commands/mockup.md` exists with frontmatter matching `groom-backlog.md`
- [x] Skill dry-runs on real slug `test-mockup` and produces `docs/mockups/test-mockup-2026-07-02.html`
- [x] Generated HTML file starts with `<!-- SPDX-License-Identifier: BUSL-1.1 -->` on line 1
- [x] `mockup.md` passes `markdownlint-cli2 mockup.md` locally (0 errors)
- [x] Skill file contains explicit "This skill does NOT modify bootstrap-architecture" comment
- [x] PR description includes dry-run output verbatim
- [x] `Closes #256`, cross-references `#255`
- [x] Preflight failure path documented + inspectable
- [x] `git diff main` shows no modifications to `.claude/commands/bootstrap-architecture.md` (only two added files)

## Test plan

- [x] `ruff check` — passed (pre-push hook)
- [x] `pytest` — 274 passed (pre-push hook)
- [x] `markdownlint-cli2 .claude/commands/mockup.md` — 0 errors
- [ ] Future session invokes `/mockup <slug>` against a real UX-change candidate and produces a mockup the operator reacts to substantively

## Related issues

Closes #256
Part of #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)