### PR TITLE
fix(auth): log the /login 502 cause instead of swallowing it

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -24,6 +24,7 @@ The legacy `User` SQLModel is still alive — see the transitional
 shim in `app/services/identity/session.py`. SUPA-2b (#87) removes it.
 """
 
+import logging
 from typing import Annotated
 
 from email_validator import EmailNotValidError, validate_email
@@ -39,6 +40,8 @@ from app.integrations.supabase.client import anon_client
 from app.services.rate_limit import check_login_rate_limit
 
 router = APIRouter()
+
+logger = logging.getLogger(__name__)
 
 SettingsDep = Annotated[Settings, Depends(get_settings)]
 SessionDep = Annotated[Session, Depends(get_session)]
@@ -193,6 +196,7 @@ def login(
         # guard: we don't echo Supabase's message verbatim for non-rate-
         # limit errors (which can leak whether an email is known).
         if exc.code in RATE_LIMIT_CODES:
+            logger.warning("login.supabase_rate_limited code=%s status=%s", exc.code, exc.status)
             # Supabase's shared-SMTP-pool default is 30 emails per project
             # per hour. AuthApiError does not surface Supabase's actual
             # Retry-After (checked upstream: only message/status/code).
@@ -209,6 +213,19 @@ def login(
                 status_code=429,
                 headers={"Retry-After": "900"},
             )
+        # Non-rate-limit Supabase error -> 502. Log the code/status/message so
+        # the cause is in Cloud Logging instead of only the Supabase dashboard.
+        # This is server-side observability, not echoed to the client, so it
+        # doesn't touch the enumeration guard — and Supabase send-failure
+        # messages (e.g. the SMTP 535 that took down sign-in on 2026-08-03,
+        # #246) describe infrastructure, not which emails exist. No raw user
+        # email is logged.
+        logger.warning(
+            "login.supabase_error code=%s status=%s message=%s",
+            exc.code,
+            exc.status,
+            exc.message,
+        )
         return HTMLResponse(
             content=signin_form_fragment(
                 "Sign-in is temporarily unavailable. Please try again in a moment."
@@ -216,8 +233,10 @@ def login(
             status_code=502,
         )
     except Exception:
-        # Non-Supabase failure (network, config, code bug). Same 502 as
-        # before so operators can spot the class from Cloud Logging.
+        # Non-Supabase failure (network, config, code bug). Log with the
+        # traceback so operators can spot the class from Cloud Logging (the
+        # comment here used to claim this happened — now it actually does).
+        logger.exception("login.unexpected_error")
         return HTMLResponse(
             content=signin_form_fragment(
                 "Sign-in is temporarily unavailable. Please try again in a moment."

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -233,3 +233,65 @@ def test_local_rate_limit_renders_fragment_with_retry_after(client: TestClient) 
     assert "Retry-After" in last.headers
     # Enumeration / leak guard: the rate-limited email must not appear.
     assert email not in body
+
+
+# ---------------------------------------------------------------------------
+# Observability — the /login 502 cause is logged (motivated by the SMTP-535
+# production outage on 2026-08-03, which the app had swallowed silently)
+# ---------------------------------------------------------------------------
+
+
+def test_supabase_502_logs_error_code_and_message(
+    client: TestClient, supabase_mock: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A non-rate-limit Supabase error must land a warning in the logs with
+    the code/status/message, so operators see the cause in Cloud Logging
+    instead of having to open the Supabase dashboard."""
+    from supabase_auth.errors import AuthApiError
+
+    supabase_mock.auth.sign_in_with_otp.side_effect = AuthApiError(
+        "Error sending magic link email: 535 authentication credentials invalid",
+        500,
+        "unexpected_failure",
+    )
+    with caplog.at_level("WARNING", logger="app.api.auth"):
+        response = client.post("/login", data={"email": "reader@example.com"})
+
+    assert response.status_code == 502
+    record = next((r for r in caplog.records if "login.supabase_error" in r.getMessage()), None)
+    assert record is not None, "expected a login.supabase_error warning"
+    msg = record.getMessage()
+    assert "unexpected_failure" in msg
+    assert "535" in msg  # the actual SMTP failure reason is visible
+
+
+def test_unexpected_502_logs_with_traceback(
+    client: TestClient, supabase_mock: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A non-AuthApiError failure (network, code bug) logs at ERROR with the
+    traceback so the class is spottable in Cloud Logging."""
+    supabase_mock.auth.sign_in_with_otp.side_effect = RuntimeError("supabase down")
+    with caplog.at_level("WARNING", logger="app.api.auth"):
+        response = client.post("/login", data={"email": "reader@example.com"})
+
+    assert response.status_code == 502
+    record = next((r for r in caplog.records if "login.unexpected_error" in r.getMessage()), None)
+    assert record is not None
+    assert record.exc_info is not None  # logger.exception captured the traceback
+
+
+def test_login_502_log_does_not_leak_the_email(
+    client: TestClient, supabase_mock: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """PII guard: the raw submitted email must never appear in the logs
+    (mirrors the enumeration guard the response already honors)."""
+    from supabase_auth.errors import AuthApiError
+
+    secret_email = "very.identifiable.person@example.com"
+    supabase_mock.auth.sign_in_with_otp.side_effect = AuthApiError(
+        "smtp failure", 500, "unexpected_failure"
+    )
+    with caplog.at_level("WARNING", logger="app.api.auth"):
+        client.post("/login", data={"email": secret_email})
+
+    assert secret_email not in caplog.text


### PR DESCRIPTION
## Summary

On 2026-08-03 production magic-link sign-in was down for hours — Supabase custom SMTP was misconfigured (**535 "authentication credentials invalid"**) — and **the app logged nothing**. The `/login` 502 paths returned a user fragment (#288) but emitted no server-side log, so the only way to find the cause was opening the Supabase Auth dashboard. `app/api/auth.py` had **no logger at all**, and the generic-`except` comment even *claimed* operators could "spot the class from Cloud Logging" while emitting nothing.

## Changes

Adds a module logger and logs on the failure paths:

| Path | Log |
|---|---|
| Supabase `AuthApiError`, non-rate-limit → 502 | `logger.warning("login.supabase_error code=… status=… message=…")` |
| Non-Supabase exception → 502 | `logger.exception("login.unexpected_error")` (with traceback) |
| Supabase rate-limit → 429 | `logger.warning("login.supabase_rate_limited …")` (shared-pool exhaustion is now visible too) |

On 2026-08-03 this would have produced a `login.supabase_error … 535 authentication credentials invalid` line in Cloud Logging instead of a silent outage.

## Safety

- **Enumeration guard intact.** These are server-side logs, never echoed to the client. The `code`/`status` are enum-y, and Supabase *send-failure* messages describe infrastructure (SMTP), not which emails exist.
- **No PII.** The raw submitted email is never passed to the logger — pinned by `test_login_502_log_does_not_leak_the_email`. (`exc.message` is Supabase's own text; for send failures it doesn't contain the recipient. If you'd prefer to drop `message` entirely and keep only `code`/`status`, that's a one-line change — flagging the tradeoff since `message` is what carried the diagnostic "535".)

## Verification

- [x] `ruff` / `ruff format` / `mypy` — clean
- [x] `uv run pytest` — **313 passed** (+3): 502 logs code+message, unexpected-error logs traceback, email never leaks
- [x] Behavior otherwise unchanged — same status codes, same fragments (#288)

## Context

Directly motivated by the outage recorded on #246. Complements #284 (Sentry activation), which is still pending — until Sentry is live, Cloud Logging is the only server-side window, and this makes it actually useful for `/login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)