### PR TITLE
feat(ingestion): strip page headers and footers from PDF extraction (#169)

### DIFF
--- a/app/services/ingestion/pdf.py
+++ b/app/services/ingestion/pdf.py
@@ -13,6 +13,16 @@ row.
 import io
 
 import pdfplumber
+from pdfplumber.page import Page
+
+# INGEST-P2-1 (#169): fraction of each page's height treated as the header
+# band (top) and footer band (bottom). Text inside these bands — running
+# titles, page numbers, copyright lines — is excluded before extraction so it
+# doesn't interrupt sentence flow on the reading surface. 8% ≈ 0.63in on US
+# Letter, just under a standard 1in margin, so headerless pages keep all body
+# text. Module-level so they're tunable without hunting through the code.
+HEADER_MARGIN_FRACTION = 0.08
+FOOTER_MARGIN_FRACTION = 0.08
 
 
 class PdfParseError(Exception):
@@ -38,7 +48,7 @@ def extract_text(pdf_bytes: bytes) -> str:
     """
     try:
         with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
-            pages = [page.extract_text() or "" for page in pdf.pages]
+            pages = [_extract_page_body(page) for page in pdf.pages]
     except Exception as exc:  # pdfplumber raises a mix of exception types
         raise PdfParseError(str(exc)) from exc
 
@@ -46,3 +56,25 @@ def extract_text(pdf_bytes: bytes) -> str:
     if not text.strip():
         raise EmptyPdfTextError()
     return text
+
+
+def _extract_page_body(page: Page) -> str:
+    """Extract a page's text with the header and footer bands cropped out.
+
+    Crops to the vertical middle of the page — excluding the top
+    HEADER_MARGIN_FRACTION and bottom FOOTER_MARGIN_FRACTION — using
+    `within_bbox` (pdfplumber's recommended cropping API). The crop is silent:
+    a page whose text all sits in the margins yields "" here, and the
+    all-empty-document case is handled once, upstream, by `extract_text`.
+
+    The only fallback is for a page box pdfplumber can't crop (degenerate or
+    out-of-bounds mediabox): rather than fail the whole upload, that one page
+    is extracted uncropped. That path can't re-introduce a header on a normal
+    page — it fires solely on a `within_bbox` error, not on an empty crop.
+    """
+    top = page.height * HEADER_MARGIN_FRACTION
+    bottom = page.height * (1 - FOOTER_MARGIN_FRACTION)
+    try:
+        return page.within_bbox((0, top, page.width, bottom)).extract_text() or ""
+    except ValueError:
+        return page.extract_text() or ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@ dev = [
     "httpx>=0.28",
     "ruff>=0.8",
     "mypy>=1.11",
+    # Test-only PDF writer (BSD-licensed) for building synthetic PDFs with
+    # text at known positions — used by tests/test_pdf_header_footer.py to
+    # verify header/footer cropping (#169). Never imported by app/, so it is
+    # not a runtime dependency and does not touch ADR-003 (pdfplumber-only).
+    "reportlab>=4.0",
 ]
 
 [tool.ruff]

--- a/tests/fixtures/generate_sample_passage.py
+++ b/tests/fixtures/generate_sample_passage.py
@@ -1,0 +1,58 @@
+"""Regenerate tests/fixtures/sample_passage.pdf.
+
+Run: `uv run python tests/fixtures/generate_sample_passage.py`
+
+This is a two-page PDF representing a realistically-margined book page: body
+text sits in the vertical middle, with a running header and a page-number
+footer in the top/bottom margins. It exercises the PDF ingestion pipeline
+end-to-end (test_passages_pdf.py) AND the header/footer crop (#169) — the
+header and footer land in the cropped bands and must NOT survive extraction,
+while the body markers ("O Son of Spirit!", "Second page") must.
+
+The previous fixture placed body text flush against the page edges, which is
+not how real documents are laid out; it broke once header/footer cropping
+landed. reportlab is a test-only dependency.
+"""
+
+from pathlib import Path
+
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+_WIDTH, _HEIGHT = letter  # 612 x 792 pt; reportlab origin is bottom-left.
+OUT = Path(__file__).parent / "sample_passage.pdf"
+
+# Page 1: header (drop), body markers (keep), footer (drop).
+PAGE1_BODY = [
+    "O Son of Spirit!",
+    "My first counsel is this: Possess a pure, kindly and radiant heart,",
+    "that thine may be a sovereignty ancient, imperishable and everlasting.",
+    "(A representative passage exercising the Master Key PDF pipeline.)",
+]
+PAGE2_BODY = [
+    "Second page.",
+    "Multi-page handling is part of the Definition of Done.",
+]
+
+
+def _draw_page(c: canvas.Canvas, header: str, body: list[str], footer: str) -> None:
+    c.setFont("Helvetica", 11)
+    c.drawString(72, _HEIGHT * 0.96, header)  # ~4% from top -> header band
+    y = _HEIGHT * 0.75  # body starts well below the 8% header band
+    for line in body:
+        c.drawString(72, y, line)
+        y -= 20
+    c.drawString(_WIDTH / 2, _HEIGHT * 0.03, footer)  # ~3% from bottom -> footer band
+    c.showPage()
+
+
+def main() -> None:
+    c = canvas.Canvas(str(OUT), pagesize=letter)
+    _draw_page(c, "The Hidden Words - Part I", PAGE1_BODY, "- 1 -")
+    _draw_page(c, "The Hidden Words - Part I", PAGE2_BODY, "- 2 -")
+    c.save()
+    print(f"wrote {OUT} ({OUT.stat().st_size} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/sample_passage.pdf
+++ b/tests/fixtures/sample_passage.pdf
@@ -37,7 +37,7 @@ endobj
 endobj
 6 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260512174439+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260512174439+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260723164418+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260723164418+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -48,17 +48,17 @@ endobj
 endobj
 8 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 354
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 371
 >>
 stream
-Gaqc19htgF&A@rkSgP9UaK?d6*`7b!N?g@NZBqj;f[4TkFLhVS]j2h=Aj/#=2fE;#bd3NMhfQY+iI5(,XJ#88(UF:p)d_#gY*Zo*b:;ftW^H<-X`s8]C]d1&[pu?iW&kDg]UuIl-jbn%SWF!_;TnWeN>E`MBS8Rt"Q/R)4[V;`W"!O/d#sE'Eh-:-<i5ub#b=.h7i<iV8<N]*dK"-O>ag2T5`qnn4%kokPaeb?`9o>V[pE@AU[PG8D>g[e8,^N_+_aGu=#PdQ5(,8>\uM'a/Q.BMR6r>c&qUnH#=A!S'?,][r[^]el?CXJY^'P"1K3G^NsZlJ%QBJ*e)[Debj+^5QbSKK+&&5Pp&~>endstream
+Garo:5u5?_&;BTPMWYEW<42rK]kN^EPXrY<?FVQR5Y'RGZa15?mp1f?'.'.7iQ]%()hh.6Wr'+0\CJ*Z.B")0"#Z+Yd*K5RBA^8bng'*BEqP,WA#.RNP_;nfSh:9ZSEFGQ>.\#n`54Kpa$0,7oYo_YjD*I-?a-U`l4'$g48.j8$gFoMDm<^u*a-1_67#al$^PQZC(V)06*kVh^cU;`Cgh,iB6#o]US)SVi3[!7FSN`J"4Rr5dpc%&.J98Pn^dO=11RV=!3R5\/;75ne;5S)Pt!mjD0/sF*&XeR%3.6c,f#B%4eXSSAkSd-EZ%NcKKBJ2J0]mtC9b:<U#CaKE*]j9s"?r5;oD7l:-6cU,f<uI3;Wi=+HO2~>endstream
 endobj
 9 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 161
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 224
 >>
 stream
-Gaq3^5n8K3$q9o\i\-E^UkH\"6!(Y'(EbC62:+'=hVSed+oV@tQ^="7g!JIO!aHS?)hDb.#;p&p^>mA(ESAo`D5k;Ynu(f+%X<2m.hCPS\3SdGnXH9n'?AVe0T1sQYDJm-i"7>lep1,L&i>_/k^LDJ+o;@C$7R_~>endstream
+Garo:;%%t0'SYHC($Dh'Q^alE)AWJ[6%bcJ9jQru])I2#'a5`sp@.H2k?a%e%J=Ym!?7'\Ne0%U$8`n4p^p^OHoUd]-LAq?]-:b+dYPj0X2BlT&pkpXe@:rR$j^i*HAfZ\r!'n1&$OQ@:L7RG[(sAR-(1(*Q[F+d<e[<,VU2&;\qV,.fW?nDXLf[CQ.!f)UIUId4]NFk.9K9Le2N.j#_,5F:\m+Dg&~>endstream
 endobj
 xref
 0 10
@@ -71,11 +71,11 @@ xref
 0000000653 00000 n 
 0000000914 00000 n 
 0000000979 00000 n 
-0000001423 00000 n 
+0000001440 00000 n 
 trailer
 <<
 /ID 
-[<c0c2e0dc299dcbf0f3813ea8439f1360><c0c2e0dc299dcbf0f3813ea8439f1360>]
+[<7976151730e165536f55db5db87c36e0><7976151730e165536f55db5db87c36e0>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 6 0 R
@@ -83,5 +83,5 @@ trailer
 /Size 10
 >>
 startxref
-1674
+1754
 %%EOF

--- a/tests/test_pdf_header_footer.py
+++ b/tests/test_pdf_header_footer.py
@@ -1,0 +1,129 @@
+"""Tests for header/footer cropping in PDF extraction (INGEST-P2-1 #169).
+
+pdfplumber pulls every line on a page, including running page headers
+(titles, chapter names) and footers (page numbers, copyright lines) that
+interrupt sentence flow on the reading surface. `extract_text` now crops the
+top HEADER_MARGIN_FRACTION and bottom FOOTER_MARGIN_FRACTION off each page
+before extracting.
+
+These tests build synthetic PDFs with `reportlab` (a test-only dependency)
+so text can be placed at exact y-coordinates: in the header band, the footer
+band, or the body.
+"""
+
+import io
+
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+from app.services.ingestion.pdf import (
+    FOOTER_MARGIN_FRACTION,
+    HEADER_MARGIN_FRACTION,
+    extract_text,
+)
+
+_WIDTH, _HEIGHT = letter  # 612 x 792 pt
+
+
+def _pdf(pages: list[dict[str, str]]) -> bytes:
+    """Build a PDF from a list of pages.
+
+    Each page dict may set `header`, `body`, and `footer` text. reportlab's
+    origin is the BOTTOM-left, so a high y is near the top of the page.
+    """
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf, pagesize=letter)
+    for page in pages:
+        if header := page.get("header"):
+            # ~2% from the top -> inside the 8% header band.
+            c.drawString(72, _HEIGHT * 0.98, header)
+        if body := page.get("body"):
+            # Middle of the page -> safely inside the body band.
+            c.drawString(72, _HEIGHT * 0.5, body)
+        if footer := page.get("footer"):
+            # ~2% from the bottom -> inside the 8% footer band.
+            c.drawString(72, _HEIGHT * 0.02, footer)
+        c.showPage()
+    c.save()
+    return buf.getvalue()
+
+
+def test_header_and_footer_are_cropped_out() -> None:
+    """The DoD case: a two-page PDF with a header on page 1 and a footer on
+    page 2. After extraction neither the header nor footer text appears, but
+    the body of both pages does."""
+    pdf = _pdf(
+        [
+            {"header": "The Kitab-i-Iqan Chapter 3", "body": "Page one body sentence."},
+            {"footer": "Copyright Bahai Publishing Trust 1978", "body": "Page two body sentence."},
+        ]
+    )
+
+    text = extract_text(pdf)
+
+    assert "Page one body sentence." in text
+    assert "Page two body sentence." in text
+    assert "Kitab-i-Iqan" not in text
+    assert "Copyright" not in text
+
+
+def test_footer_page_numbers_are_removed() -> None:
+    """Running footers (page numbers) on every page are stripped."""
+    pdf = _pdf(
+        [
+            {"body": "First chapter opening.", "footer": "- 47 -"},
+            {"body": "The chapter continues here.", "footer": "- 48 -"},
+        ]
+    )
+
+    text = extract_text(pdf)
+
+    assert "First chapter opening." in text
+    assert "The chapter continues here." in text
+    assert "- 47 -" not in text
+    assert "- 48 -" not in text
+
+
+def test_body_only_pdf_is_unchanged_by_cropping() -> None:
+    """DoD: a PDF with no header/footer content returns the same body text —
+    cropping blank margins must not remove content."""
+    pdf = _pdf(
+        [
+            {"body": "Only body text on page one."},
+            {"body": "Only body text on page two."},
+        ]
+    )
+
+    text = extract_text(pdf)
+
+    assert "Only body text on page one." in text
+    assert "Only body text on page two." in text
+
+
+def test_body_spanning_multiple_lines_survives() -> None:
+    """A fuller body block (not just one line) round-trips intact — guards
+    against the crop being too aggressive on a realistically dense page."""
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf, pagesize=letter)
+    lines = [f"Body line number {i} of the passage." for i in range(1, 15)]
+    y = _HEIGHT * 0.85  # starts below the 8% header band
+    c.drawString(72, _HEIGHT * 0.97, "RUNNING HEADER TO DROP")
+    for line in lines:
+        c.drawString(72, y, line)
+        y -= 24
+    c.drawString(72, _HEIGHT * 0.02, "footer 1")
+    c.showPage()
+    c.save()
+
+    text = extract_text(buf.getvalue())
+
+    for line in lines:
+        assert line in text
+    assert "RUNNING HEADER TO DROP" not in text
+    assert "footer 1" not in text
+
+
+def test_margin_fractions_are_module_constants() -> None:
+    """DoD: the crop fractions are tunable module-level constants."""
+    assert 0 < HEADER_MARGIN_FRACTION < 0.5
+    assert 0 < FOOTER_MARGIN_FRACTION < 0.5

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "reportlab" },
     { name = "ruff" },
 ]
 
@@ -46,6 +47,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
+    { name = "reportlab", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.20" },
     { name = "sqlmodel", specifier = ">=0.0.22" },
@@ -1805,6 +1807,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b2/a2/0328d49d3b5fb427068e9200e7de5b0d708d021a1ad98d004bc685d2529e/realtime-2.30.0.tar.gz", hash = "sha256:7aa593da52ed5f92c34ec4e50e32043afa62f219c94f717ad64a66ab0ef9f1ba", size = 18718, upload-time = "2026-05-06T17:35:23.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/75/1b2cfc949595e22d8c05a2aa2cfc222921f7f94177d7e8a90542f3f73b33/realtime-2.30.0-py3-none-any.whl", hash = "sha256:7c93b63d2cf99aa1da4fa8826b03b00cd32f7b38abb27ff47b19eb5dcb5707c6", size = 22376, upload-time = "2026-05-06T17:35:22.568Z" },
+]
+
+[[package]]
+name = "reportlab"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/d6/4b7b0cf56880eb96533e607967be6a939e344675601e033d113a0bfa1f4e/reportlab-5.0.0.tar.gz", hash = "sha256:e4494a0c6623ae213bb856fba523171b2b54a7bf629fda02d5e525a7b899a784", size = 3701928, upload-time = "2026-06-18T11:34:31.145Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/07/70085c17a369605f15e301d10ab902115019b1126c7253d964afc230c7d6/reportlab-5.0.0-py3-none-any.whl", hash = "sha256:9d5a3affa84919e1111ede580031266a570e93b1ce388219621347965ff1d93c", size = 1956710, upload-time = "2026-06-18T11:34:29.07Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

pdfplumber extracts every line on a page, including running **headers** (titles, chapter names) and **footers** (page numbers, copyright lines) that interrupt sentence flow on the reading surface. `extract_text` now crops the top and bottom margin bands (8% each, `HEADER_MARGIN_FRACTION` / `FOOTER_MARGIN_FRACTION`) via `page.within_bbox()` before extracting.

## Changes

| File | Change |
|---|---|
| `app/services/ingestion/pdf.py` | Crop each page to its vertical middle before `extract_text()`; module-level margin constants |
| `pyproject.toml` | `reportlab>=4.0` as a **dev-only** dep (BSD) for building synthetic test PDFs |
| `tests/test_pdf_header_footer.py` | 5 tests (real extraction, not mocks) |
| `tests/fixtures/sample_passage.pdf` | **Regenerated** — see below |
| `tests/fixtures/generate_sample_passage.py` | New committed generator for the fixture |

## Design notes

- **Silent crop.** A page whose text is entirely in the margins yields `""`; the all-empty-document case is still handled once, upstream, by the existing `EmptyPdfTextError` path (unchanged, per the ticket guardrail).
- **One narrow fallback.** If pdfplumber can't crop a page (degenerate mediabox → `within_bbox` `ValueError`), that page is extracted *uncropped* rather than failing the whole upload. It fires **only** on a crop error, never on an empty crop — so it can't silently re-introduce a header on a normal page. (My first draft had a broader "empty crop → full page" fallback; I removed it precisely because it would re-include the header on a body-less section-divider page.)
- **ADR-003 untouched.** `reportlab` is imported only by tests, never by `app/`, so the pdfplumber-only *runtime* constraint is unaffected.

## ⚠️ I regenerated a shared test fixture — flagging explicitly

The existing `tests/fixtures/sample_passage.pdf` placed body text **flush against the page edges**, which no real document does. Cropping the top 8% legitimately removed its "O Son of Spirit" line, failing `test_uploaded_pdf_persists_extracted_text`.

Rather than weaken that test or lower the crop below the ticket's mandated 0.08, I regenerated the fixture to be **realistically margined**: body in the middle, a running header + page numbers in the cropped bands. The existing assertions ("O Son of Spirit!", "Second page" survive) still hold, and the fixture now *also* demonstrates the feature (header + `- 1 -` / `- 2 -` are correctly dropped). Added a committed generator script so the fixture is reproducible rather than an opaque binary.

Verified extraction output:
```
O Son of Spirit!
My first counsel is this: Possess a pure, kindly and radiant heart,
...
Second page.
Multi-page handling is part of the Definition of Done.
```
(header `The Hidden Words - Part I` and page numbers absent)

## Verification

- [x] `ruff` / `ruff format` / `mypy` — clean
- [x] `uv run pytest` — **307 passed** (+5)
- [x] New tests build real PDFs with positioned text and assert header/footer strings are absent, body present
- [x] Body-only PDF unchanged by cropping (DoD)
- [x] Existing PDF integration + splitting tests still green against the regenerated fixture
- [ ] Reviewer note: 8% is the ticket's specified starting value. It's ~0.63in on US Letter, just under a standard 1in margin — safe for normally-margined books, but a PDF whose body genuinely starts in the top 8% would lose its first line. Constants are tunable if real Baha'i book PDFs need it.

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)