### PR TITLE
chore: tighten 429 detection to code whitelist, drop message fallback

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -64,6 +64,20 @@ RATE_LIMIT_FRAGMENT = (
     "</form>"
 )
 
+# AuthApiError codes that indicate a Supabase rate limit — map to 429 not 502.
+# The substring fallback that preceded this (#252, was in #247's PR #249) risked
+# misclassifying unrelated errors whose message happened to contain "rate limit".
+# The whitelist is the explicit inversion: only these codes are 429; everything
+# else (including future codes we haven't seen) is 502 until we add it here.
+# All three are real Supabase codes per supabase-auth-py.
+RATE_LIMIT_CODES = frozenset(
+    {
+        "over_email_send_rate_limit",
+        "over_sms_send_rate_limit",
+        "over_request_rate_limit",
+    }
+)
+
 # Cookie max-age. Supabase access tokens default to 1 hour but the
 # client refreshes them automatically; the cookie's max-age is the
 # upper bound on how long the user stays signed in across reloads.
@@ -136,7 +150,7 @@ def login(
         # HTMX/browsers already know how to back off from). Enumeration
         # guard: we don't echo Supabase's message verbatim for non-rate-
         # limit errors (which can leak whether an email is known).
-        if exc.code == "over_email_send_rate_limit" or "rate limit" in exc.message.lower():
+        if exc.code in RATE_LIMIT_CODES:
             # Return HTML fragment (not JSON HTTPException) so HTMX's
             # response-targets ext (#250) can swap it into #signin-form
             # for the real user to see instead of a silent 4xx.

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -20,6 +20,7 @@ MagicLinkToken; that whole flow no longer exists.
 
 from unittest.mock import MagicMock
 
+import pytest
 from fastapi.testclient import TestClient
 
 
@@ -114,19 +115,41 @@ def test_supabase_rate_limit_returns_429_with_retry_after(
     assert 'hx-target-4*="#signin-form"' in body
 
 
-def test_supabase_rate_limit_by_message_returns_429(
-    client: TestClient, supabase_mock: MagicMock
+@pytest.mark.parametrize(
+    "code",
+    ["over_email_send_rate_limit", "over_sms_send_rate_limit", "over_request_rate_limit"],
+)
+def test_supabase_rate_limit_codes_return_429(
+    client: TestClient, supabase_mock: MagicMock, code: str
 ) -> None:
-    """Belt-and-suspenders: even if Supabase's error code changes upstream,
-    a message containing 'rate limit' still maps to 429. Covers the case
-    where AuthApiError.code is None but message is descriptive."""
+    """Every rate-limit code on the RATE_LIMIT_CODES whitelist maps to 429.
+    The old message-substring fallback was dropped in #252 — a hypothetical
+    non-rate-limit error whose message happened to contain 'rate limit' should
+    not be misclassified. This test pins the whitelist to keep future edits
+    honest about what counts as rate-limited."""
     from supabase_auth.errors import AuthApiError
 
     supabase_mock.auth.sign_in_with_otp.side_effect = AuthApiError(
-        "Email rate limit exceeded", 429, None
+        "unrelated message text", 429, code
     )
     response = client.post("/login", data={"email": "reader@example.com"})
     assert response.status_code == 429
+
+
+def test_supabase_rate_limit_message_only_no_code_returns_502(
+    client: TestClient, supabase_mock: MagicMock
+) -> None:
+    """Regression guard for #252: an AuthApiError whose message contains
+    'rate limit' but whose code is NOT on the whitelist must NOT be
+    classified as 429. Before #252 this case was mapped to 429 via a
+    message-substring fallback; that fallback was intentionally removed."""
+    from supabase_auth.errors import AuthApiError
+
+    supabase_mock.auth.sign_in_with_otp.side_effect = AuthApiError(
+        "IP-level rate limit reached, check dashboard", 400, "unexpected_failure"
+    )
+    response = client.post("/login", data={"email": "reader@example.com"})
+    assert response.status_code == 502
 
 
 def test_supabase_non_rate_limit_authapierror_returns_502(


### PR DESCRIPTION
## Summary

Implements #252 during drain-run \`drain-2026-07-03T1840Z\` (anchor #269, cycle 3/3, second reversible after 30-min rate-limit pause).

Replaces the substring-based fallback in \`/login\`'s 429-detection with an explicit code whitelist. Closes the last of the three review suggestions from PR #249 review.

## Change

**Before:**
\`\`\`python
if exc.code == "over_email_send_rate_limit" or "rate limit" in exc.message.lower():
\`\`\`

**After:**
\`\`\`python
RATE_LIMIT_CODES = frozenset({
    "over_email_send_rate_limit",
    "over_sms_send_rate_limit",
    "over_request_rate_limit",
})
# ...
if exc.code in RATE_LIMIT_CODES:
\`\`\`

## Rationale (per ticket recommendation — approach 3)

- The old message fallback risked misclassifying unrelated errors whose text happened to contain "rate limit" — e.g., \`"IP-level rate limit reached, check dashboard"\` from a hypothetical future Supabase error
- The whitelist inversion: **only** these codes map to 429; everything else (including future codes we haven't seen yet) → 502 until explicitly added to the whitelist
- All three codes are real Supabase codes per \`supabase-auth-py\` — email + SMS + request rate limits

## Tests

- \`test_supabase_rate_limit_by_message_returns_429\` **replaced** with parameterized \`test_supabase_rate_limit_codes_return_429\` covering all 3 codes
- **New** \`test_supabase_rate_limit_message_only_no_code_returns_502\` — regression guard: an \`AuthApiError\` with \"rate limit\" in message but a non-whitelisted code MUST return 502, not 429

Went from 9 auth-login tests to 12.

## DoD

- [x] \`if exc.code in RATE_LIMIT_CODES:\` used, no substring match on the message
- [x] Test covers each code in the whitelist (parameterized × 3)
- [x] Regression test for the dropped substring fallback
- [x] Pre-push hook green (ruff + 274 pytest, now 277 with new tests)

## Test plan

- [x] Local: \`pytest tests/test_auth_login.py\` — 12 passed
- [x] Pre-push: ruff clean, full test suite passing
- [ ] CI: all jobs pass
- [ ] Gate: safety:reversible — 30-min rate-limit window since #271 merge has elapsed

Closes #252
Drain-run: drain-2026-07-03T1840Z (anchor #269, cycle 3/3 — closes the drain if all cycles ship)

🤖 Generated with [Claude Code](https://claude.com/claude-code)