### PR TITLE
chore(docs): replace local absolute path in /mockup skill with upstream URLs

### DIFF
--- a/.claude/commands/mockup.md
+++ b/.claude/commands/mockup.md
@@ -196,8 +196,11 @@ Fix: run /bootstrap-product or restore the file from git history
 
 ## References
 
-- Upstream design plan (context only, not a runtime dependency):
-  `/Users/teddykim/projects/vibeacademy/gembaflow-meta/docs/plans/mockup-skill-downstream-implementation.md`
+- Upstream prior-art plans (context only, not a runtime dependency):
+  - [`vibeacademy/gembaflow-meta:plans/mockup-feature-spec.md`](https://github.com/vibeacademy/gembaflow-meta/blob/main/plans/mockup-feature-spec.md) (2026-06-04, PM product-shape)
+  - [`vibeacademy/gembaflow-meta:plans/mockup-implementation-plan.md`](https://github.com/vibeacademy/gembaflow-meta/blob/main/plans/mockup-implementation-plan.md) (2026-06-04, framework-architect)
+- Downstream retrofit synthesis (this fork's adoption reasoning):
+  `reports/downstream-reports/2026-07-03-mockup-pressure-test.md`
 - Reticle's mockup precedent (empirical single-file shape reference):
   `feature-x/reticle:docs/MOCKUP.html`
 - Parent epic: #255 — `/mockup design-review skill (retrofit)`


### PR DESCRIPTION
## Summary

Implements #261 during drain-run \`drain-2026-07-03T1530Z\` (anchor: #265).

Line 200 of \`.claude/commands/mockup.md\` referenced a machine-specific local absolute path (\`/Users/teddykim/...\`) that no other contributor could resolve. The originally-referenced plan file (\`mockup-skill-downstream-implementation.md\`) was authored locally 2026-07-02 and never pushed upstream.

## Fix

Replaces the broken local path with:

- Two upstream **prior-art** plan URLs that DO resolve (verified via \`gh api\`):
  - [\`plans/mockup-feature-spec.md\`](https://github.com/vibeacademy/gembaflow-meta/blob/main/plans/mockup-feature-spec.md) (2026-06-04, PM)
  - [\`plans/mockup-implementation-plan.md\`](https://github.com/vibeacademy/gembaflow-meta/blob/main/plans/mockup-implementation-plan.md) (2026-06-04, framework-architect)
- The downstream retrofit synthesis report we shipped in #262:
  \`reports/downstream-reports/2026-07-03-mockup-pressure-test.md\`

## DoD

- [x] \`.claude/commands/mockup.md\` no longer contains any \`/Users/\` absolute path
- [x] Both replacement URLs verified via \`gh api repos/vibeacademy/gembaflow-meta/contents/plans/...\`
- [x] \`markdownlint-cli2 .claude/commands/mockup.md\` — 0 errors
- [x] Pre-push hook green (ruff + 274 pytest)

## Test plan

- [x] Local: markdownlint 0 errors, pre-push hook green
- [ ] CI: markdownlint job passes
- [ ] Post-merge: any reader clicking the References section resolves to real files

Closes #261
Part of drain-run drain-2026-07-03T1530Z (anchor #265)

🤖 Generated with [Claude Code](https://claude.com/claude-code)