### PR TITLE
feat(monitor): check the POST /login email-send path (#291)

### DIFF
--- a/scripts/smoke_auth.py
+++ b/scripts/smoke_auth.py
@@ -19,6 +19,11 @@ that hits the *real* deployed URL with a *real* Supabase session can.
    Supabase stack in CI — so the token is byte-for-byte what `/auth/callback`
    produces for a genuine magic-link sign-in.
 2. Hit the live app over HTTP:
+   - `POST /login` with the throwaway user's email → expect 202 (#291). This
+     is the email SEND path: a broken/misconfigured mailer (e.g. an SMTP 535
+     auth failure) surfaces as a 502 here. The rest of the flow mints sessions
+     server-side and never sends email, so without this a total email outage
+     stays green — as it did during the 2026-08 SMTP outage.
    - `GET /auth/callback?access_token=…&refresh_token=…` → expect a 303 to
      `/passages/new` with an `sb-access-token` cookie set.
    - `GET /passages/new` (cookie attached) → expect 200 + the authed page.
@@ -37,10 +42,11 @@ that hits the *real* deployed URL with a *real* Supabase session can.
 
 ## What it deliberately does NOT cover
 
-- **Supabase's own email-link generation.** We mint the session server-side
-  rather than clicking a real emailed link. POST /login → `sign_in_with_otp`
-  is unit-tested separately; this monitor is about our token-validation,
-  session, and logout contract against the live deploy.
+- **Email delivery / clicking the real link.** We verify that `POST /login`
+  is ACCEPTED (Supabase handed the message to the mailer → 202), which catches
+  mailer-auth outages, but we don't read an inbox or click the emailed link —
+  no mailbox to poll. Delivery failures (bad recipient, spam) are out of scope;
+  the session flow below mints the token server-side.
 - **The browser-side JS hash extractor** (`/auth/callback` stage 1). That moves
   the token from the URL fragment into query params *in a real browser*; a
   headless HTTP client has the token already, so it calls stage 2 directly. The
@@ -124,6 +130,48 @@ def _cookie_header_clears(set_cookie_values: list[str]) -> bool:
         if token == "" or "max-age=0" in lowered or "expires=thu, 01 jan 1970" in lowered:
             return True
     return False
+
+
+def _login_send_outcome(status_code: int) -> str:
+    """Classify a POST /login response for the email-send check (#291).
+
+    Returns "ok" (202 — Supabase accepted the send) or "rate_limited" (429 —
+    our 10/hr limiter or Supabase's shared pool; a soft, self-clearing state,
+    NOT an outage). Any other status raises: a broken email sender surfaces as
+    a 502 here (e.g. an SMTP 535 auth failure), which is exactly the outage
+    class the rest of this monitor is blind to.
+    """
+    if status_code == 202:
+        return "ok"
+    if status_code == 429:
+        return "rate_limited"
+    raise SmokeFailure(
+        f"POST /login returned {status_code}, expected 202 — the email SEND path is broken "
+        "(a broken/misconfigured mailer, e.g. SMTP 535, surfaces here as 502; see #291)"
+    )
+
+
+def check_login_send(base_url: str, email: str) -> None:
+    """Exercise POST /login — the magic-link SEND path — and require a 202.
+
+    This is the layer a broken email sender takes down (`sign_in_with_otp`
+    fails → /login 502). The rest of this monitor mints sessions server-side
+    and never touches email, so without this a total email outage stays green
+    (it did, 2026-08 SMTP 535). We check only that Supabase ACCEPTED the send —
+    no inbox, we do not click the emailed link.
+
+    Uses the existing throwaway user's email (already created + confirmed via
+    admin API), so a disabled-signups setting doesn't reject it. A 429 is
+    logged and treated as pass — rate-limiting is not an outage.
+    """
+    base = base_url.rstrip("/")
+    with httpx.Client(timeout=HTTP_TIMEOUT_SECONDS, follow_redirects=False) as client:
+        resp = client.post(f"{base}/login", data={"email": email}, headers={"HX-Request": "true"})
+    if _login_send_outcome(resp.status_code) == "rate_limited":
+        print(
+            "WARN: POST /login rate-limited (429) — treating as pass, not an outage",
+            flush=True,
+        )
 
 
 def create_throwaway_user(service: Client) -> tuple[str, str, str]:
@@ -287,6 +335,10 @@ def main() -> int:
     try:
         user_id, email, password = create_throwaway_user(service_client)
         _step(f"created throwaway user {user_id}")
+        # Email SEND path (#291): the one layer a broken mailer takes down. Run
+        # it before the session flow so an SMTP outage is the first thing named.
+        _step("POST /login — email send path, expect 202 (#291)")
+        check_login_send(base_url, email)
         access_token, refresh_token = sign_in(anon, email, password)
         _step("minted session via password grant")
         run_flow(base_url, access_token, refresh_token)
@@ -310,7 +362,7 @@ def main() -> int:
                 print(f"WARN: failed to delete throwaway user {user_id}: {exc}", flush=True)
 
     print(
-        "PASS: session → authed page → reload → paste → read → logout all verified",
+        "PASS: login-send → session → authed page → reload → paste → read → logout all verified",
         flush=True,
     )
     return 0

--- a/tests/test_smoke_auth.py
+++ b/tests/test_smoke_auth.py
@@ -101,3 +101,50 @@ def test_no_delete_when_user_creation_fails(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert smoke.main() == 1
     service_fake.auth.admin.delete_user.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #291 — POST /login email-send check classifies statuses correctly
+# ---------------------------------------------------------------------------
+
+
+def test_login_send_202_is_ok() -> None:
+    assert smoke._login_send_outcome(202) == "ok"
+
+
+def test_login_send_429_is_soft_rate_limited() -> None:
+    """A rate limit is self-clearing, not an outage — must not fail the run."""
+    assert smoke._login_send_outcome(429) == "rate_limited"
+
+
+@pytest.mark.parametrize("status", [502, 500, 400, 422, 503])
+def test_login_send_other_statuses_raise(status: int) -> None:
+    """502 (broken mailer, e.g. SMTP 535) and any other non-202/429 status
+    must raise so the monitor fails and pages."""
+    with pytest.raises(smoke.SmokeFailure):
+        smoke._login_send_outcome(status)
+
+
+def test_login_send_failure_fails_run_and_cleans_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An email-send outage (POST /login → 502) must fail the monitor (exit 1)
+    AND still delete the throwaway user — the outage this check exists to catch
+    must not also leak a user."""
+    _set_required_env(monkeypatch)
+
+    service_fake = MagicMock()
+    service_fake.auth.admin.create_user.return_value = SimpleNamespace(
+        user=SimpleNamespace(id="user-xyz")
+    )
+    anon_fake = MagicMock()
+    monkeypatch.setattr(smoke, "create_client", MagicMock(side_effect=[service_fake, anon_fake]))
+    # Simulate the mailer being down: the send check raises before sign-in.
+    monkeypatch.setattr(
+        smoke,
+        "check_login_send",
+        MagicMock(side_effect=smoke.SmokeFailure("POST /login returned 502")),
+    )
+
+    assert smoke.main() == 1
+    service_fake.auth.admin.delete_user.assert_called_once_with("user-xyz")
+    # The session flow must not have run once the send check failed.
+    anon_fake.auth.sign_in_with_password.assert_not_called()


### PR DESCRIPTION
## Summary

The synthetic monitor minted sessions server-side and **never exercised email**, so a total mailer outage stayed **green** — exactly what happened during the 2026-08 SMTP 535 outage (production sign-in was down for hours; the monitor was green the whole time). The script's own docstring admitted the gap.

Adds a `POST /login` step that requires **202** (Supabase accepted the send). A broken mailer surfaces as `/login` **502** → `SmokeFailure` → exit 1 → the existing **OPS-1** failure handler opens/updates an incident issue. **No workflow change** — the check runs inside the script the hourly monitor already invokes.

## Design

- Uses the throwaway user's **already-confirmed** email (created via admin API), so a disabled-signups setting doesn't reject it with a 400.
- **429 is soft** (our 10/hr limiter or Supabase's shared pool) — logged, treated as pass. Rate-limiting isn't an outage.
- Decision logic factored into the pure `_login_send_outcome(status)` — unit-tested (202 → ok, 429 → soft, 502/500/400/422/503 → raise), mirroring the file's existing "test the pure logic" approach.
- Integration test: a send failure fails the run **and** still deletes the throwaway user (the outage this catches must not also leak a user).

## Verification

- [x] `ruff` / `ruff format` / `mypy app/ scripts/` — clean
- [x] `uv run pytest` — **344 passed** (+8, incl. the `_login_send_outcome` matrix and the fail-and-cleanup integration test)

## ⚠️ Watch the first few live runs after merge

This is monitoring code — it can only be fully validated against live Supabase + prod, which I can't run locally. Two things to confirm on the first hourly runs:

1. **No false positive.** The check assumes the mailer returns 202 as soon as it *accepts* the send (async delivery), regardless of recipient. It sends to the reserved `smoke.cubrox.test` domain (which never resolves). If the live mailer instead does *synchronous* recipient/MX validation and errors, `/login` would 502 and the monitor would false-fail — in which case point `SMOKE_EMAIL_DOMAIN` at a deliverable black-hole address, or soften the check. Prod `/login` currently returns 202 for existing users, so the baseline is healthy.
2. **Bounce volume.** This sends ~1 real OTP email/hour to a non-deliverable domain (24/day) on Supabase's shared SMTP (30/hr limit — fine). #246 (custom SMTP via Resend) removes that pool entirely.

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)