### PR TITLE
feat(obs): add Sentry SDK for production error tracking (#167)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -31,6 +31,13 @@ class Settings(BaseSettings):
     # local dev override to False via env.
     session_cookie_secure: bool = True
 
+    # OBS-1 (#167): Sentry error tracking, deferred to Phase 2 by ADR-004.
+    # Optional by design — when unset (local dev, CI, tests) app/main.py
+    # skips `sentry_sdk.init()` entirely and the app behaves exactly as
+    # before. Populated in production/preview from the Secret Manager
+    # `sentry-dsn` secret, mapped as a Cloud Run env var.
+    sentry_dsn: str = ""
+
     # Supabase (SUPA-1/2/3). Required in non-dev environments so the
     # auth flow + future RLS-aware queries work. Empty defaults so the
     # test suite can run without env setup (the legacy auth path

--- a/app/main.py
+++ b/app/main.py
@@ -9,12 +9,39 @@ Production (Cloud Run) runs the same command — see Dockerfile.
 import os
 from pathlib import Path
 
+import sentry_sdk
 from fastapi import FastAPI, Request
 from fastapi.responses import RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.starlette import StarletteIntegration
 
 from app.api import auth, health, home, passages, reading, todos
+from app.config import get_settings
 from app.integrations.supabase.auth import UnauthenticatedError
+
+# OBS-1 (#167): initialise Sentry before the app is constructed so the
+# Starlette/FastAPI integrations wrap the whole middleware stack.
+#
+# Gated on SENTRY_DSN being set: unset (local dev, CI, tests) means no
+# init at all and the app behaves exactly as it did before this ticket —
+# no network calls, no middleware, no behavioural difference. That is why
+# the guard is on the DSN rather than on `environment`.
+#
+# Error capture only. `traces_sample_rate` is deliberately NOT set —
+# performance tracing is a separate tuning (and cost) decision, and
+# leaving it unset keeps the SDK's tracing off by default.
+#
+# No route/service/model file imports sentry_sdk: the integrations
+# capture unhandled exceptions automatically via middleware, so manual
+# instrumentation would be redundant.
+_settings = get_settings()
+if _settings.sentry_dsn:
+    sentry_sdk.init(
+        dsn=_settings.sentry_dsn,
+        integrations=[StarletteIntegration(), FastApiIntegration()],
+        environment=_settings.environment,
+    )
 
 app = FastAPI(title="Master Key")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "anthropic>=0.101.0",
     "pdfplumber>=0.11.9",
     "supabase>=2.27",
+    "sentry-sdk[fastapi]>=2.20",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ Supabase `gotrue.types.User`: it has `.id` (UUID) and `.email` (str).
 That's all the routes touch.
 """
 
+import os
 import uuid
 from collections.abc import Generator
 from types import SimpleNamespace
@@ -38,10 +39,23 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
-from app.db import get_session
-from app.integrations.supabase import client as supabase_client_module
-from app.integrations.supabase.auth import current_user, try_current_user
-from app.main import app
+# OBS-1 (#167): guarantee the test session never initialises Sentry.
+#
+# `app/main.py` calls `sentry_sdk.init()` at import time when SENTRY_DSN is
+# set. `from app.main import app` below runs at COLLECTION time, so on a
+# machine with a real SENTRY_DSN exported (or present in `.env` — Settings
+# sets `env_file=".env"`) the whole test run would execute against a LIVE
+# Sentry client, shipping test failures to the real project as fake
+# production errors. Blanking the var here, before that import, is what
+# enforces the ticket's "no sentry_sdk.init() in test runs" guardrail.
+#
+# MUST stay above the `app.*` imports — moving it below re-opens the hole.
+os.environ["SENTRY_DSN"] = ""
+
+from app.db import get_session  # noqa: E402
+from app.integrations.supabase import client as supabase_client_module  # noqa: E402
+from app.integrations.supabase.auth import current_user, try_current_user  # noqa: E402
+from app.main import app  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import sentry_sdk
 from fastapi.testclient import TestClient
 
 import app.main
@@ -30,10 +31,28 @@ from app.config import get_settings
 @pytest.fixture(autouse=True)
 def _restore_main_module():
     """Reload app.main after each test so the patched-import state
-    doesn't leak into the rest of the suite."""
+    doesn't leak into the rest of the suite.
+
+    The teardown reload MUST run with `sentry_sdk.init` patched AND
+    `SENTRY_DSN` blanked. Without both, it re-executes app.main's init
+    branch against the REAL environment (and `.env`, since Settings sets
+    `env_file=".env"`): a developer with a real `SENTRY_DSN` exported
+    would be left with a LIVE Sentry client active for every test module
+    that collects after this one, shipping their test failures to the
+    real Sentry project as fake production errors. That violates the
+    ticket's "no `sentry_sdk.init()` in test runs" guardrail, and it is
+    invisible in CI because CI has no DSN. Caught in review of PR #283.
+    """
     yield
     get_settings.cache_clear()
-    importlib.reload(app.main)
+    with patch.dict("os.environ", {"SENTRY_DSN": ""}, clear=False):
+        with patch("sentry_sdk.init"):
+            importlib.reload(app.main)
+    # Self-guard: if the patching above is ever removed, fail loudly here
+    # rather than silently leaking a live client into the rest of the run.
+    assert not sentry_sdk.get_client().is_active(), (
+        "teardown left a live Sentry client active — see this fixture's docstring"
+    )
 
 
 def _reload_main_with_env(env: dict[str, str]):

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -1,0 +1,111 @@
+"""Tests for the Sentry initialisation guard (OBS-1 #167).
+
+Covers the Definition of Done from issue #167:
+  - `SENTRY_DSN` unset -> `sentry_sdk.init()` is NOT called; the app
+    imports and serves requests exactly as before
+  - `SENTRY_DSN` set -> init IS called, with the configured environment
+    and WITHOUT performance tracing
+  - No route/service/model file imports sentry_sdk (the integrations
+    capture unhandled exceptions via middleware; manual instrumentation
+    would be redundant)
+
+The init runs at module import time in app/main.py, so these tests
+reload the module under a patched environment rather than calling a
+function. `get_settings` is lru_cached, so its cache is cleared too —
+otherwise the reload would reuse settings built from the real env.
+"""
+
+import importlib
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.main
+from app.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _restore_main_module():
+    """Reload app.main after each test so the patched-import state
+    doesn't leak into the rest of the suite."""
+    yield
+    get_settings.cache_clear()
+    importlib.reload(app.main)
+
+
+def _reload_main_with_env(env: dict[str, str]):
+    """Reload app.main with a patched environment, returning the mock
+    that stands in for sentry_sdk.init during the reload."""
+    get_settings.cache_clear()
+    with patch.dict("os.environ", env, clear=False):
+        with patch("sentry_sdk.init") as mock_init:
+            importlib.reload(app.main)
+            return mock_init
+
+
+def test_sentry_not_initialised_when_dsn_absent() -> None:
+    """The default state for local dev, CI, and tests: no DSN, no init.
+    The app must behave identically to before this ticket."""
+    mock_init = _reload_main_with_env({"SENTRY_DSN": ""})
+    mock_init.assert_not_called()
+
+
+def test_app_serves_requests_when_dsn_absent() -> None:
+    """Guardrail: the app MUST start and serve normally with no DSN."""
+    mock_init = _reload_main_with_env({"SENTRY_DSN": ""})
+    mock_init.assert_not_called()
+
+    with TestClient(app.main.app) as client:
+        assert client.get("/api/health").status_code == 200
+
+
+def test_sentry_initialised_when_dsn_present() -> None:
+    """With a DSN set, init is called with that DSN and the configured
+    environment.
+
+    Note `ENVIRONMENT=test` rather than `production`: Settings has a
+    defense-in-depth validator (`_refuse_sqlite_outside_dev`) that
+    rejects the default SQLite DATABASE_URL outside dev/test, so
+    claiming production here would fail on config, not on Sentry.
+    """
+    mock_init = _reload_main_with_env(
+        {"SENTRY_DSN": "https://test@o0.ingest.sentry.io/0", "ENVIRONMENT": "test"}
+    )
+
+    mock_init.assert_called_once()
+    kwargs = mock_init.call_args.kwargs
+    assert kwargs["dsn"] == "https://test@o0.ingest.sentry.io/0"
+    assert kwargs["environment"] == "test"
+
+
+def test_sentry_init_does_not_enable_performance_tracing() -> None:
+    """Guardrail: error capture only. `traces_sample_rate` must not be
+    set in this ticket — tracing is a separate tuning/cost decision."""
+    mock_init = _reload_main_with_env({"SENTRY_DSN": "https://test@o0.ingest.sentry.io/0"})
+
+    kwargs = mock_init.call_args.kwargs
+    assert "traces_sample_rate" not in kwargs
+    assert "profiles_sample_rate" not in kwargs
+
+
+def test_no_sentry_imports_in_routes_services_or_models() -> None:
+    """Guardrail: the SDK's integrations capture unhandled exceptions
+    automatically. A stray `import sentry_sdk` in a route/service/model
+    means someone added manual instrumentation this ticket forbids.
+
+    app/main.py is the ONE allowed location.
+    """
+    app_dir = Path(__file__).parent.parent / "app"
+    # Match real import statements only — a prose mention of
+    # `sentry_sdk.init()` in a comment (app/config.py has one) is not an
+    # import and must not trip this guard.
+    import_re = re.compile(r"^\s*(?:import\s+sentry_sdk|from\s+sentry_sdk)", re.MULTILINE)
+    offenders = [
+        path.relative_to(app_dir.parent).as_posix()
+        for path in app_dir.rglob("*.py")
+        if path.name != "main.py" and import_re.search(path.read_text(encoding="utf-8"))
+    ]
+    assert offenders == [], f"sentry_sdk imported outside app/main.py: {offenders}"

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlmodel" },
     { name = "supabase" },
     { name = "uvicorn", extra = ["standard"] },
@@ -46,6 +47,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.20" },
     { name = "sqlmodel", specifier = ">=0.0.22" },
     { name = "supabase", specifier = ">=2.27" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
@@ -1856,6 +1858,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
     { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
     { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.66.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/6f/d59cad0889d15fde85254cf58e701484de3f3f0406003b3197746910b19b/sentry_sdk-2.66.1.tar.gz", hash = "sha256:f882fb08710c5f8bfc603aafa3e901b384009a19cc3f76a572b863392ee81cdc", size = 940543, upload-time = "2026-07-22T12:26:54.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/d3/726bd88f0eece09ddf431bea4c9191c18e7a8d070b854eb0014d447712ee/sentry_sdk-2.66.1-py3-none-any.whl", hash = "sha256:86002793161d9a95ef04bdd8d442e9bfece5d989b755f05d6360215094a7aff6", size = 505555, upload-time = "2026-07-22T12:26:52.71Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes the **ADR-004 Phase 2 deferral**. Adds `sentry-sdk[fastapi]` and initialises it in `app/main.py` **before the FastAPI app is constructed**, so the Starlette/FastAPI integrations wrap the whole middleware stack and capture unhandled exceptions automatically.

## Changes

| File | Change |
|---|---|
| `pyproject.toml` | `sentry-sdk[fastapi]>=2.20` under runtime deps (resolved 2.66.1) |
| `app/config.py` | `sentry_dsn` setting (optional) |
| `app/main.py` | `sentry_sdk.init(...)` guarded by `if _settings.sentry_dsn:` |
| `tests/test_sentry_init.py` | 5 new tests |

## Design notes

- **Inert by default.** The guard is on the **DSN**, not on `environment`. Unset (local dev, CI, tests) → no init at all: no network calls, no middleware, no behavioural change. It activates the moment the secret is provisioned, **with no code change**.
- **Error capture only.** `traces_sample_rate` deliberately unset — performance tracing is a separate tuning/cost decision. A test asserts it stays absent.
- **No manual instrumentation.** No route/service/model file imports `sentry_sdk`; a test enforces this so nobody adds redundant instrumentation later.
- **Minor deviation from the ticket:** `sentry_dsn: str = ""` rather than `str | None = None`, to match the existing convention in `app/config.py` (`anthropic_api_key`, `supabase_*` are all empty-string defaults). The `if settings.sentry_dsn:` guard behaves identically either way.

## Verification

- [x] `uv run ruff check .` / `ruff format --check .` — clean
- [x] `uv run mypy app/` — no issues (44 files)
- [x] `uv run pytest` — **302 passed** (+5)
- [x] **DoD startup check 1:** `uvicorn` boots clean without `SENTRY_DSN`, `/api/health` → 200
- [x] **DoD startup check 2:** boots clean with placeholder `SENTRY_DSN=https://test@o0.ingest.sentry.io/0`, `/api/health` → 200
- [x] No `sentry_sdk` import outside `app/main.py` (enforced by test)

## ⚠️ Operator follow-up — required for this to do anything

This ships **inert**. Activating error tracking is a sequenced, three-step job — and the order matters:

1. **Create the Sentry project** and obtain its DSN.
2. **Store it in GCP Secret Manager** as `sentry-dsn` (project `master-key-501023`), and grant the runtime SA `roles/secretmanager.secretAccessor` on it — the same binding the `supabase-*` secrets have.
3. **Merge #284** to add `SENTRY_DSN=sentry-dsn:latest` to `deploy.yml`'s `secrets:` block.

> **Correction to an earlier version of this PR body:** it said to map `SENTRY_DSN` onto the Cloud Run revision manually. That is **not sufficient** — `deploy.yml:212-213` notes that `deploy-cloudrun@v2` uses set/replace semantics, so the `env_vars:`/`secrets:` blocks are authoritative on every deploy and a hand-set var is wiped by the next merge to main. It must be declared in the workflow, which is what #284 does. Caught in review.
>
> #284 must land **after** steps 1–2: `deploy-cloudrun` fails the deploy if told to mount a secret that doesn't exist yet.

Until then the SDK is not initialised and behaviour is unchanged — the intended safe default, not a bug.

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)