### PR TITLE
infra(ci): add 'Deploy PR Preview to Cloud Run' to agent-merge IGNORED_CHECKS

### DIFF
--- a/.github/workflows/agent-merge.yml
+++ b/.github/workflows/agent-merge.yml
@@ -97,7 +97,13 @@ jobs:
       # Render integration is empirically unreliable. See
       # docs/agent-merge-gate.md § "Informational checks" for the
       # 3-criteria bar for adding entries.
-      IGNORED_CHECKS: '[]'
+      # Downstream drift (masterkey #267): 'Deploy PR Preview to Cloud Run'
+      # legitimately reports 'skipping' on docs-only PRs due to preview-deploy's
+      # paths-ignore filter. Empirically observed during drain-run
+      # drain-2026-07-03T1530Z on PR #266 (docs-only) — the gate rejected the
+      # merge because the skipped check counted as non-SUCCESS. Adding it here
+      # so future docs-only drain runs pass. Preserve on template-sync.
+      IGNORED_CHECKS: '["Deploy PR Preview to Cloud Run"]'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Implements #267. Populates \`IGNORED_CHECKS\` in \`.github/workflows/agent-merge.yml\` with \`Deploy PR Preview to Cloud Run\` so docs-only PRs pass the drain gate.

## Root cause (empirical)

Discovered during **drain-run drain-2026-07-03T1530Z** on PR #266 (docs-only, implementing #261). The gate rejected the merge with:

\`\`\`
##[error]PR #266 has non-SUCCESS relevant checks (23 relevant of 23 total):
  Deploy PR Preview to Cloud Run
\`\`\`

The check reported \`skipping\` (correctly — masterkey's \`preview-deploy.yml\` has a paths-ignore filter that skips Cloud Run preview deploys for docs-only PRs). But the gate's condition 4 treats \`skipping\` as non-SUCCESS, so the merge was denied.

Wake-up summary from that halted drain: https://github.com/cubrox/masterkey/issues/265#issuecomment-4877840876

## Change

Single-line env-var edit:

\`\`\`diff
-      IGNORED_CHECKS: '[]'
+      IGNORED_CHECKS: '[\"Deploy PR Preview to Cloud Run\"]'
\`\`\`

Plus a comment block above it recording the drift + why, so future \`template-sync\` reviewers preserve it.

## Upstream drift discipline

- The upstream workflow's own comment (lines 94-97) explicitly documents this downstream-population pattern:
  > "The framework ships with an empty list. Downstream forks add entries based on their own observed flakiness"
- This PR is masterkey exercising the intended extension point, not a hack
- Downstream drift is recorded in the added comment above the env var
- Follow-up out of scope: file upstream downstream-report suggesting the framework provide a Cloud-Run-adopting-fork default preset

## DoD

- [x] \`.github/workflows/agent-merge.yml\` \`IGNORED_CHECKS\` includes \`Deploy PR Preview to Cloud Run\`
- [x] \`actionlint\` passes locally
- [x] Pre-push hook green (ruff + 274 pytest)
- [x] PR body notes the upstream-drift decision + rationale
- [ ] CI actionlint job passes
- [ ] Verification (deferred): the next docs-only PR the drain picks up should pass the gate — will be exercised naturally when #258 is drained

## Non-scope

- Verifying by re-dispatching bridge on #266 — that PR is already merged (operator merged manually after drain halt)
- Filing upstream downstream-report — separate ticket if we want to make this a framework-level improvement

## Test plan

- [x] Local: actionlint clean, pre-push hook green
- [ ] CI: actionlint job passes
- [ ] Next drain run: docs-only ticket (#258) passes the gate

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)