### PR TITLE
chore(presets): fold in the 3 non-blocking review suggestions

### DIFF
--- a/supabase/migrations/20260812000000_add_preset_passage_active_index.sql
+++ b/supabase/migrations/20260812000000_add_preset_passage_active_index.sql
@@ -1,0 +1,10 @@
+-- Follow-up to PRESET-1/3 review (#279/#281): index the picker query.
+--
+-- GET /passages/new lists active presets ordered by sort_order then
+-- created_at (app/api/passages.py new_passage_form). A partial index on
+-- exactly that shape keeps the picker cheap as the curated library grows.
+-- (The library is tiny today, so this is hygiene, not a hot path — but it's
+-- free and matches the query.)
+CREATE INDEX IF NOT EXISTS ix_preset_passage_active_order
+    ON public.preset_passage (sort_order, created_at)
+    WHERE is_active;

--- a/templates/pages/reading.html
+++ b/templates/pages/reading.html
@@ -53,7 +53,11 @@
       <p class="attribution-credit">
         {% if passage.attribution_author %}{{ passage.attribution_author }}. {% endif %}
         Copyright &copy; {{ passage.attribution_copyright }}.
-        {% if passage.attribution_source_url %}
+        {# Only render the Source link for an https URL — defends against a
+           non-https or `javascript:` scheme ever reaching href, even though
+           preset data is service-role-seeded. The copyright/author above
+           always render regardless. #}
+        {% if passage.attribution_source_url and passage.attribution_source_url.startswith("https://") %}
           <a href="{{ passage.attribution_source_url }}"
              rel="noopener noreferrer" target="_blank">Source</a>.
         {% endif %}

--- a/tests/test_preset_copy_on_select.py
+++ b/tests/test_preset_copy_on_select.py
@@ -125,3 +125,70 @@ def test_from_preset_requires_auth(client: TestClient, session: Session) -> None
     assert response.status_code in (302, 303)
     assert response.headers["location"] == "/"
     assert session.exec(select(Passage)).all() == []
+
+
+# ---------------------------------------------------------------------------
+# Review follow-ups (#282 review)
+# ---------------------------------------------------------------------------
+
+
+def test_split_preset_carries_attribution_on_later_parts(
+    client: TestClient, session: Session
+) -> None:
+    """A preset longer than MAX_TEXT_LEN splits into linked parts. Every part —
+    not just part 0 — must carry the attribution, so the reading surface shows
+    the copyright on whichever page the reader is on."""
+    from app.api.passages import MAX_TEXT_LEN
+
+    long_text = ("Consider the words of justice and mercy. " * 5000)[: MAX_TEXT_LEN + 20_000]
+    assert len(long_text) > MAX_TEXT_LEN  # guard: actually triggers a split
+    preset = _add_preset(session, text=long_text)
+
+    signed_in(session)
+    client.post(f"/passages/from-preset/{preset.id}", follow_redirects=False)
+
+    parts = session.exec(select(Passage).order_by(Passage.part_index)).all()  # type: ignore[arg-type]
+    assert len(parts) > 1, "expected the long preset to split into multiple parts"
+    # Every part carries the attribution, and they share one document_id.
+    assert all(p.attribution_copyright == "Bahá'í International Community" for p in parts)
+    assert all(p.attribution_author == "Bahá'u'lláh" for p in parts)
+    later = next(p for p in parts if p.part_index >= 1)
+    assert later.attribution_title == "The Hidden Words"
+
+
+def test_source_link_only_rendered_for_https(client: TestClient, session: Session) -> None:
+    """The Source link renders only for an https URL; a non-https scheme is
+    dropped (defensive), but the copyright/author still render."""
+    user = signed_in(session)
+
+    def _preset_passage(url: str) -> Passage:
+        # Text must NOT contain the url, else it appears in the body regardless
+        # of the link — the assertions below are about the rendered link only.
+        text = f"passage body for {url[:4]}"
+        p = Passage(
+            owner_id=user.id,
+            text=text,
+            text_hash=hashlib.sha256(text.encode()).digest(),
+            source_type="preset",
+            attribution_title="T",
+            attribution_author="A",
+            attribution_copyright="Bahá'í International Community",
+            attribution_source_url=url,
+        )
+        session.add(p)
+        session.commit()
+        session.refresh(p)
+        return p
+
+    https_p = _preset_passage("https://www.bahai.org/x")
+    http_p = _preset_passage("http://insecure.example.com/x")
+
+    https_body = client.get(f"/read/{https_p.id}").text
+    assert ">Source</a>" in https_body
+    assert "https://www.bahai.org/x" in https_body
+
+    http_body = client.get(f"/read/{http_p.id}").text
+    assert ">Source</a>" not in http_body  # link dropped for non-https
+    assert "insecure.example.com" not in http_body
+    # ...but the copyright still renders — attribution is not gated on the link.
+    assert "Copyright" in http_body and "International Community" in http_body


### PR DESCRIPTION
## Summary

Folds in the three non-blocking suggestions from the presets epic reviews (#292, #294). None change happy-path behavior.

| # | Suggestion (from) | Change |
|---|---|---|
| 1 | index the picker query (#292) | Partial index `ix_preset_passage_active_order` on `preset_passage (sort_order, created_at) WHERE is_active` — matches `new_passage_form`'s query. Hygiene as the library grows; free today. |
| 2 | https-scheme validation on `attribution_source_url` (#294) | `reading.html` renders the Source link only when the URL starts with `https://`. Defends against a non-https / `javascript:` scheme reaching `href`, even though preset data is service-role-seeded. **Copyright/author still render regardless** — attribution isn't gated on the link. |
| 3 | test that a split preset's later parts carry attribution (#294) | New test: a preset > `MAX_TEXT_LEN` splits into parts and **every** part (incl. `part_index ≥ 1`) carries the attribution. |

Plus a test that the Source link is dropped for a non-https URL while the copyright still renders.

## Verification

- [x] `ruff` / `ruff format` / `mypy` — clean
- [x] `uv run pytest` — **336 passed** (+2)
- [x] Template guard verified (LINK for https, no link for http); attribution always renders
- [ ] Migration not run under `supabase db reset` locally (no Docker); **CI Supabase Preview validates it**.

Refs #279, #281, #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)