### PR TITLE
chore(ci): re-enable synthetic auth monitor schedule (#215)

### DIFF
--- a/.github/workflows/synthetic-monitor.yml
+++ b/.github/workflows/synthetic-monitor.yml
@@ -17,15 +17,9 @@ name: Synthetic Auth Monitor
 #     default) — that's how the throwaway session is minted.
 
 on:
-  # DISABLED for masterkey rename — restore in #215 (E5-T6). Cron can fire up
-  # to 15 min late; a fire mid-cutover would probe the resolved old-service
-  # URL and false-alert. workflow_dispatch stays enabled for manual diagnostic
-  # fires during the cutover window. TODO(#215): uncomment the schedule block
-  # once the masterkey Phase 4 cutover has landed and the new service is
-  # verified healthy for 24h.
-  # schedule:
-  #   # Hourly at :17 past, to avoid top-of-hour runner congestion.
-  #   - cron: '17 * * * *'
+  schedule:
+    # Hourly at :17 past, to avoid top-of-hour runner congestion.
+    - cron: '17 * * * *'
   workflow_dispatch:
     inputs:
       base_url:


### PR DESCRIPTION
## Summary

Re-enables the hourly `schedule:` cron on the synthetic auth monitor, reversing the E2-T8 disable that was in place for the cubrox → masterkey rename cutover window.

The Phase 4 cutover has landed and the new service is verified healthy (#214 Done), so the guard that motivated the disable no longer applies. The monitor resolves its target via `gcloud run services describe ${SERVICE_NAME}` → `vars.CLOUD_RUN_SERVICE`, which already points at masterkey, so no URL change is needed — the schedule simply needed turning back on.

## Changes

- Uncomment the `schedule:` block (`cron: '17 * * * *'`, hourly at :17 past).
- Remove the `# DISABLED for masterkey rename` marker comment.
- `workflow_dispatch` trigger unchanged (per ticket guardrail).

Net: `+3 / -9` in a single file — no other changes bundled.

## Verification

- [x] `grep -E '^\s*schedule:' .github/workflows/synthetic-monitor.yml` returns 1 (uncommented).
- [x] YAML parses; `cron` = `17 * * * *`; `workflow_dispatch` still present.
- [ ] Post-merge: next :17-past run shows `success` via `gh run list --workflow=synthetic-monitor.yml --limit 1` (observable only after merge).

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)