### PR TITLE
feat(reading): preset picker on /passages/new (#281)

### DIFF
--- a/app/api/passages.py
+++ b/app/api/passages.py
@@ -20,11 +20,12 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse
-from sqlmodel import Session
+from sqlmodel import Session, col, select
 
 from app.db import get_session
 from app.integrations.supabase.auth import current_user
 from app.models.passage import Passage
+from app.models.preset_passage import PresetPassage
 from app.services.ingestion.pdf import EmptyPdfTextError, PdfParseError, extract_text
 from app.services.ingestion.split import MAX_PARTS, split_into_parts
 from app.templates import templates
@@ -100,12 +101,25 @@ def _persist_as_passages(
 
 
 @router.get("/passages/new", response_class=HTMLResponse)
-def new_passage_form(request: Request, user: CurrentUser) -> HTMLResponse:
-    """Render the paste-text form."""
+def new_passage_form(request: Request, user: CurrentUser, session: SessionDep) -> HTMLResponse:
+    """Render the passage-input page: paste, PDF upload, and the preset picker.
+
+    PRESET-3 (#281): lists the active curated presets so a reader can start
+    from a message instead of pasting. Read-only here — selecting one is
+    handled by PRESET-4's `POST /passages/from-preset/{id}`. Ordered by
+    `sort_order` then `created_at` for a stable listing; inactive presets are
+    excluded. Empty (the current state until PRESET-2 seeds the corpus) renders
+    a clean placeholder.
+    """
+    presets = session.exec(
+        select(PresetPassage)
+        .where(col(PresetPassage.is_active))
+        .order_by(col(PresetPassage.sort_order), col(PresetPassage.created_at))
+    ).all()
     return templates.TemplateResponse(
         request=request,
         name="pages/passages_new.html",
-        context={"user": user},
+        context={"user": user, "presets": presets},
     )
 
 

--- a/templates/pages/passages_new.html
+++ b/templates/pages/passages_new.html
@@ -48,4 +48,34 @@
       <button type="submit">Upload and read</button>
     </form>
   </article>
+
+  {# PRESET-3 (#281): pick a curated message instead of pasting. Read-only
+     listing; selecting one is PRESET-4's POST /passages/from-preset/{id}.
+     Renders a clean placeholder while the corpus is empty (pre PRESET-2). #}
+  <article aria-labelledby="preset-heading">
+    <header><strong id="preset-heading">Start from a message</strong></header>
+    {% if presets %}
+      <p>Pick a message to read — no need to paste anything.</p>
+      <ul class="preset-list">
+        {% for preset in presets %}
+          <li class="preset-item">
+            <div class="preset-meta">
+              <strong>{{ preset.title }}</strong>
+              <small>
+                {% if preset.author %}{{ preset.author }} · {% endif %}
+                {{ preset.copyright_holder }}{% if preset.source_date %} ·
+                {{ preset.source_date.year }}{% endif %}
+              </small>
+            </div>
+            <form action="/passages/from-preset/{{ preset.id }}" method="post">
+              <button type="submit" aria-label="Read {{ preset.title }}">Read this</button>
+            </form>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p>No preset messages are available yet — paste your own text or upload a
+         PDF above to start reading.</p>
+    {% endif %}
+  </article>
 {% endblock %}

--- a/tests/test_preset_picker.py
+++ b/tests/test_preset_picker.py
@@ -1,0 +1,111 @@
+"""Tests for the preset picker on GET /passages/new (PRESET-3 #281).
+
+Covers the Definition of Done:
+  - lists active presets with title + attribution
+  - excludes inactive presets
+  - orders by sort_order
+  - empty-corpus state renders cleanly (no broken section)
+"""
+
+import hashlib
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.models.preset_passage import PresetPassage
+from tests.conftest import signed_in
+
+
+def _add_preset(
+    session: Session,
+    *,
+    title: str,
+    author: str | None = None,
+    is_active: bool = True,
+    sort_order: int = 0,
+) -> PresetPassage:
+    text = f"body of {title}"
+    preset = PresetPassage(
+        title=title,
+        author=author,
+        source_url="https://www.bahai.org/x",
+        text=text,
+        text_hash=hashlib.sha256(text.encode()).digest(),
+        is_active=is_active,
+        sort_order=sort_order,
+    )
+    session.add(preset)
+    session.commit()
+    session.refresh(preset)
+    return preset
+
+
+def test_empty_corpus_renders_clean_placeholder(client: TestClient, session: Session) -> None:
+    """No presets → the section still renders with a readable placeholder,
+    and the paste/PDF forms remain."""
+    signed_in(session)
+    body = client.get("/passages/new").text
+
+    assert "Start from a message" in body
+    assert "No preset messages are available yet" in body
+    # The primary input methods are untouched.
+    assert 'action="/passages"' in body
+    assert 'action="/passages/pdf"' in body
+
+
+def test_active_preset_listed_with_title_and_attribution(
+    client: TestClient, session: Session
+) -> None:
+    signed_in(session)
+    _add_preset(session, title="Ridván 2024 Message", author="The Universal House of Justice")
+
+    body = client.get("/passages/new").text
+
+    assert "Ridván 2024 Message" in body
+    assert "The Universal House of Justice" in body  # author attribution
+    # Copyright attribution renders (the apostrophe in "Bahá'í" is HTML-escaped
+    # to &#39; by Jinja auto-escape, so match the unambiguous tail).
+    assert "International Community" in body
+    assert "No preset messages are available yet" not in body
+
+
+def test_select_control_targets_the_preset4_route(client: TestClient, session: Session) -> None:
+    """Each row's control points at PRESET-4's create route (read-only here)."""
+    signed_in(session)
+    preset = _add_preset(session, title="A Message")
+
+    body = client.get("/passages/new").text
+
+    assert f'action="/passages/from-preset/{preset.id}"' in body
+    # Accessible, distinct label per row (a11y gate).
+    assert 'aria-label="Read A Message"' in body
+
+
+def test_inactive_presets_are_excluded(client: TestClient, session: Session) -> None:
+    signed_in(session)
+    _add_preset(session, title="Visible One", is_active=True)
+    _add_preset(session, title="Hidden One", is_active=False)
+
+    body = client.get("/passages/new").text
+
+    assert "Visible One" in body
+    assert "Hidden One" not in body
+
+
+def test_presets_ordered_by_sort_order(client: TestClient, session: Session) -> None:
+    signed_in(session)
+    _add_preset(session, title="Third", sort_order=30)
+    _add_preset(session, title="First", sort_order=10)
+    _add_preset(session, title="Second", sort_order=20)
+
+    body = client.get("/passages/new").text
+
+    assert body.index("First") < body.index("Second") < body.index("Third")
+
+
+def test_picker_requires_auth(client: TestClient) -> None:
+    """Unauthenticated GET redirects to the landing page, like the rest of
+    /passages/new (no preset data leaks to anon)."""
+    response = client.get("/passages/new", follow_redirects=False)
+    assert response.status_code in (302, 303)
+    assert response.headers["location"] == "/"


### PR DESCRIPTION
## Summary

**PRESET-3** — adds a "Start from a message" section to the passage-input page (`GET /passages/new`) that lists the active curated presets, so a reader can start from a message instead of pasting.

> ⚠️ **Stacked on #292 (PRESET-1).** This branch includes #279's schema commit, so **this PR's diff currently also shows the `preset_passage` migration/model**. **Merge #292 first**, then I'll rebase this branch onto `main` and the diff drops to just the picker (`app/api/passages.py` handler + `passages_new.html` + `tests/test_preset_picker.py`). Review those three files here; the rest is #292.

## Picker changes (the part to review)

| File | Change |
|---|---|
| `app/api/passages.py` | `new_passage_form` loads active presets (`is_active`, ordered by `sort_order` then `created_at`) and passes them to the template |
| `templates/pages/passages_new.html` | New "Start from a message" section + clean empty-state placeholder |
| `tests/test_preset_picker.py` | 6 tests |

## Design notes

- **Read-only, per the ticket.** Lists presets; does **not** create passages. Each row's button posts to `/passages/from-preset/{id}` — **PRESET-4's** route (#282). No content to click until #280 seeds + #282 lands.
- **Empty state is the current reality.** No presets exist yet, so the section renders a clean *"No preset messages are available yet…"* placeholder rather than a broken block. Pinned by a test.
- **Attribution shown** (DoD): title + `author · copyright_holder · year`. Full `Copyright ©…` on the reading surface is PRESET-4's job.
- **No JavaScript.** Plain forms; each button carries a distinct `aria-label="Read <title>"` for the a11y gate. Paste + PDF forms untouched.

## Verification

- [x] `ruff` / `ruff format` / `mypy` — clean
- [x] `uv run pytest` — **327 passed** (+6): empty-state, active preset listed w/ attribution, control targets #282 route, inactive excluded, ordering, auth required

Closes #281 · unblocks #282. Still parked: #280 (seed corpus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)