### PR TITLE
fix(auth): render /login errors as form fragments, not raw JSON (#288)

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -29,40 +29,57 @@ from typing import Annotated
 from email_validator import EmailNotValidError, validate_email
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlmodel import Session
 from supabase_auth.errors import AuthApiError
 
 from app.config import Settings, get_settings
+from app.db import get_session
 from app.integrations.supabase.auth import SUPABASE_COOKIE_NAME, current_user
 from app.integrations.supabase.client import anon_client
-from app.services.rate_limit import enforce_login_rate_limit
+from app.services.rate_limit import check_login_rate_limit
 
 router = APIRouter()
 
 SettingsDep = Annotated[Settings, Depends(get_settings)]
+SessionDep = Annotated[Session, Depends(get_session)]
 CurrentUser = Annotated[object, Depends(current_user)]  # User; loose typing for transition
 
 GENERIC_FRAGMENT = "<p>Check your inbox for a sign-in link.</p>"
 
-# Rate-limit fragment: re-renders the sign-in form (so the user can retry with
-# the same or a different address) plus an inline error message HTMX's
-# response-targets ext (#250) swaps into #signin-form on a 429. Kept minimal
-# and self-contained — no template round-trip so the /login handler stays
-# entirely synchronous. Matches the visual shape of the form in
-# templates/home.html so the swap doesn't feel jarring.
-RATE_LIMIT_FRAGMENT = (
-    '<form id="signin-form" hx-post="/login" hx-target="#signin-form"'
-    ' hx-swap="outerHTML" hx-ext="response-targets" hx-target-4*="#signin-form">'
-    '<p role="alert" class="error">Too many sign-in emails just now.'
-    " Please try again in a few minutes.</p>"
-    '<label for="email">Email'
-    '<input type="email" id="email" name="email" required autofocus'
-    ' autocomplete="email" placeholder="you@example.com">'
-    "<small>We'll email you a one-time sign-in link."
-    " No password to remember.</small>"
-    "</label>"
-    '<button type="submit">Send me a sign-in link</button>'
-    "</form>"
-)
+
+def signin_form_fragment(error_message: str | None = None) -> str:
+    """Re-render the sign-in form, optionally with an inline error message.
+
+    Every non-success `/login` outcome (bad email, rate limit, upstream
+    failure) returns this so HTMX's response-targets ext swaps a readable
+    form-plus-message into #signin-form — never a raw JSON `{"detail": …}`
+    body or, for a 5xx with no target, nothing at all (#288).
+
+    Self-contained (no template round-trip) so the /login handler stays
+    synchronous, and structurally identical to the form in
+    templates/home.html — including BOTH `hx-target-4*` and `hx-target-5*`
+    so a subsequent 4xx OR 5xx also swaps back in rather than leaking JSON.
+
+    The message must never echo the submitted email (enumeration + the
+    "don't leak the rate-limited email" guard) — callers pass fixed strings,
+    and the email input is re-rendered empty.
+    """
+    alert = f'<p role="alert" class="error">{error_message}</p>' if error_message else ""
+    return (
+        '<form id="signin-form" hx-post="/login" hx-target="#signin-form"'
+        ' hx-swap="outerHTML" hx-ext="response-targets"'
+        ' hx-target-4*="#signin-form" hx-target-5*="#signin-form">'
+        f"{alert}"
+        '<label for="email">Email'
+        '<input type="email" id="email" name="email" required autofocus'
+        ' autocomplete="email" placeholder="you@example.com">'
+        "<small>We'll email you a one-time sign-in link."
+        " No password to remember.</small>"
+        "</label>"
+        '<button type="submit">Send me a sign-in link</button>'
+        "</form>"
+    )
+
 
 # AuthApiError codes that indicate a Supabase rate limit — map to 429 not 502.
 # The substring fallback that preceded this (#252, was in #247's PR #249) risked
@@ -103,11 +120,11 @@ def _external_origin(request: Request, fallback: str) -> str:
     "/login",
     response_class=HTMLResponse,
     status_code=202,
-    dependencies=[Depends(enforce_login_rate_limit)],
 )
 def login(
     request: Request,
     settings: SettingsDep,
+    session: SessionDep,
     email: Annotated[str, Form()],
 ) -> Response:
     """Issue a Supabase magic-link to the supplied email.
@@ -127,12 +144,37 @@ def login(
       - 502 for anything else (network, config bug, non-rate-limit
         Supabase error). Enumeration guard: generic message.
     """
+    # Every failure below returns an HTML form fragment (never a JSON
+    # HTTPException) so the response-targets ext swaps a readable message into
+    # #signin-form, at the right status code. See signin_form_fragment / #288.
     try:
         result = validate_email(email, check_deliverability=False)
-    except EmailNotValidError as exc:
-        raise HTTPException(status_code=422, detail="Invalid email format") from exc
+    except EmailNotValidError:
+        return HTMLResponse(
+            content=signin_form_fragment("Please enter a valid email address."),
+            status_code=422,
+        )
 
     normalized_email = result.normalized.lower()
+
+    # Local token-bucket limit (10/hour per IP and per email). Called directly
+    # rather than as a dependency so the 429 renders as a fragment; the check
+    # runs AFTER email validation so a malformed address doesn't burn a token.
+    try:
+        check_login_rate_limit(request, session, normalized_email)
+    except HTTPException as exc:
+        if exc.status_code != 429:
+            raise
+        headers = {"Retry-After": exc.headers["Retry-After"]} if exc.headers else {}
+        # Fixed message — never echo the rate-limited email (leak guard).
+        return HTMLResponse(
+            content=signin_form_fragment(
+                "Too many sign-in attempts. Please wait a few minutes and try again."
+            ),
+            status_code=429,
+            headers=headers,
+        )
+
     origin = _external_origin(request, settings.app_url)
     redirect_url = f"{origin}/auth/callback"
 
@@ -151,9 +193,6 @@ def login(
         # guard: we don't echo Supabase's message verbatim for non-rate-
         # limit errors (which can leak whether an email is known).
         if exc.code in RATE_LIMIT_CODES:
-            # Return HTML fragment (not JSON HTTPException) so HTMX's
-            # response-targets ext (#250) can swap it into #signin-form
-            # for the real user to see instead of a silent 4xx.
             # Supabase's shared-SMTP-pool default is 30 emails per project
             # per hour. AuthApiError does not surface Supabase's actual
             # Retry-After (checked upstream: only message/status/code).
@@ -164,15 +203,27 @@ def login(
             # when the user has a different email in mind. #246 (custom
             # SMTP via Resend) is the structural fix.
             return HTMLResponse(
-                content=RATE_LIMIT_FRAGMENT,
+                content=signin_form_fragment(
+                    "Too many sign-in emails just now. Please try again in a few minutes."
+                ),
                 status_code=429,
                 headers={"Retry-After": "900"},
             )
-        raise HTTPException(status_code=502, detail="Sign-in unavailable") from exc
-    except Exception as exc:
+        return HTMLResponse(
+            content=signin_form_fragment(
+                "Sign-in is temporarily unavailable. Please try again in a moment."
+            ),
+            status_code=502,
+        )
+    except Exception:
         # Non-Supabase failure (network, config, code bug). Same 502 as
         # before so operators can spot the class from Cloud Logging.
-        raise HTTPException(status_code=502, detail="Sign-in unavailable") from exc
+        return HTMLResponse(
+            content=signin_form_fragment(
+                "Sign-in is temporarily unavailable. Please try again in a moment."
+            ),
+            status_code=502,
+        )
 
     return HTMLResponse(content=GENERIC_FRAGMENT, status_code=202)
 

--- a/app/services/rate_limit.py
+++ b/app/services/rate_limit.py
@@ -191,32 +191,22 @@ def _enforce(
 SessionDep = Annotated[Session, Depends(get_session)]
 
 
-async def enforce_login_rate_limit(
-    request: Request,
-    session: SessionDep,
-) -> None:
-    """FastAPI dependency for POST /login.
+def check_login_rate_limit(request: Request, session: Session, email: str) -> None:
+    """Enforce the /login rate limit for a (client IP, email) pair.
 
-    Extracts the IP and the form-submitted `email` field. Both buckets
-    must have ≥1 token; otherwise the request is rejected with 429.
+    Called directly from the `login` handler — not as a dependency — so the
+    handler can catch the 429 and render it as an HTML form fragment instead
+    of a raw JSON body (#288). Both the IP bucket and the email bucket must
+    have ≥1 token; otherwise raises HTTPException(429) with `Retry-After`.
+
+    `email` is the already-normalised address the handler validated, so the
+    bucket key is stable across requests for the same user.
     """
-    ip = _client_ip(request)
-    # Read the email out of the form body. FastAPI's form parsing has
-    # already cached the body by the time this dependency runs, so the
-    # downstream route reading `email: Form()` doesn't re-read.
-    form = await request.form()
-    raw_email = form.get("email")
-    if not isinstance(raw_email, str) or not raw_email:
-        # No email supplied — the route's own Form validation will 422
-        # this. Don't burn a token on malformed input.
-        return
-    email_norm = raw_email.strip().lower()
-
     _enforce(
         session,
-        keys=(f"login:ip:{ip}", f"login:email:{email_norm}"),
+        keys=(f"login:ip:{_client_ip(request)}", f"login:email:{email}"),
         route="login",
-        email_hash=_hash_email(email_norm),
+        email_hash=_hash_email(email),
     )
 
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -22,7 +22,8 @@
         hx-target="#signin-form"
         hx-swap="outerHTML"
         hx-ext="response-targets"
-        hx-target-4*="#signin-form">
+        hx-target-4*="#signin-form"
+        hx-target-5*="#signin-form">
     <label for="email">
       Email
       <input

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -164,7 +164,13 @@ def test_supabase_non_rate_limit_authapierror_returns_502(
     )
     response = client.post("/login", data={"email": "reader@example.com"})
     assert response.status_code == 502
-    assert response.json()["detail"] == "Sign-in unavailable"
+    # #288: 502 now renders an HTML form fragment (not a JSON HTTPException) so
+    # HTMX can swap a readable message in via hx-target-5*. The generic message
+    # preserves the enumeration guard — Supabase's error text is never echoed.
+    body = response.text
+    assert '<form id="signin-form"' in body
+    assert "temporarily unavailable" in body
+    assert "invalid grant" not in body
 
 
 def test_supabase_upstream_error_returns_502(client: TestClient, supabase_mock: MagicMock) -> None:
@@ -173,3 +179,57 @@ def test_supabase_upstream_error_returns_502(client: TestClient, supabase_mock: 
     supabase_mock.auth.sign_in_with_otp.side_effect = RuntimeError("supabase down")
     response = client.post("/login", data={"email": "reader@example.com"})
     assert response.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# #288 — every /login error path renders a readable form fragment, not JSON
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_email_renders_form_fragment_not_json(client: TestClient) -> None:
+    """422 body is an HTML form fragment with a readable message, not a raw
+    JSON HTTPException that HTMX would dump into #signin-form verbatim."""
+    response = client.post("/login", data={"email": "not-an-email"})
+
+    assert response.status_code == 422
+    body = response.text
+    assert '<form id="signin-form"' in body
+    assert 'role="alert"' in body
+    assert "valid email address" in body
+    assert '{"detail"' not in body
+
+
+def test_error_fragments_carry_both_4xx_and_5xx_targets(client: TestClient) -> None:
+    """The re-rendered form must declare hx-target-5* as well as hx-target-4*,
+    so a follow-up 5xx (502) also swaps back in rather than vanishing — the
+    root cause of the '502 shows nothing' symptom."""
+    body = client.post("/login", data={"email": "not-an-email"}).text
+
+    assert 'hx-target-4*="#signin-form"' in body
+    assert 'hx-target-5*="#signin-form"' in body
+
+
+def test_local_rate_limit_renders_fragment_with_retry_after(client: TestClient) -> None:
+    """Exhaust the local 10/hour bucket from one IP, then confirm the 429 is a
+    readable fragment (not JSON) that keeps Retry-After and does not echo the
+    email (leak guard)."""
+    ip = "203.0.113.55"
+    email = "loop@example.com"
+    last = None
+    for _ in range(11):
+        last = client.post(
+            "/login",
+            data={"email": email},
+            headers={"X-Forwarded-For": ip},
+        )
+
+    assert last is not None
+    assert last.status_code == 429
+    body = last.text
+    assert '<form id="signin-form"' in body
+    assert 'role="alert"' in body
+    assert "wait a few minutes" in body
+    assert '{"detail"' not in body
+    assert "Retry-After" in last.headers
+    # Enumeration / leak guard: the rate-limited email must not appear.
+    assert email not in body


### PR DESCRIPTION
## Summary

Every non-success `/login` outcome except the Supabase-429 path (fixed in #250) returned a **JSON `HTTPException`**, and the sign-in form declared only `hx-target-4*`. So a real user saw **raw `{"detail":"..."}`** on a 422 or the local rate-limit 429, and **nothing at all** on a 502 (no 5xx target). Found during the #285 browser check — *"the first few times nothing happened, the most recent showed `{"detail":"Too many requests. Try again later."}`"*.

## Before → after

| Outcome | Status | Before | After |
|---|---|---|---|
| Malformed email | 422 | raw JSON | form fragment + message |
| Local rate limit (10/hr) | 429 | raw JSON | form fragment + message + `Retry-After` |
| Supabase rate limit | 429 | fragment (#250) | fragment (unchanged) |
| Upstream/other error | 502 | **nothing** (no 5xx target) | form fragment + message |

Status codes are **unchanged** — only the response body/rendering changes, so monitoring is unaffected.

## Changes

- **`signin_form_fragment(error)`** — one helper that re-renders the form with an optional inline `role="alert"` message and declares **both** `hx-target-4*` and `hx-target-5*`. Replaces the duplicated `RATE_LIMIT_FRAGMENT`.
- **`templates/home.html`** — add `hx-target-5*="#signin-form"` so a 502 fragment swaps in instead of vanishing (the root cause of "nothing happened").
- **Rate-limit check moved into the handler** (new sync `check_login_rate_limit`) so its 429 can be caught and rendered as a fragment. It now runs *after* email validation, so a malformed address no longer burns a token. `Retry-After` preserved.

## Guardrails honored

- **Enumeration / leak guards intact:** fixed messages, the email input is re-rendered empty, and Supabase's error text is never echoed. Pinned by new tests + the existing `test_429_body_does_not_leak_the_email`.
- Status codes and the `RATE_LIMIT_CODES` whitelist (#252) unchanged.

## Verification

- [x] `ruff` / `ruff format` / `mypy` — clean
- [x] `uv run pytest` — **305 passed** (+3 new #288 tests; updated the one test that asserted 502-as-JSON)
- [x] **Live check:** ran uvicorn, a bad email now returns `<form id="signin-form"...` instead of `{"detail":"Invalid email format"}`
- [x] Local-429 test exhausts the real bucket and asserts fragment + `Retry-After` + no email leak

## Context

Found while diagnosing why #285's browser check couldn't sign in. The *underlying* auth failure (sign-in not completing on preview) traces to **#286** (Site URL) and **#207** (redirect allowlist), still open — this PR is specifically the error-**rendering** defect, which is independent and worth fixing regardless.

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)