### PR TITLE
feat(analytics): snapshot active preferences on reading events (#166)

### DIFF
--- a/app/api/reading.py
+++ b/app/api/reading.py
@@ -340,11 +340,18 @@ def passage_close(
         )
         return Response(status_code=204)
 
+    # ANALYTICS-1 (#166): snapshot the user's raw stored preferences so
+    # mode-correlation analysis reflects what they actually had set during the
+    # session, not their current settings. No preference row -> null snapshot
+    # (all defaults), which is not an error. Stored server-side only; never
+    # echoed in the response (this route returns 204 with no body) or logged.
+    stored_pref = session.get(Preference, user.id)
     session.add(
         ReadingEvent(
             owner_id=user.id,
             passage_id=passage_id,
             lines_processed=lines,
+            preferences_snapshot=stored_pref.values if stored_pref else None,
         )
     )
     session.commit()

--- a/app/models/reading_event.py
+++ b/app/models/reading_event.py
@@ -27,6 +27,7 @@ Indexes:
 
 import uuid
 from datetime import UTC, datetime
+from typing import Any
 
 import sqlalchemy as sa
 from sqlmodel import Field, SQLModel
@@ -54,3 +55,13 @@ class ReadingEvent(SQLModel, table=True):
     # `ReadingEvent(...)` without `occurred_at` works whether or not the
     # writer relies on the DB's clock.
     occurred_at: datetime = Field(default_factory=lambda: datetime.now(UTC), nullable=False)
+    # ANALYTICS-1 (#166): the user's raw stored preference values at the moment
+    # this event was recorded, so mode-correlation analysis reflects what the
+    # reader actually had set during the session (the `preference` table only
+    # holds their *current* settings). JSONB on Postgres, JSON on SQLite — same
+    # column type as Preference.values. Nullable: null means the user had no
+    # preference row (i.e. all defaults), which is not an error. Append-only,
+    # like the rest of this row — never updated after insert.
+    preferences_snapshot: dict[str, Any] | None = Field(
+        default=None, sa_column=sa.Column(sa.JSON, nullable=True)
+    )

--- a/supabase/migrations/20260720000000_add_preferences_snapshot_to_reading_event.sql
+++ b/supabase/migrations/20260720000000_add_preferences_snapshot_to_reading_event.sql
@@ -1,0 +1,16 @@
+-- ANALYTICS-1 (#166): capture the reader's active preferences on each event.
+--
+-- Additive, nullable JSONB column. Existing rows keep NULL (no backfill) —
+-- a NULL snapshot means "the user had no preference row at event time", i.e.
+-- all defaults. The write path (POST /passages/{id}/close) populates it from
+-- the user's `preference.values` blob; ANALYTICS-2 reads it for
+-- mode-correlation analysis.
+--
+-- JSONB (not JSON) to match `preference.values` and to keep the door open for
+-- containment/GIN queries in the dashboard without a follow-up migration.
+--
+-- IF NOT EXISTS keeps the migration idempotent across re-applies and per-PR
+-- Supabase branches. The reading_event RLS policy (owner_id = auth.uid())
+-- already covers this column — no policy change needed.
+ALTER TABLE public.reading_event
+    ADD COLUMN IF NOT EXISTS preferences_snapshot jsonb DEFAULT NULL;

--- a/tests/test_passage_close.py
+++ b/tests/test_passage_close.py
@@ -17,6 +17,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
 from app.models.passage import Passage
+from app.models.preference import Preference
 from app.models.reading_event import ReadingEvent
 from tests.conftest import make_user, signed_in
 
@@ -235,3 +236,91 @@ def test_reading_view_template_contains_line_count_script(
     # The script reads computed line-height — pin the property reference
     # so a refactor that drops it surfaces here, not in production.
     assert "lineHeight" in body
+
+
+# ---------------------------------------------------------------------------
+# ANALYTICS-1 (#166) — preferences snapshot on the reading event
+# ---------------------------------------------------------------------------
+
+
+def _set_preference(session: Session, owner_id: uuid.UUID, values: dict) -> None:
+    """Create the user's Preference row directly, mirroring what the
+    POST /preferences/{key} route would persist."""
+    session.add(Preference(owner_id=owner_id, values=values))
+    session.commit()
+
+
+def test_close_snapshots_current_preferences(client: TestClient, session: Session) -> None:
+    """The reading_event row captures the user's stored preference values
+    at close time (DoD: snapshot matches preference.values)."""
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+    prefs = {"size": "24px", "bionic_enabled": True, "letter_spacing": "0.05em"}
+    _set_preference(session, user.id, prefs)
+
+    response = client.post(f"/passages/{passage.id}/close", data={"lines": 10})
+    assert response.status_code == 204
+
+    row = session.exec(select(ReadingEvent)).one()
+    assert row.preferences_snapshot == prefs
+
+
+def test_close_snapshot_is_null_when_no_preference_row(
+    client: TestClient, session: Session
+) -> None:
+    """A user who never toggled a preference has no Preference row; the
+    snapshot is null (all defaults), NOT a 500 (DoD + guardrail)."""
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+
+    response = client.post(f"/passages/{passage.id}/close", data={"lines": 7})
+    assert response.status_code == 204
+
+    row = session.exec(select(ReadingEvent)).one()
+    assert row.preferences_snapshot is None
+
+
+def test_close_snapshot_is_point_in_time_not_a_live_reference(
+    client: TestClient, session: Session
+) -> None:
+    """The snapshot records what the user had AT close time. A later
+    preference change must not retroactively alter the stored event —
+    the whole point of snapshotting rather than joining live."""
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+    _set_preference(session, user.id, {"size": "16px"})
+
+    client.post(f"/passages/{passage.id}/close", data={"lines": 5})
+
+    # User changes a preference after the event was recorded.
+    pref = session.get(Preference, user.id)
+    assert pref is not None
+    pref.values = {"size": "28px"}
+    session.add(pref)
+    session.commit()
+
+    row = session.exec(select(ReadingEvent)).one()
+    assert row.preferences_snapshot == {"size": "16px"}
+
+
+def test_close_snapshot_not_echoed_in_response_body(client: TestClient, session: Session) -> None:
+    """Guardrail: preferences_snapshot is user data and must never appear
+    in the HTTP response. The 204 carries no body regardless."""
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+    _set_preference(session, user.id, {"size": "24px", "bionic_enabled": True})
+
+    response = client.post(f"/passages/{passage.id}/close", data={"lines": 9})
+    assert response.text == ""
+
+
+def test_close_rejected_lines_writes_no_snapshot_row(client: TestClient, session: Session) -> None:
+    """An out-of-range line count still inserts NO row (existing
+    behaviour), so there's no snapshot to capture either."""
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+    _set_preference(session, user.id, {"size": "24px"})
+
+    response = client.post(f"/passages/{passage.id}/close", data={"lines": 0})
+    assert response.status_code == 204
+    assert session.exec(select(ReadingEvent)).all() == []


### PR DESCRIPTION
## Summary

Adds a nullable JSONB `preferences_snapshot` column to `reading_event` and populates it on passage-close from the user's stored preferences. This records **what the reader actually had set during the session** — the `preference` table only holds *current* settings, so mode-correlation analysis (ANALYTICS-2, #170) can't reconstruct it retroactively without this. This ticket is the hard prerequisite for #170.

## Changes

| File | Change |
|---|---|
| `supabase/migrations/20260720000000_…sql` | `ALTER TABLE reading_event ADD COLUMN IF NOT EXISTS preferences_snapshot jsonb DEFAULT NULL` |
| `app/models/reading_event.py` | `preferences_snapshot: dict \| None` via `sa.Column(sa.JSON)` (mirrors `Preference.values`) |
| `app/api/reading.py` | `POST /passages/{id}/close` reads `session.get(Preference, user.id)` and stores `.values` (or `None`) on the event |
| `tests/test_passage_close.py` | 5 new tests |

## Design notes / guardrails honored

- **Additive & backfill-free** — `IF NOT EXISTS`, `DEFAULT NULL`. Existing rows keep `NULL`; a null snapshot means "user had no preference row" (all defaults), which is explicitly not an error.
- **Point-in-time by construction** — stores a copy of `.values`, not a live join. A later preference change does not alter a recorded event (pinned by `test_close_snapshot_is_point_in_time_not_a_live_reference`).
- **Never exposed** — written server-side only; the route returns 204 with no body, and the snapshot is not logged (the existing invalid-lines WARN doesn't touch it). Pinned by a response-body test.
- **No change** to `lines_processed`, `occurred_at`, RLS, data-access client, or the beacon contract. The new column is automatically covered by the existing `owner_id = auth.uid()` RLS policy.
- **Stores raw `values`, not merged-with-defaults** — per the ticket's Happy Path. Analytics can merge against known defaults at query time; storing raw keeps "what did they explicitly set" recoverable.

## Verification

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy app/` — no issues (44 files)
- [x] `uv run pytest` — **297 passed** (+5)
- [x] Snapshot matches `preference.values`; null when no row; point-in-time; not echoed; no row on rejected lines
- [ ] ⚠️ **Migration not run under `supabase db reset` locally** — no Docker in this environment. Follows the `comprehension_enabled` migration pattern exactly; **CI's Supabase Preview applies it**. Reviewer/human: confirm the Supabase Preview check is green.

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)