### PR TITLE
chore: tune Retry-After on /login 429 from 300 to 900 seconds

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -140,10 +140,19 @@ def login(
             # Return HTML fragment (not JSON HTTPException) so HTMX's
             # response-targets ext (#250) can swap it into #signin-form
             # for the real user to see instead of a silent 4xx.
+            # Supabase's shared-SMTP-pool default is 30 emails per project
+            # per hour. AuthApiError does not surface Supabase's actual
+            # Retry-After (checked upstream: only message/status/code).
+            # 300s (5 min) from #247 was optimistic — a client hitting 429
+            # would often retry back into the same hourly window. 900s
+            # (15 min) is a compromise: long enough to matter for a
+            # sliding-window recovery, short enough not to feel punitive
+            # when the user has a different email in mind. #246 (custom
+            # SMTP via Resend) is the structural fix.
             return HTMLResponse(
                 content=RATE_LIMIT_FRAGMENT,
                 status_code=429,
-                headers={"Retry-After": "300"},
+                headers={"Retry-After": "900"},
             )
         raise HTTPException(status_code=502, detail="Sign-in unavailable") from exc
     except Exception as exc:

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -100,7 +100,7 @@ def test_supabase_rate_limit_returns_429_with_retry_after(
     )
     response = client.post("/login", data={"email": "reader@example.com"})
     assert response.status_code == 429
-    assert response.headers.get("Retry-After") == "300"
+    assert response.headers.get("Retry-After") == "900"
     # HTML fragment, not JSON — HTMX response-targets ext (#250) swaps this
     # into #signin-form directly so the user sees the message.
     assert response.headers["content-type"].startswith("text/html")


### PR DESCRIPTION
## Summary

Implements #251 during drain-run \`drain-2026-07-03T1840Z\` (anchor #269, cycle 2). Increases the \`/login\` 429 Retry-After from 300s (5 min) to 900s (15 min).

## Investigation

Ticket asked whether \`AuthApiError\` exposes Supabase's own Retry-After (option 1). **No** — verified in \`supabase_auth.errors.AuthApiError\`: only \`message\`, \`status\`, and \`code\` are surfaced. Dynamic-from-response is not available.

## Rationale for 900s

- Supabase's shared-SMTP-pool default is 30 emails per project per hour → sliding window is ~1 hour
- 300s (from #247) was optimistic — clients hitting 429 would often retry back into the same window
- 3600s (full window) would be technically accurate but feels punitive if the user has a different email in mind
- 900s is the ticket-recommended compromise

Also added a code comment explaining the choice + why dynamic-from-response isn't possible.

## Structural fix reference

#246 (custom SMTP via Resend) is the real fix — it moves rate limiting off Supabase's shared pool entirely. This ticket is just tuning the interim behavior until #246 lands.

## Change

- \`app/api/auth.py\` — Retry-After 300 → 900 + rationale comment
- \`tests/test_auth_login.py\` — assertion updated

## DoD

- [x] Retry-After reflects a value calibrated to Supabase's actual rate-limit window (or explains why dynamic isn't possible)
- [x] Test updated to match
- [x] Pre-push hook green (ruff + 274 pytest)

## Test plan

- [x] Local: \`pytest tests/test_auth_login.py\` — 9 passed
- [x] Pre-push: ruff clean, 274 pytest passing
- [ ] CI: all jobs pass
- [ ] Gate: safety:reversible — starts drain's rate-limit clock

Closes #251
Drain-run: drain-2026-07-03T1840Z (anchor #269, cycle 2/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)