### PR TITLE
feat(data): preset_passage table + passage attribution columns (#279)

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -3,6 +3,7 @@
 from app.models.comprehension_question_cache import ComprehensionQuestionCache
 from app.models.passage import Passage
 from app.models.preference import Preference
+from app.models.preset_passage import PresetPassage
 from app.models.rate_bucket import RateBucket
 from app.models.reading_event import ReadingEvent
 from app.models.todo import Todo
@@ -11,6 +12,7 @@ __all__ = [
     "ComprehensionQuestionCache",
     "Passage",
     "Preference",
+    "PresetPassage",
     "RateBucket",
     "ReadingEvent",
     "Todo",

--- a/app/models/passage.py
+++ b/app/models/passage.py
@@ -6,24 +6,42 @@ content-addressable key into `comprehension_question_cache` (per
 ADR-001 in docs/TECHNICAL-ARCHITECTURE.md), so the SAME passage pasted
 by two different users hits the same cached questions.
 
-`source_type` is constrained to `'paste' | 'pdf'`. `source_filename` is
-populated only for PDF uploads (kept for display, never re-read from
-disk — the parsed text is the source of truth post-ingestion).
+`source_type` is constrained to `'paste' | 'pdf' | 'preset'`.
+`source_filename` is populated only for PDF uploads (kept for display,
+never re-read from disk — the parsed text is the source of truth
+post-ingestion).
 
 `owner_id` references `auth.users(id)` in Supabase. The FK constraint
 lives in the SQL migration (supabase/migrations/*.sql), not on the
 SQLModel field — `auth.users` is in a different schema and isn't a
 SQLModel-managed table.
+
+PRESET-1 (#279): the `attribution_*` columns are populated only when a
+passage was created by selecting a preset (`source_type='preset'`), so
+the reading surface can render the required
+`Copyright © Bahá'í International Community` + source/author. They are
+NULL for paste/pdf passages.
 """
 
 import uuid
 from datetime import UTC, datetime
 
+import sqlalchemy as sa
 from sqlmodel import Field, SQLModel
 
 
 class Passage(SQLModel, table=True):
     __tablename__ = "passage"
+    # Mirror the migration's source_type CHECK so the test conftest's
+    # `SQLModel.metadata.create_all` enforces it too — otherwise the tests
+    # would accept a bogus source_type that Supabase-managed Postgres rejects.
+    # Same precedent as ReadingEvent's lines_processed CHECK.
+    __table_args__ = (
+        sa.CheckConstraint(
+            "source_type IN ('paste', 'pdf', 'preset')",
+            name="passage_source_type_check",
+        ),
+    )
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     owner_id: uuid.UUID = Field(nullable=False)
@@ -31,6 +49,12 @@ class Passage(SQLModel, table=True):
     text_hash: bytes
     source_type: str
     source_filename: str | None = Field(default=None)
+    # PRESET-1 (#279): attribution carried from a preset onto the user-owned
+    # passage created by copy-on-select. NULL for paste/pdf.
+    attribution_title: str | None = Field(default=None)
+    attribution_author: str | None = Field(default=None)
+    attribution_copyright: str | None = Field(default=None)
+    attribution_source_url: str | None = Field(default=None)
     # COMP-5 (#128): per-passage comprehension toggle. Default on; a reader
     # can disable questions for a passage where the auto-generated ones are
     # unhelpful (PRD Risk #2 mitigation for sacred/poetic text).

--- a/app/models/preset_passage.py
+++ b/app/models/preset_passage.py
@@ -1,0 +1,45 @@
+"""PresetPassage model.
+
+The curated preset message library (PRESET-1 #279, epic #278) — e.g. recent
+Universal House of Justice messages a reader can pick instead of pasting their
+own text. Shared reference data, not per-user: readable by any authenticated
+session (RLS SELECT policy), writable only by the service role (seeded via
+migration/script in PRESET-2).
+
+Selecting a preset creates a normal user-owned `Passage` with
+`source_type='preset'` that copies this row's `text` and carries its
+attribution (copy-on-select, PRESET-4), so the whole existing reading pipeline
+is reused and the required attribution travels with the text.
+
+`text_hash` is the same content-addressable key `Passage` uses into
+`comprehension_question_cache` (ADR-001): every reader who opens the same
+preset shares one set of generated comprehension questions.
+
+Rights basis: bahai.org content is usable provided each message displays
+`Copyright © Bahá'í International Community` and source/author attribution —
+hence `copyright_holder` and `source_url` are NOT NULL, and `author` is
+nullable only because not every message names an individual author.
+"""
+
+import uuid
+from datetime import UTC, date, datetime
+
+from sqlmodel import Field, SQLModel
+
+
+class PresetPassage(SQLModel, table=True):
+    __tablename__ = "preset_passage"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    title: str
+    # Nullable: not every message names an individual author.
+    author: str | None = Field(default=None)
+    copyright_holder: str = Field(default="Bahá'í International Community", nullable=False)
+    source_url: str
+    source_date: date | None = Field(default=None)
+    text: str
+    text_hash: bytes
+    # Soft on/off; the picker (PRESET-3) lists only active rows.
+    is_active: bool = Field(default=True, nullable=False)
+    sort_order: int = Field(default=0, nullable=False)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/supabase/migrations/20260804000000_add_preset_passage_and_attribution.sql
+++ b/supabase/migrations/20260804000000_add_preset_passage_and_attribution.sql
@@ -1,0 +1,62 @@
+-- PRESET-1 (#279): foundation for the curated preset message library (#278).
+--
+-- Adds:
+--   1. `preset_passage` — the curated library of messages (e.g. UHJ letters).
+--      Shared reference data: readable by any authenticated user, writable
+--      only by the service role (seeded via migration/script in PRESET-2).
+--   2. Nullable attribution columns on `passage` — copy-on-select (PRESET-4)
+--      copies a preset's attribution onto the user-owned Passage it creates,
+--      so the reading surface can always render the required
+--      `Copyright © Bahá'í International Community` + source/author. Nullable
+--      because paste/pdf passages carry no attribution.
+--   3. Widens the `source_type` CHECK to allow 'preset'.
+--
+-- Additive and idempotent (IF NOT EXISTS / DROP-then-ADD) so it is safe to
+-- re-apply across Supabase preview branches. No backfill: existing passages
+-- keep NULL attribution.
+
+-- 1. Curated library table.
+CREATE TABLE IF NOT EXISTS public.preset_passage (
+    id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    title            text NOT NULL,
+    -- Nullable: not every message names an individual author.
+    author           text,
+    copyright_holder text NOT NULL DEFAULT 'Bahá''í International Community',
+    source_url       text NOT NULL,
+    source_date      date,
+    text             text NOT NULL,
+    -- Content-addressable key into comprehension_question_cache (ADR-001), so
+    -- every reader who opens the same preset shares one set of generated
+    -- questions. SHA-256 of the exact stored text, same rule as passage.
+    text_hash        bytea NOT NULL,
+    -- Soft on/off without deleting history; the picker lists only active rows.
+    is_active        boolean NOT NULL DEFAULT true,
+    sort_order       integer NOT NULL DEFAULT 0,
+    created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- 2. Attribution columns on passage (nullable — paste/pdf have none).
+ALTER TABLE public.passage
+    ADD COLUMN IF NOT EXISTS attribution_title      text,
+    ADD COLUMN IF NOT EXISTS attribution_author     text,
+    ADD COLUMN IF NOT EXISTS attribution_copyright  text,
+    ADD COLUMN IF NOT EXISTS attribution_source_url text;
+
+-- 3. Widen the source_type CHECK to include 'preset'. DROP-then-ADD (not left
+--    at the old 2-value form) so the constraint actually reflects reality.
+ALTER TABLE public.passage
+    DROP CONSTRAINT IF EXISTS passage_source_type_check;
+ALTER TABLE public.passage
+    ADD CONSTRAINT passage_source_type_check
+        CHECK (source_type IN ('paste', 'pdf', 'preset'));
+
+-- RLS: preset_passage is shared reference data. Any authenticated session may
+-- SELECT; there is NO insert/update/delete policy, so only the service role
+-- (which bypasses RLS) can write it. `anon` has no policy and cannot read it.
+ALTER TABLE public.preset_passage ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "authenticated can read preset passages" ON public.preset_passage;
+CREATE POLICY "authenticated can read preset passages"
+    ON public.preset_passage FOR SELECT
+    TO authenticated
+    USING (true);

--- a/tests/test_preset_passage_model.py
+++ b/tests/test_preset_passage_model.py
@@ -1,0 +1,143 @@
+"""Tests for the PRESET-1 (#279) schema foundation.
+
+Covers the Definition of Done:
+  - preset_passage round-trips (create -> read) with its defaults
+  - passage accepts source_type='preset'; an invalid source_type is rejected
+  - the new passage attribution columns are nullable (paste/pdf leave them NULL)
+    and populated for a preset-sourced passage
+"""
+
+import hashlib
+import uuid
+from datetime import date
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, select
+
+from app.models.passage import Passage
+from app.models.preset_passage import PresetPassage
+
+
+def _hash(text: str) -> bytes:
+    return hashlib.sha256(text.encode("utf-8")).digest()
+
+
+# ---------------------------------------------------------------------------
+# preset_passage
+# ---------------------------------------------------------------------------
+
+
+def test_preset_passage_round_trips_with_defaults(session: Session) -> None:
+    text = "O Son of Spirit! My first counsel is this..."
+    preset = PresetPassage(
+        title="Ridván 2024 Message",
+        source_url="https://www.bahai.org/library/authoritative-texts/x",
+        text=text,
+        text_hash=_hash(text),
+    )
+    session.add(preset)
+    session.commit()
+
+    row = session.exec(select(PresetPassage)).one()
+    assert row.title == "Ridván 2024 Message"
+    assert row.text == text
+    assert row.text_hash == _hash(text)
+    # Defaults applied.
+    assert row.copyright_holder == "Bahá'í International Community"
+    assert row.is_active is True
+    assert row.sort_order == 0
+    assert row.author is None
+    assert row.source_date is None
+    assert row.created_at is not None
+
+
+def test_preset_passage_accepts_full_attribution(session: Session) -> None:
+    preset = PresetPassage(
+        title="A Named Letter",
+        author="The Universal House of Justice",
+        copyright_holder="Bahá'í International Community",
+        source_url="https://www.bahai.org/x",
+        source_date=date(2024, 4, 21),
+        text="body",
+        text_hash=_hash("body"),
+        is_active=False,
+        sort_order=5,
+    )
+    session.add(preset)
+    session.commit()
+
+    row = session.exec(select(PresetPassage)).one()
+    assert row.author == "The Universal House of Justice"
+    assert row.source_date == date(2024, 4, 21)
+    assert row.is_active is False
+    assert row.sort_order == 5
+
+
+# ---------------------------------------------------------------------------
+# passage source_type widening + attribution columns
+# ---------------------------------------------------------------------------
+
+
+def test_passage_accepts_source_type_preset(session: Session) -> None:
+    p = Passage(
+        owner_id=uuid.uuid4(),
+        text="copied preset text",
+        text_hash=_hash("copied preset text"),
+        source_type="preset",
+        attribution_title="Ridván 2024 Message",
+        attribution_author="The Universal House of Justice",
+        attribution_copyright="Bahá'í International Community",
+        attribution_source_url="https://www.bahai.org/x",
+    )
+    session.add(p)
+    session.commit()
+
+    row = session.exec(select(Passage).where(Passage.source_type == "preset")).one()
+    assert row.attribution_copyright == "Bahá'í International Community"
+    assert row.attribution_author == "The Universal House of Justice"
+
+
+@pytest.mark.parametrize("source_type", ["paste", "pdf", "preset"])
+def test_passage_allows_every_valid_source_type(session: Session, source_type: str) -> None:
+    p = Passage(
+        owner_id=uuid.uuid4(),
+        text="x",
+        text_hash=_hash("x"),
+        source_type=source_type,
+    )
+    session.add(p)
+    session.commit()  # should not raise
+
+
+def test_passage_rejects_invalid_source_type(session: Session) -> None:
+    """The CHECK constraint (mirrored in __table_args__) must reject a
+    source_type outside the allow-list, on SQLite as in Postgres."""
+    p = Passage(
+        owner_id=uuid.uuid4(),
+        text="x",
+        text_hash=_hash("x"),
+        source_type="video",
+    )
+    session.add(p)
+    with pytest.raises(IntegrityError):
+        session.commit()
+
+
+def test_paste_passage_leaves_attribution_null(session: Session) -> None:
+    """A normal paste passage carries no attribution — the new columns stay
+    NULL (they're only populated by copy-on-select from a preset)."""
+    p = Passage(
+        owner_id=uuid.uuid4(),
+        text="just pasted",
+        text_hash=_hash("just pasted"),
+        source_type="paste",
+    )
+    session.add(p)
+    session.commit()
+
+    row = session.exec(select(Passage)).one()
+    assert row.attribution_title is None
+    assert row.attribution_author is None
+    assert row.attribution_copyright is None
+    assert row.attribution_source_url is None


### PR DESCRIPTION
## Summary

**PRESET-1** — the schema foundation for the curated preset message library (epic #278). No user-facing behavior yet; it's the base the rest of the epic builds on.

## Changes

| File | Change |
|---|---|
| `supabase/migrations/20260804000000_…sql` | CREATE `preset_passage`; add nullable `attribution_*` to `passage`; widen `source_type` CHECK; RLS |
| `app/models/preset_passage.py` | New `PresetPassage` SQLModel |
| `app/models/passage.py` | 4 nullable `attribution_*` fields + mirrored `source_type` CHECK in `__table_args__` |
| `app/models/__init__.py` | register `PresetPassage` (so `create_all` builds it in tests) |
| `tests/test_preset_passage_model.py` | 8 tests |

## Design notes

- **`preset_passage` is shared reference data.** RLS grants `SELECT` to `authenticated`; there is **no** insert/update/delete policy, so only the service role (which bypasses RLS) can write it — it'll be seeded via migration/script in PRESET-2. `anon` has no policy and cannot read it.
- **Attribution travels with the copy.** The nullable `attribution_*` columns on `passage` let copy-on-select (PRESET-4) carry a preset's `Copyright © Bahá'í International Community` + source/author onto the user-owned passage, so the reading surface can always render it. NULL for paste/pdf.
- **`copyright_holder` / `source_url` are NOT NULL** on `preset_passage` (the rights basis requires attribution); `author` is nullable because not every message names one.
- **CHECK mirrored in the model** (`__table_args__`), matching the `ReadingEvent` precedent, so the test SQLite DB rejects a bad `source_type` just like Postgres — pinned by `test_passage_rejects_invalid_source_type`.
- **`text_hash`** reuses the comprehension-cache key (ADR-001): readers of the same preset share generated questions.

## Rights scope

This PR contains **no actual message text** — it's pure schema — so it's intentionally **decoupled from PRESET-2's open rights-scope question** (redistribute-in-app vs display-only). That question only gates seeding the corpus (#280), not this foundation.

## Verification

- [x] `ruff` / `ruff format` / `mypy` — clean (45 source files)
- [x] `uv run pytest` — **321 passed** (+8): preset round-trip, `source_type='preset'` accepted, invalid rejected, attribution nullable for paste/pdf
- [x] No regression — existing passage/pdf/reading tests still green under the widened CHECK
- [ ] ⚠️ Migration **not run under `supabase db reset` locally** (no Docker in this env). Follows the additive `IF NOT EXISTS` pattern; **CI Supabase Preview validates it** — please confirm that check is green.

Closes #279 · unblocks #280 (seed), #281 (picker), #282 (copy-on-select)

🤖 Generated with [Claude Code](https://claude.com/claude-code)