### PR TITLE
feat(reading): copy-on-select from presets + attribution rendering (#282)

### DIFF
--- a/app/api/passages.py
+++ b/app/api/passages.py
@@ -57,6 +57,10 @@ def _persist_as_passages(
     text: str,
     source_type: str,
     source_filename: str | None,
+    attribution_title: str | None = None,
+    attribution_author: str | None = None,
+    attribution_copyright: str | None = None,
+    attribution_source_url: str | None = None,
 ) -> Passage:
     """Persist `text` as one passage, or — if it's over MAX_TEXT_LEN — as an
     ordered set of linked parts (INGEST-3 #145). Returns the FIRST passage
@@ -65,6 +69,10 @@ def _persist_as_passages(
     Text within the cap stays a standalone passage (document_id=None) exactly
     as before. Over the cap, it's split into <= MAX_TEXT_LEN-render-safe parts
     that share one document_id; the reading view links them with Prev/Next.
+
+    PRESET-4 (#282): the `attribution_*` args carry a preset's copyright/author
+    onto EVERY part, so each page of a split preset renders the required
+    attribution. They default to None for paste/pdf, which store no attribution.
     """
     if len(text) <= MAX_TEXT_LEN:
         parts = [text]
@@ -90,6 +98,10 @@ def _persist_as_passages(
             document_id=document_id,
             part_index=index,
             part_count=part_count,
+            attribution_title=attribution_title,
+            attribution_author=attribution_author,
+            attribution_copyright=attribution_copyright,
+            attribution_source_url=attribution_source_url,
         )
         session.add(passage)
         if index == 0:
@@ -121,6 +133,40 @@ def new_passage_form(request: Request, user: CurrentUser, session: SessionDep) -
         name="pages/passages_new.html",
         context={"user": user, "presets": presets},
     )
+
+
+@router.post("/passages/from-preset/{preset_id}")
+def create_passage_from_preset(
+    preset_id: uuid.UUID,
+    user: CurrentUser,
+    session: SessionDep,
+) -> RedirectResponse:
+    """Create a user-owned passage from a curated preset, then open it.
+
+    PRESET-4 (#282): copy-on-select. Reuses `_persist_as_passages` (so hashing,
+    comprehension-cache sharing, and part-splitting all come for free) with
+    `source_type='preset'`, copying the preset's attribution onto the new
+    passage(s) so the reading surface renders the required copyright/author.
+
+    An unknown or inactive preset returns 404 with the same shape as GET /read
+    — it doesn't leak which ids exist.
+    """
+    preset = session.get(PresetPassage, preset_id)
+    if preset is None or not preset.is_active:
+        raise HTTPException(status_code=404, detail="Preset not found")
+
+    first = _persist_as_passages(
+        session=session,
+        owner_id=user.id,
+        text=preset.text,
+        source_type="preset",
+        source_filename=None,
+        attribution_title=preset.title,
+        attribution_author=preset.author,
+        attribution_copyright=preset.copyright_holder,
+        attribution_source_url=preset.source_url,
+    )
+    return RedirectResponse(url=f"/read/{first.id}", status_code=303)
 
 
 @router.post("/passages")

--- a/app/api/test_seed.py
+++ b/app/api/test_seed.py
@@ -78,7 +78,7 @@ router = APIRouter()
 SessionDep = Annotated[Session, Depends(get_session)]
 SettingsDep = Annotated[Settings, Depends(get_settings)]
 
-Variant = Literal["default", "high-contrast", "large-text", "bionic"]
+Variant = Literal["default", "high-contrast", "large-text", "bionic", "preset"]
 
 # Representative passage with multiple paragraphs so axe-core has a
 # real surface to analyze — headings, paragraph spacing, line wrap,
@@ -126,6 +126,9 @@ _PREFS_FOR_VARIANT: dict[str, dict[str, Any]] = {
     "high-contrast": {"bg": "#1a1a1a", "fg": "#e8e8e8"},
     "large-text": {"size": "28px"},
     "bionic": {"bionic_enabled": True},
+    # PRESET-4 (#282): no preference overrides — this variant is about the
+    # attribution block set on the seeded passage above, so axe can scan it.
+    "preset": {},
 }
 
 
@@ -175,6 +178,9 @@ def seed_passage_and_login(
     access_token: str = auth_resp.session.access_token
     user_id = uuid.UUID(str(auth_resp.user.id))
 
+    # PRESET-4 (#282): the `preset` variant seeds a preset-sourced passage with
+    # attribution so axe scans the copyright/author block on the reading surface.
+    is_preset = variant == "preset"
     passage = Passage(
         owner_id=user_id,
         # Placeholder hash — the read path doesn't validate it. Note the
@@ -183,8 +189,12 @@ def seed_passage_and_login(
         # directly rather than reusing this value.
         text_hash=b"\x00" * 32,
         text=SEED_PASSAGE_TEXT,
-        source_type="paste",
+        source_type="preset" if is_preset else "paste",
         source_filename=None,
+        attribution_title="The Hidden Words" if is_preset else None,
+        attribution_author="Bahá'u'lláh" if is_preset else None,
+        attribution_copyright="Bahá'í International Community" if is_preset else None,
+        attribution_source_url="https://www.bahai.org/library/" if is_preset else None,
     )
     session.add(passage)
 

--- a/static/style.css
+++ b/static/style.css
@@ -39,6 +39,27 @@
   padding-bottom: var(--reader-paragraph-spacing, 1em);
 }
 
+/* PRESET-4 (#282): attribution for preset-sourced passages. Aligned to the
+   reading column and separated by a rule. Uses full-strength text color (NOT a
+   muted/low-opacity grey) so it stays WCAG AA — the copyright line is a
+   licensing requirement and must be legible, not de-emphasised. */
+.passage-attribution {
+  max-width: var(--reader-max-width, 33em);
+  margin: 1.5rem auto 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--pico-muted-border-color);
+  font-size: 0.85rem;
+}
+
+.passage-attribution .attribution-title {
+  font-weight: 600;
+  margin: 0 0 0.25rem 0;
+}
+
+.passage-attribution .attribution-credit {
+  margin: 0;
+}
+
 /* Inline comprehension question shown after each passage section. */
 .inline-question {
   border-left: 3px solid var(--pico-primary);

--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -41,6 +41,26 @@
 
   {% include "fragments/reading_surface.html" %}
 
+  {# PRESET-4 (#282): attribution for preset-sourced passages. Rendered
+     unconditionally whenever present — it is the licensing condition for
+     using this text, NOT a user preference, so there is no toggle. Absent
+     (NULL) for paste/pdf passages, so nothing renders for those. #}
+  {% if passage.attribution_copyright %}
+    <footer class="passage-attribution">
+      {% if passage.attribution_title %}
+        <p class="attribution-title">{{ passage.attribution_title }}</p>
+      {% endif %}
+      <p class="attribution-credit">
+        {% if passage.attribution_author %}{{ passage.attribution_author }}. {% endif %}
+        Copyright &copy; {{ passage.attribution_copyright }}.
+        {% if passage.attribution_source_url %}
+          <a href="{{ passage.attribution_source_url }}"
+             rel="noopener noreferrer" target="_blank">Source</a>.
+        {% endif %}
+      </p>
+    </footer>
+  {% endif %}
+
   {% include "fragments/comprehension.html" %}
 
   {#

--- a/tests/a11y/fixtures/seed.ts
+++ b/tests/a11y/fixtures/seed.ts
@@ -1,6 +1,11 @@
 import type { APIRequestContext, BrowserContext } from "@playwright/test";
 
-export type Variant = "default" | "high-contrast" | "large-text" | "bionic";
+export type Variant =
+  | "default"
+  | "high-contrast"
+  | "large-text"
+  | "bionic"
+  | "preset";
 
 export interface SeedResult {
   passageId: string;

--- a/tests/a11y/reading_surface.spec.ts
+++ b/tests/a11y/reading_surface.spec.ts
@@ -21,9 +21,16 @@ import { seedAndLogin, type Variant } from "./fixtures/seed";
  *   - high-contrast → dark bg + light fg (dark-mode users)
  *   - large-text   → 28px font (low-vision users)
  *   - bionic       → bionic_enabled=true (the bionicize transform)
+ *   - preset       → preset-sourced passage w/ attribution block (#282)
  */
 
-const VARIANTS: Variant[] = ["default", "high-contrast", "large-text", "bionic"];
+const VARIANTS: Variant[] = [
+  "default",
+  "high-contrast",
+  "large-text",
+  "bionic",
+  "preset",
+];
 
 for (const variant of VARIANTS) {
   test(`reading surface a11y: ${variant}`, async ({ page, context, request }) => {

--- a/tests/test_preset_copy_on_select.py
+++ b/tests/test_preset_copy_on_select.py
@@ -1,0 +1,127 @@
+"""Tests for copy-on-select + attribution rendering (PRESET-4 #282).
+
+POST /passages/from-preset/{id} creates a user-owned Passage from a curated
+preset, copying its attribution, then opens the reading view where the
+copyright/author must render.
+"""
+
+import hashlib
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.models.passage import Passage
+from app.models.preset_passage import PresetPassage
+from tests.conftest import make_user, signed_in
+
+
+def _add_preset(session: Session, *, text: str = "O Son of Spirit!", is_active: bool = True):
+    preset = PresetPassage(
+        title="The Hidden Words",
+        author="Bahá'u'lláh",
+        source_url="https://www.bahai.org/library/x",
+        text=text,
+        text_hash=hashlib.sha256(text.encode()).digest(),
+        is_active=is_active,
+    )
+    session.add(preset)
+    session.commit()
+    session.refresh(preset)
+    return preset
+
+
+def test_from_preset_creates_owned_passage_with_attribution(
+    client: TestClient, session: Session
+) -> None:
+    user = signed_in(session)
+    preset = _add_preset(session)
+
+    response = client.post(f"/passages/from-preset/{preset.id}", follow_redirects=False)
+    assert response.status_code == 303
+
+    passage = session.exec(select(Passage)).one()
+    assert response.headers["location"] == f"/read/{passage.id}"
+    assert passage.owner_id == user.id
+    assert passage.source_type == "preset"
+    assert passage.text == preset.text
+    # All attribution copied from the preset (compliance guardrail).
+    assert passage.attribution_title == "The Hidden Words"
+    assert passage.attribution_author == "Bahá'u'lláh"
+    assert passage.attribution_copyright == "Bahá'í International Community"
+    assert passage.attribution_source_url == "https://www.bahai.org/library/x"
+
+
+def test_reading_view_renders_attribution_for_preset_passage(
+    client: TestClient, session: Session
+) -> None:
+    signed_in(session)
+    preset = _add_preset(session)
+    client.post(f"/passages/from-preset/{preset.id}", follow_redirects=False)
+    passage = session.exec(select(Passage)).one()
+
+    body = client.get(f"/read/{passage.id}").text
+
+    assert "passage-attribution" in body
+    assert "Copyright" in body and "International Community" in body
+    assert "Bahá" in body  # author/copyright present
+    assert "The Hidden Words" in body
+
+
+def test_reading_view_has_no_attribution_for_paste_passage(
+    client: TestClient, session: Session
+) -> None:
+    """Paste/pdf passages carry no attribution, so the block must not render."""
+    user = signed_in(session)
+    text = "just some pasted text"
+    p = Passage(
+        owner_id=user.id,
+        text=text,
+        text_hash=hashlib.sha256(text.encode()).digest(),
+        source_type="paste",
+    )
+    session.add(p)
+    session.commit()
+    session.refresh(p)
+
+    body = client.get(f"/read/{p.id}").text
+    assert "passage-attribution" not in body
+
+
+def test_unknown_preset_returns_404_no_passage(client: TestClient, session: Session) -> None:
+    signed_in(session)
+    response = client.post(f"/passages/from-preset/{uuid.uuid4()}", follow_redirects=False)
+    assert response.status_code == 404
+    assert session.exec(select(Passage)).all() == []
+
+
+def test_inactive_preset_returns_404_no_passage(client: TestClient, session: Session) -> None:
+    signed_in(session)
+    preset = _add_preset(session, is_active=False)
+    response = client.post(f"/passages/from-preset/{preset.id}", follow_redirects=False)
+    assert response.status_code == 404
+    assert session.exec(select(Passage)).all() == []
+
+
+def test_two_users_same_preset_share_text_hash(client: TestClient, session: Session) -> None:
+    """Both users' preset passages share one text_hash → one comprehension
+    cache entry (ADR-001), so questions are generated once, not per user."""
+    preset = _add_preset(session)
+
+    signed_in(session)  # user A
+    client.post(f"/passages/from-preset/{preset.id}", follow_redirects=False)
+
+    signed_in(session, email="userb@example.com")  # user B
+    client.post(f"/passages/from-preset/{preset.id}", follow_redirects=False)
+
+    hashes = {p.text_hash for p in session.exec(select(Passage)).all()}
+    assert len(hashes) == 1  # identical text_hash across both users' passages
+
+
+def test_from_preset_requires_auth(client: TestClient, session: Session) -> None:
+    preset = _add_preset(session)
+    make_user(session)  # a user exists, but the request is unauthenticated
+    response = client.post(f"/passages/from-preset/{preset.id}", follow_redirects=False)
+    assert response.status_code in (302, 303)
+    assert response.headers["location"] == "/"
+    assert session.exec(select(Passage)).all() == []


### PR DESCRIPTION
## Summary

**PRESET-4** — the **compliance-critical** piece of the epic. Selecting a preset now creates a user-owned passage and opens it in the reading view **with the required copyright/author rendered alongside the text**.

> ⚠️ **Third in the stack.** Includes #279 (schema) + #281 (picker) commits. **Merge order: #292 → #293 → #294 (this).** After #292 and #293 merge, I'll rebase and this diff drops to just the #282 files below. Review these: `app/api/passages.py`, `templates/pages/reading.html`, `static/style.css`, `app/api/test_seed.py` + the two `tests/a11y/*` files, `tests/test_preset_copy_on_select.py`.

## Changes

- **`POST /passages/from-preset/{preset_id}`** — loads the active preset (unknown **or** inactive → **404**, same existence-privacy shape as `GET /read`), then reuses `_persist_as_passages` with `source_type='preset'`, copying the preset's attribution onto the created passage(s). `303 → /read/{first.id}`, exactly like paste.
- **`_persist_as_passages`** now threads the four `attribution_*` fields onto **every part** (so each page of a split preset carries attribution); defaults `None` for paste/pdf.
- **`reading.html`** renders a `.passage-attribution` footer whenever `attribution_copyright` is present — **unconditionally**, since it's the licensing condition, not a user preference (no toggle). Nothing renders for paste/pdf.
- **CSS** uses full-strength text color (no muted grey) so the copyright line stays WCAG AA — the copyright must be legible, not de-emphasised.
- **`preset` a11y variant** — the seed route seeds a preset-sourced passage with attribution, so the axe job **scans the attribution block** on the reading surface (the same pattern that caught the #168 contrast bug).

## Guardrails honored

- Created passage is owned by the current user and copies **all** attribution (compliance).
- Attribution renders whenever present — not gated behind a toggle.
- Unknown/inactive `preset_id` → 404, no passage created.
- Does not bypass `_persist_as_passages` (keeps hashing + part-splitting + cache-sharing).

## Verification

- [x] `ruff` / `ruff format` / `mypy` — clean
- [x] `uv run pytest` — **334 passed** (+7): owned passage w/ attribution copied, attribution renders for preset and **not** for paste, unknown/inactive → 404 no passage, two users share one `text_hash` (one cache row), auth required
- [x] a11y: new `preset` variant added so axe scans the attribution block in CI

Closes #282. With this, the presets **mechanism is complete** — the only remaining piece is #280 (seed the corpus), which needs the rights-scope answer + the actual messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)