### PR TITLE
feat(reading): add focus mode to dim non-active passage sections (#168)

### DIFF
--- a/app/api/test_seed.py
+++ b/app/api/test_seed.py
@@ -78,7 +78,7 @@ router = APIRouter()
 SessionDep = Annotated[Session, Depends(get_session)]
 SettingsDep = Annotated[Settings, Depends(get_settings)]
 
-Variant = Literal["default", "high-contrast", "large-text", "bionic"]
+Variant = Literal["default", "high-contrast", "large-text", "bionic", "focus-mode"]
 
 # Representative passage with multiple paragraphs so axe-core has a
 # real surface to analyze — headings, paragraph spacing, line wrap,
@@ -126,6 +126,9 @@ _PREFS_FOR_VARIANT: dict[str, dict[str, Any]] = {
     "high-contrast": {"bg": "#1a1a1a", "fg": "#e8e8e8"},
     "large-text": {"size": "28px"},
     "bionic": {"bionic_enabled": True},
+    # READ-P2-2 (#168): dimmed sections are the a11y-relevant part of
+    # focus mode — this variant lets axe scan the surface with dimming on.
+    "focus-mode": {"focus_mode_enabled": True},
 }
 
 

--- a/app/services/reading/defaults.py
+++ b/app/services/reading/defaults.py
@@ -34,6 +34,8 @@ DEFAULT_PREFERENCES: dict[str, Any] = {
     # renders exactly as before this preference existed — spacing is opt-in.
     "letter_spacing": "normal",
     "word_spacing": "normal",
+    # READ-P2-2 (#168): focus mode off by default — opt-in, like bionic.
+    "focus_mode_enabled": False,
     # 1em ≈ one blank line between sections. Unlike the two above there is no
     # no-op value in the allow-list; sections previously had no margin-bottom,
     # so this default does slightly increase inter-section spacing.

--- a/app/services/reading/options.py
+++ b/app/services/reading/options.py
@@ -50,7 +50,17 @@ PREFERENCE_OPTIONS: dict[str, list[Any]] = {
     # section text is `white-space: pre-wrap`, so intra-section paragraph breaks
     # are literal newlines in the source text with no element to target.
     "paragraph_spacing": ["0.5em", "1em", "1.5em", "2em"],
+    # READ-P2-2 (#168): focus mode dims passage sections other than the one
+    # centered in the viewport, reducing visual competition for readers who
+    # lose their place (PRD: sustained attention is the primary friction).
+    "focus_mode_enabled": [True, False],
 }
+
+# Preference keys whose values are booleans rather than CSS strings. Form data
+# always arrives as strings, so `coerce_value` converts 'true'/'false' for
+# these before the allow-list check. Kept as a set so adding a new toggle is a
+# one-line change rather than another branch in coerce_value.
+BOOLEAN_KEYS: frozenset[str] = frozenset({"bionic_enabled", "focus_mode_enabled"})
 
 # Friendly labels for sidebar UI section headings (the <legend> per
 # fieldset). Falls back to the title-cased key with underscores replaced
@@ -90,6 +100,8 @@ PREFERENCE_LABELS: dict[tuple[str, Any], str] = {
     ("paragraph_spacing", "1em"): "Standard",
     ("paragraph_spacing", "1.5em"): "Loose",
     ("paragraph_spacing", "2em"): "Loosest",
+    ("focus_mode_enabled", True): "On",
+    ("focus_mode_enabled", False): "Off",
 }
 
 
@@ -97,10 +109,10 @@ def coerce_value(key: str, raw: str) -> Any:
     """Coerce a Form-submitted string into the right type for the given key.
 
     Form data arrives as strings. Most preference values are stored as
-    strings already (e.g., '18px', '#ffffff', '1.6'). The exception is
-    `bionic_enabled`, which is a boolean. Returns None if coercion fails.
+    strings already (e.g., '18px', '#ffffff', '1.6'). The exceptions are
+    the boolean toggles in BOOLEAN_KEYS. Returns None if coercion fails.
     """
-    if key == "bionic_enabled":
+    if key in BOOLEAN_KEYS:
         if raw == "true":
             return True
         if raw == "false":

--- a/static/style.css
+++ b/static/style.css
@@ -39,6 +39,51 @@
   padding-bottom: var(--reader-paragraph-spacing, 1em);
 }
 
+/* READ-P2-2 (#168): focus mode — dim every passage section except the one
+   centered in the viewport, so the reader's eye isn't competing with the rest
+   of the passage.
+
+   Gated on `.focus-ready`, which the inline script in reading.html adds only
+   once the IntersectionObserver is wired up. Without JavaScript the class is
+   never added, so no section is ever dimmed and the passage reads normally —
+   that's the graceful-degradation requirement. (Dimming via CSS alone would
+   leave a JS-less reader with the WHOLE passage at 0.4 and nothing
+   highlighted.)
+
+   The opacity value comes from --reader-section-opacity, set server-side in
+   reader_style.html: 0.4 when focus mode is on, 1 when off. Because that
+   variable lives in the swapped <style> block, toggling the preference takes
+   effect immediately with no page reload.
+
+   CONTRAST TRADE-OFF (measured, #168). Dimmed text at 0.4 does NOT meet
+   WCAG AA 4.5:1 — the ticket's guardrail asserted it did, which is incorrect:
+
+     light bg / dark text    17.40:1 full -> 2.51:1 dimmed
+     sepia bg / sepia text   11.24:1 full -> 2.22:1 dimmed
+     dark bg / light text    14.20:1 full -> 3.33:1 dimmed
+
+   Holding 4.5:1 needs roughly 0.51-0.68 alpha depending on theme. 0.4 is kept
+   deliberately: the whole point of the mode is to de-emphasise text the reader
+   is NOT on, and the mitigations are that it is opt-in (default off), instantly
+   reversible, the focused section always renders at full contrast, and opacity
+   does not affect assistive tech (nothing is hidden from a screen reader).
+   Raising the floor is a one-value change here if the accessibility audit
+   (roadmap M1) prefers conformance over focus strength. */
+#reading-surface.focus-ready .reading-section {
+  opacity: var(--reader-section-opacity, 1);
+  transition: opacity 0.2s ease;
+}
+
+#reading-surface.focus-ready .reading-section.focus-active {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #reading-surface.focus-ready .reading-section {
+    transition: none;
+  }
+}
+
 /* Inline comprehension question shown after each passage section. */
 .inline-question {
   border-left: 3px solid var(--pico-primary);

--- a/static/style.css
+++ b/static/style.css
@@ -55,20 +55,26 @@
    variable lives in the swapped <style> block, toggling the preference takes
    effect immediately with no page reload.
 
-   CONTRAST TRADE-OFF (measured, #168). Dimmed text at 0.4 does NOT meet
-   WCAG AA 4.5:1 — the ticket's guardrail asserted it did, which is incorrect:
+   WHY 0.7 AND NOT 0.4 (#168). The ticket specified 0.4 and asserted it
+   "preserves WCAG AA contrast". It does not — dimmed body text at 0.4 measures:
 
      light bg / dark text    17.40:1 full -> 2.51:1 dimmed
      sepia bg / sepia text   11.24:1 full -> 2.22:1 dimmed
      dark bg / light text    14.20:1 full -> 3.33:1 dimmed
 
-   Holding 4.5:1 needs roughly 0.51-0.68 alpha depending on theme. 0.4 is kept
-   deliberately: the whole point of the mode is to de-emphasise text the reader
-   is NOT on, and the mitigations are that it is opt-in (default off), instantly
-   reversible, the focused section always renders at full contrast, and opacity
-   does not affect assistive tech (nothing is hidden from a screen reader).
-   Raising the floor is a one-value change here if the accessibility audit
-   (roadmap M1) prefers conformance over focus strength. */
+   all far below the 4.5:1 AA threshold. axe independently confirmed this in CI
+   (2.52:1, effective foreground #a3a3a3) and failed the a11y gate as a
+   `serious` wcag143 violation, so the ticket's own "zero new axe violations"
+   requirement contradicted its 0.4 value.
+
+   0.7 is the smallest round value clearing AA on every supported theme:
+
+     light 6.41:1   sepia 4.78:1   dark 7.51:1
+
+   (sepia is the binding constraint — it needs 0.68.) The trade-off is that
+   dimming is gentler than the ticket imagined. If real readers find the cue too
+   subtle, strengthen the ACTIVE section instead of dimming the rest further —
+   anything that pushes non-active text below 4.5:1 re-breaks the gate. */
 #reading-surface.focus-ready .reading-section {
   opacity: var(--reader-section-opacity, 1);
   transition: opacity 0.2s ease;

--- a/templates/fragments/reader_style.html
+++ b/templates/fragments/reader_style.html
@@ -9,5 +9,11 @@
     --reader-letter-spacing: {{ prefs.letter_spacing | safe }};
     --reader-word-spacing: {{ prefs.word_spacing | safe }};
     --reader-paragraph-spacing: {{ prefs.paragraph_spacing | safe }};
+    {# READ-P2-2 (#168): focus mode is expressed as the dimmed-section opacity
+       rather than a <body> class, because this <style> block is the ONLY thing
+       the preference toggle swaps (hx-target="#reading-surface-style"). A body
+       class could not change until a full page reload; a variable here makes
+       the toggle instant, like every other preference. 1 = no dimming. #}
+    --reader-section-opacity: {{ "0.4" if prefs.focus_mode_enabled else "1" }};
   }
 </style>

--- a/templates/fragments/reader_style.html
+++ b/templates/fragments/reader_style.html
@@ -14,6 +14,6 @@
        the preference toggle swaps (hx-target="#reading-surface-style"). A body
        class could not change until a full page reload; a variable here makes
        the toggle instant, like every other preference. 1 = no dimming. #}
-    --reader-section-opacity: {{ "0.4" if prefs.focus_mode_enabled else "1" }};
+    --reader-section-opacity: {{ "0.7" if prefs.focus_mode_enabled else "1" }};
   }
 </style>

--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -81,6 +81,90 @@
        aria-hidden="true"
        style="display:none"></div>
 
+  {#
+    READ-P2-2 (#168): focus mode. Marks the passage section currently centered
+    in the viewport with `.focus-active`; style.css dims the others to
+    --reader-section-opacity (0.4 when focus mode is on, 1 when off).
+
+    Design notes:
+      - IntersectionObserver, NOT a scroll listener. The observer fires only
+        when a section crosses the centre band, so there is no per-frame work
+        and no jank — which is what the ticket's "debounce scroll with
+        requestAnimationFrame" guardrail was protecting against. rootMargin
+        collapses the viewport to a thin band at its vertical centre; whichever
+        section intersects that band is the one being read.
+      - The script adds `.focus-ready` to the surface. CSS dims ONLY when that
+        class is present, so with JS disabled nothing is dimmed and the passage
+        reads normally.
+      - Whether dimming is visible is decided purely in CSS by the server-set
+        variable, so this script does not need to know the preference or re-run
+        when it changes — the HTMX <style> swap handles it.
+      - Re-initialised on htmx:afterSwap because the bionic toggle replaces the
+        whole <article> out-of-band, which would otherwise leave the observer
+        watching detached nodes.
+  #}
+  <script>
+    (function () {
+      var observer = null;
+
+      function initFocusMode() {
+        var surface = document.getElementById("reading-surface");
+        if (!surface || !("IntersectionObserver" in window)) return;
+
+        if (observer) observer.disconnect();
+
+        var sections = surface.querySelectorAll(".reading-section");
+        if (!sections.length) return;
+
+        var active = null;
+        function setActive(el) {
+          if (el === active) return;
+          if (active) active.classList.remove("focus-active");
+          el.classList.add("focus-active");
+          active = el;
+        }
+
+        observer = new IntersectionObserver(
+          function (entries) {
+            // Prefer whichever intersecting section is nearest the viewport
+            // centre. Entries arrive only for sections that changed state, so
+            // fall back to keeping the current one when none qualify — that
+            // way exactly one section is always lit, never zero.
+            var centre = window.innerHeight / 2;
+            var best = null;
+            var bestDistance = Infinity;
+            entries.forEach(function (entry) {
+              if (!entry.isIntersecting) return;
+              var box = entry.boundingClientRect;
+              var distance = Math.abs(box.top + box.height / 2 - centre);
+              if (distance < bestDistance) {
+                bestDistance = distance;
+                best = entry.target;
+              }
+            });
+            if (best) setActive(best);
+          },
+          // A thin band across the viewport's vertical centre.
+          { rootMargin: "-45% 0px -45% 0px", threshold: 0 }
+        );
+
+        sections.forEach(function (section) {
+          observer.observe(section);
+        });
+
+        // Light the first section up front so the passage never renders with
+        // everything dimmed before the first scroll.
+        setActive(sections[0]);
+        surface.classList.add("focus-ready");
+      }
+
+      initFocusMode();
+      document.body.addEventListener("htmx:afterSwap", function (event) {
+        if (event.target && event.target.id === "reading-surface") initFocusMode();
+      });
+    })();
+  </script>
+
   <script>
     // Reflect the just-clicked preference button as `aria-pressed=true`
     // (and reset its siblings) immediately on click — without this, the

--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -84,7 +84,8 @@
   {#
     READ-P2-2 (#168): focus mode. Marks the passage section currently centered
     in the viewport with `.focus-active`; style.css dims the others to
-    --reader-section-opacity (0.4 when focus mode is on, 1 when off).
+    --reader-section-opacity (0.7 when focus mode is on, 1 when off; 0.7 is the
+    WCAG-AA floor — see the rationale in static/style.css).
 
     Design notes:
       - IntersectionObserver, NOT a scroll listener. The observer fires only

--- a/tests/a11y/fixtures/seed.ts
+++ b/tests/a11y/fixtures/seed.ts
@@ -1,6 +1,11 @@
 import type { APIRequestContext, BrowserContext } from "@playwright/test";
 
-export type Variant = "default" | "high-contrast" | "large-text" | "bionic";
+export type Variant =
+  | "default"
+  | "high-contrast"
+  | "large-text"
+  | "bionic"
+  | "focus-mode";
 
 export interface SeedResult {
   passageId: string;

--- a/tests/a11y/reading_surface.spec.ts
+++ b/tests/a11y/reading_surface.spec.ts
@@ -21,9 +21,16 @@ import { seedAndLogin, type Variant } from "./fixtures/seed";
  *   - high-contrast → dark bg + light fg (dark-mode users)
  *   - large-text   → 28px font (low-vision users)
  *   - bionic       → bionic_enabled=true (the bionicize transform)
+ *   - focus-mode   → focus_mode_enabled=true (dimmed non-active sections)
  */
 
-const VARIANTS: Variant[] = ["default", "high-contrast", "large-text", "bionic"];
+const VARIANTS: Variant[] = [
+  "default",
+  "high-contrast",
+  "large-text",
+  "bionic",
+  "focus-mode",
+];
 
 for (const variant of VARIANTS) {
   test(`reading surface a11y: ${variant}`, async ({ page, context, request }) => {

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -605,7 +605,7 @@ def test_focus_mode_on_emits_dimmed_opacity(client: TestClient, session: Session
     body = client.post("/preferences/focus_mode_enabled", data={"value": "true"}).text
 
     assert '<style id="reading-surface-style">' in body
-    assert "--reader-section-opacity: 0.4" in body
+    assert "--reader-section-opacity: 0.7" in body
 
 
 def test_focus_mode_accepts_true_and_false_strings(client: TestClient, session: Session) -> None:
@@ -637,7 +637,7 @@ def test_focus_mode_persists_across_requests(client: TestClient, session: Sessio
     client.post("/preferences/focus_mode_enabled", data={"value": "true"})
     body = client.get(f"/read/{passage.id}").text
 
-    assert "--reader-section-opacity: 0.4" in body
+    assert "--reader-section-opacity: 0.7" in body
 
 
 def test_focus_mode_renders_sidebar_toggle(client: TestClient, session: Session) -> None:

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -16,6 +16,7 @@ Covers the Definition of Done from issue #16 (READ-2):
 
 import hashlib
 import uuid
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -578,3 +579,112 @@ def test_sidebar_renders_spacing_controls(client: TestClient, session: Session) 
     # Friendly labels, not raw CSS values, for the button text.
     assert "Widest" in body
     assert "Loosest" in body
+
+
+# ---------------------------------------------------------------------------
+# READ-P2-2 (#168) — focus mode
+# ---------------------------------------------------------------------------
+
+
+def test_focus_mode_defaults_to_off(client: TestClient, session: Session) -> None:
+    """Opt-in, like bionic. A user with no Preference row gets the
+    no-dimming opacity, so the passage renders exactly as before."""
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+
+    body = client.get(f"/read/{passage.id}").text
+
+    assert "--reader-section-opacity: 1" in body
+
+
+def test_focus_mode_on_emits_dimmed_opacity(client: TestClient, session: Session) -> None:
+    """Enabling focus mode is observable in page source as the dimmed
+    section opacity (the DoD's 'verifiable in page source')."""
+    signed_in(session)
+
+    body = client.post("/preferences/focus_mode_enabled", data={"value": "true"}).text
+
+    assert '<style id="reading-surface-style">' in body
+    assert "--reader-section-opacity: 0.4" in body
+
+
+def test_focus_mode_accepts_true_and_false_strings(client: TestClient, session: Session) -> None:
+    """The new boolean must coerce like bionic_enabled — without being
+    added to BOOLEAN_KEYS it would fail the allow-list check with 422."""
+    user = signed_in(session)
+
+    assert client.post("/preferences/focus_mode_enabled", data={"value": "true"}).status_code == 200
+    pref = session.get(Preference, user.id)
+    assert pref is not None and pref.values["focus_mode_enabled"] is True
+
+    assert (
+        client.post("/preferences/focus_mode_enabled", data={"value": "false"}).status_code == 200
+    )
+    session.refresh(pref)
+    assert pref.values["focus_mode_enabled"] is False
+
+
+def test_focus_mode_rejects_non_boolean_strings(client: TestClient, session: Session) -> None:
+    signed_in(session)
+    response = client.post("/preferences/focus_mode_enabled", data={"value": "invalid"})
+    assert response.status_code == 422
+
+
+def test_focus_mode_persists_across_requests(client: TestClient, session: Session) -> None:
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+
+    client.post("/preferences/focus_mode_enabled", data={"value": "true"})
+    body = client.get(f"/read/{passage.id}").text
+
+    assert "--reader-section-opacity: 0.4" in body
+
+
+def test_focus_mode_renders_sidebar_toggle(client: TestClient, session: Session) -> None:
+    """Generated from PREFERENCE_OPTIONS, so the toggle appears with no
+    template change — and posts lowercase booleans the route accepts."""
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+
+    body = client.get(f"/read/{passage.id}").text
+
+    assert 'hx-post="/preferences/focus_mode_enabled"' in body
+    assert '"value": "true"' in body and '"value": "false"' in body
+
+
+def test_focus_mode_dimming_is_gated_on_js_applied_class(
+    client: TestClient, session: Session
+) -> None:
+    """Graceful degradation (ticket guardrail): the CSS dims only under
+    `.focus-ready`, which the inline script adds. Without JS nothing is
+    dimmed. Pin both halves so a refactor can't drop the gate and leave
+    JS-less readers with the whole passage at 0.4.
+    """
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+    client.post("/preferences/focus_mode_enabled", data={"value": "true"})
+
+    body = client.get(f"/read/{passage.id}").text
+    css = (Path(__file__).parent.parent / "static" / "style.css").read_text(encoding="utf-8")
+
+    # The stylesheet only dims within .focus-ready.
+    assert "#reading-surface.focus-ready .reading-section" in css
+    # The page never server-renders the class — JS is the only source.
+    assert "focus-ready" not in body.split("<script>")[0]
+    assert 'classList.add("focus-ready")' in body
+
+
+def test_focus_mode_uses_intersection_observer_not_scroll_handler(
+    client: TestClient, session: Session
+) -> None:
+    """Guardrail intent was 'no scroll jank'. IntersectionObserver fires
+    only on band crossings, so there is no per-frame scroll work at all —
+    pin that we didn't regress to a raw scroll listener.
+    """
+    user = signed_in(session)
+    passage = _make_passage(session, user.id)
+
+    body = client.get(f"/read/{passage.id}").text
+
+    assert "IntersectionObserver" in body
+    assert 'addEventListener("scroll"' not in body


### PR DESCRIPTION
## Summary

Focus mode dims every passage section except the one centred in the viewport, reducing visual competition for readers who lose their place — the PRD's primary stated friction (sustained attention).

## Two deliberate deviations from the ticket's suggested implementation

Both serve the ticket's own guardrails better. Flagging them explicitly for review:

**1. Driven by a CSS variable, not a `<body class="focus-mode-on">`.**
The preference toggle uses `hx-target="#reading-surface-style"`, so it swaps **only** the `<style>` block. A body class therefore could not change until a full page reload — the ticket concedes this ("page reloads … on the next navigation"). Emitting `--reader-section-opacity` in that swapped block makes the toggle **instant**, consistent with every other preference, and avoids needing an out-of-band swap (the workaround `bionic_enabled` required).

**2. Dimming is gated on a JS-applied `.focus-ready` class.**
With CSS-only dimming, a reader with JavaScript disabled would get the **whole passage at 0.4 opacity with nothing highlighted** — actively broken, and the opposite of the ticket's graceful-degradation guardrail. Gating on a class the script adds means no JS → no dimming at all.

Also: `IntersectionObserver` with a centre-band `rootMargin` instead of a scroll listener. There is no per-frame work at all, which is the *intent* behind the "debounce scroll with `requestAnimationFrame`" guardrail, achieved more thoroughly. Re-initialises on `htmx:afterSwap` because the bionic toggle replaces the whole `<article>` out-of-band.

## Bug found on the way

`coerce_value` hardcoded `if key == "bionic_enabled"` for boolean coercion, so `focus_mode_enabled=true` would have been stored as the **string** `"true"` and rejected 422. Generalised to a `BOOLEAN_KEYS` frozenset.

## ⚠️ The ticket contained two contradictory requirements

The ticket specified **opacity 0.4** *and* a DoD item of **"zero new axe violations"**. Those cannot both hold — and CI proved it.

I calculated up front that 0.4 fails WCAG AA, then the a11y gate I added **independently confirmed it**: axe measured **2.52:1** with effective foreground `#a3a3a3` — a `serious` `wcag143` violation that blocked the merge.

| Theme | Full | @ 0.4 (ticket) | @ 0.7 (shipped) |
|---|---|---|---|
| light bg / dark text | 17.40:1 | 2.51:1 ❌ | **6.41:1** ✅ |
| sepia bg / sepia text | 11.24:1 | 2.22:1 ❌ | **4.78:1** ✅ |
| dark bg / light text | 14.20:1 | 3.33:1 ❌ | **7.51:1** ✅ |

**Resolved in favour of conformance** (`68beb8f`): 0.7 is the smallest round value clearing AA on every theme — sepia binds at 0.68. The roadmap's M1 criterion is a WCAG-conformant reading surface and the a11y check is blocking, so shipping a known serious violation into an accessibility product wasn't defensible.

**Trade-off to be aware of:** dimming is gentler than the ticket imagined. If real readers find the cue too subtle, the fix is to **strengthen the active section** rather than dim the rest further — anything pushing non-active text below 4.5:1 re-breaks the gate. Documented at the value in `static/style.css`.

## Verification

- [x] `ruff` / `ruff format` / `mypy` — clean
- [x] `uv run pytest` — **310 passed** (+8)
- [x] **axe scan with focus mode active** — new `focus-mode` a11y variant, now green (DoD item)
- [x] All 22 CI checks green, `mergeStateStatus: CLEAN`
- [x] Tests pin the JS-degradation gate and that we didn't regress to a scroll listener
- [ ] ⚠️ **Rendered behaviour NOT verified locally.** I tried to drive it with the Playwright harness, but chromium cannot launch in this container (14 missing system libs; `--with-deps` needs root). The pytest suite asserts the *CSS variable value*, **not computed opacity** — structurally the same blind spot that hid the `paragraph_spacing` margin-collapse bug in #165.

### Reviewer: please confirm in a browser
1. Enable focus mode → non-centred sections visibly dim **immediately, without a page reload**.
2. Scroll → the lit section **follows** you, and exactly one is lit at a time.
3. Disable → all sections return to full opacity immediately.
4. With comprehension **on** (questions interleaved between sections), the effect still tracks correctly.
5. **Judge whether 0.7 is a strong enough cue** — this is the open product question above.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)